### PR TITLE
fix: include wip_adjustments in authoritative WIP calculation

### DIFF
--- a/src/hooks/useAuthoritativeInventory.ts
+++ b/src/hooks/useAuthoritativeInventory.ts
@@ -129,6 +129,23 @@ function useWipLedgerTransactions() {
 }
 
 /**
+ * Fetch manual WIP adjustments (opening balances, recounts, losses, etc.)
+ * These are separate from inventory_transactions and must be included for correct WIP totals.
+ */
+function useWipManualAdjustments() {
+  return useQuery({
+    queryKey: ['authoritative-wip-manual-adjustments'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('wip_adjustments')
+        .select('roast_group, kg_delta');
+      if (error) throw error;
+      return data ?? [];
+    },
+  });
+}
+
+/**
  * Fetch all products with roast_group mapping
  */
 function useProductsWithRoastGroup() {
@@ -252,11 +269,12 @@ function useOpenOrderLines() {
  */
 export function useAuthoritativeWip() {
   const { data: wipTransactions, isLoading: wipLoading } = useWipLedgerTransactions();
+  const { data: manualAdjustments, isLoading: manualLoading } = useWipManualAdjustments();
   const { data: roastGroups, isLoading: roastGroupsLoading } = useRoastGroupsInfo();
-  
+
   const wip = useMemo((): Record<string, AuthoritativeWip> => {
     if (!wipTransactions) return {};
-    
+
     // Track which roast groups are blends
     const blendGroups = new Set<string>();
     for (const rg of roastGroups ?? []) {
@@ -264,17 +282,16 @@ export function useAuthoritativeWip() {
         blendGroups.add(rg.roast_group);
       }
     }
-    
+
     // Aggregate transactions by roast group and type
     const roastedByGroup: Record<string, number> = {};
     const consumedByGroup: Record<string, number> = {};
     const adjustmentsByGroup: Record<string, number> = {};
-    
+
     for (const tx of wipTransactions) {
       if (!tx.roast_group) continue;
       const kg = Number(tx.quantity_kg ?? 0);
-      const notes = tx.notes?.toLowerCase() ?? '';
-      
+
       switch (tx.transaction_type) {
         case 'ROAST_OUTPUT':
           // Direct roast output - positive kg
@@ -291,7 +308,6 @@ export function useAuthoritativeWip() {
           break;
         case 'ADJUSTMENT':
           // Adjustments can be positive (blend output, reverts) or negative (blend consume)
-          // We track them separately to show in the UI
           adjustmentsByGroup[tx.roast_group] = (adjustmentsByGroup[tx.roast_group] ?? 0) + kg;
           break;
         case 'LOSS':
@@ -300,30 +316,30 @@ export function useAuthoritativeWip() {
           break;
       }
     }
-    
+
+    // Add manual adjustments from wip_adjustments table (opening balances, recounts, etc.)
+    // These are NOT in inventory_transactions but must be included for correct authoritative WIP.
+    for (const adj of manualAdjustments ?? []) {
+      if (!adj.roast_group) continue;
+      adjustmentsByGroup[adj.roast_group] = (adjustmentsByGroup[adj.roast_group] ?? 0) + Number(adj.kg_delta ?? 0);
+    }
+
     // Combine into authoritative WIP
     const allGroups = new Set([
-      ...Object.keys(roastedByGroup), 
+      ...Object.keys(roastedByGroup),
       ...Object.keys(consumedByGroup),
       ...Object.keys(adjustmentsByGroup),
     ]);
     const result: Record<string, AuthoritativeWip> = {};
-    
+
     for (const rg of allGroups) {
       const roasted = roastedByGroup[rg] ?? 0;
       const consumed = consumedByGroup[rg] ?? 0;
       const adjusted = adjustmentsByGroup[rg] ?? 0;
-      
-      // For blends: roasted_completed_kg may still include component roast outputs
-      // but the net WIP formula is the same: roasted - consumed + adjustments
-      // Adjustments for blends include "Created blend" (positive) and component consumption is tracked elsewhere
-      const isBlend = blendGroups.has(rg);
-      
-      // WIP = roasted - consumed + adjustments
-      // For blends, roasted might be 0 if blend output comes via ADJUSTMENT
-      // For single origins, roasted is the primary source
+
+      // WIP = roasted - consumed + adjustments (includes manual adjustments from wip_adjustments)
       const wipAvailable = roasted - consumed + adjusted;
-      
+
       result[rg] = {
         roast_group: rg,
         roasted_completed_kg: roasted,
@@ -332,13 +348,13 @@ export function useAuthoritativeWip() {
         wip_available_kg: Math.max(0, wipAvailable),
       };
     }
-    
+
     return result;
-  }, [wipTransactions, roastGroups]);
-  
+  }, [wipTransactions, manualAdjustments, roastGroups]);
+
   return {
     data: wip,
-    isLoading: wipLoading || roastGroupsLoading,
+    isLoading: wipLoading || manualLoading || roastGroupsLoading,
   };
 }
 

--- a/src/lib/wipAdjustments.ts
+++ b/src/lib/wipAdjustments.ts
@@ -48,4 +48,7 @@ export const WIP_ADJUSTMENT_QUERY_KEYS: string[][] = [
   ['roast-group-wip'],
   ['roast-group-detail'],
   ['roast-group-inventory-levels'],
+  // Authoritative hooks used by the production page
+  ['authoritative-wip-manual-adjustments'],
+  ['authoritative-wip-ledger'],
 ];


### PR DESCRIPTION
Manual WIP adjustments (opening balances, recounts) were stored in `wip_adjustments` but not read by `useAuthoritativeWip()`, causing the production page to show 0.0 KG WIP on-hand even when opening balances existed.

Fixes #7

Generated with [Claude Code](https://claude.ai/code)