### PR TITLE
fix: green lot FX rate flow — placeholder, preservation, confirmation

### DIFF
--- a/src/components/pricing/DefaultsTab.tsx
+++ b/src/components/pricing/DefaultsTab.tsx
@@ -67,7 +67,46 @@ export function DefaultsTab() {
   const [financingDays, setFinancingDays] = useState('60');
   const [financingAprPct, setFinancingAprPct] = useState('12.0');
 
+  // Global FX rate setting
+  const [placeholderFxRate, setPlaceholderFxRate] = useState('1.38');
+
   // ---- queries ----
+  const { data: fxRateSetting } = useQuery({
+    queryKey: ['app_settings', 'placeholder_fx_rate_usd_to_cad'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('app_settings')
+        .select('value_json')
+        .eq('key', 'placeholder_fx_rate_usd_to_cad')
+        .maybeSingle();
+      if (error) throw error;
+      return data;
+    },
+  });
+
+  useEffect(() => {
+    if (fxRateSetting?.value_json) {
+      const rate = (fxRateSetting.value_json as any)?.rate;
+      if (rate != null) setPlaceholderFxRate(String(rate));
+    }
+  }, [fxRateSetting]);
+
+  const saveFxRateMutation = useMutation({
+    mutationFn: async () => {
+      const rate = Number(placeholderFxRate);
+      if (!Number.isFinite(rate) || rate <= 0) throw new Error('Rate must be a positive number');
+      const { error } = await supabase
+        .from('app_settings')
+        .upsert({ key: 'placeholder_fx_rate_usd_to_cad', value_json: { rate } as any });
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      toast.success('FX rate saved');
+      queryClient.invalidateQueries({ queryKey: ['app_settings', 'placeholder_fx_rate_usd_to_cad'] });
+    },
+    onError: (err: any) => toast.error(err?.message ?? 'Failed to save FX rate'),
+  });
+
   const { data: profiles, isLoading: profilesLoading } = useQuery({
     queryKey: ['pricing_rule_profiles'],
     queryFn: async () => {
@@ -204,6 +243,36 @@ export function DefaultsTab() {
 
   return (
     <div className="space-y-6">
+      {/* Global FX Rate */}
+      <Card>
+        <CardContent className="pt-6 space-y-4">
+          <div>
+            <h3 className="text-sm font-semibold">Placeholder FX Rate (USD → CAD)</h3>
+            <p className="text-xs text-muted-foreground mt-1">
+              Manually-maintained estimate applied to green lot costs during the Release → Lot handoff,
+              whenever any cost is in USD. Replaced by the actual confirmed rate at the Confirm Costs step.
+            </p>
+          </div>
+          <RuleField
+            id="placeholder-fx-rate"
+            label="Placeholder rate"
+            helper="Applied to USD-denominated costs (coffee price, freight, carry fees) when a release is saved. Must be > 0. Update this whenever the rate drifts materially from spot."
+            value={placeholderFxRate}
+            onChange={setPlaceholderFxRate}
+            step="0.0001"
+          />
+          <div className="flex justify-end">
+            <Button
+              size="sm"
+              onClick={() => saveFxRateMutation.mutate()}
+              disabled={saveFxRateMutation.isPending || Number(placeholderFxRate) <= 0}
+            >
+              {saveFxRateMutation.isPending ? 'Saving…' : 'Save FX Rate'}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
       {/* Profile selector */}
       <Card>
         <CardContent className="pt-6">

--- a/src/pages/internal/ReleaseDetail.tsx
+++ b/src/pages/internal/ReleaseDetail.tsx
@@ -152,6 +152,20 @@ export default function ReleaseDetail() {
     return m;
   }, [contracts]);
 
+  const { data: fxRateSetting } = useQuery({
+    queryKey: ['app_settings', 'placeholder_fx_rate_usd_to_cad'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('app_settings')
+        .select('value_json')
+        .eq('key', 'placeholder_fx_rate_usd_to_cad')
+        .maybeSingle();
+      if (error) throw error;
+      return data;
+    },
+  });
+  const placeholderFxRate: number = Number((fxRateSetting?.value_json as any)?.rate) || 1.38;
+
   // Hydrate edit state when release loads
   useEffect(() => {
     if (!release) return;
@@ -207,33 +221,88 @@ export default function ReleaseDetail() {
         const priceUsdPerLb = Number(l.price_per_lb_usd) || 0;
         const coffeeCostUsd = priceUsdPerLb > 0 ? priceUsdPerLb * KG_PER_LB * lineKg : null;
 
+        // Currency flags preserved directly from the release form (never inferred from value comparisons)
+        const carryIsUsd = editShared.carry?.currency === 'USD';
+        const freightIsUsd = editShared.freight?.currency === 'USD';
+        const dutiesIsUsd = editShared.duties?.currency === 'USD';
+        const feesIsUsd = editShared.fees?.currency === 'USD';
+        const otherIsUsd = editShared.other?.currency === 'USD';
+
+        // Per-lot prorated amounts (raw, in their original currency)
         const lotCarryUsd = bucketTotals.carry.usd * kgShare;
         const lotCarryCad = bucketTotals.carry.cad * kgShare;
-        const lotFreightCad = (bucketTotals.freight.usd + bucketTotals.freight.cad) * kgShare;
-        const lotDutiesCad = (bucketTotals.duties.usd + bucketTotals.duties.cad) * kgShare;
-        const lotFeesCad = (bucketTotals.fees.usd + bucketTotals.fees.cad) * kgShare;
-        const lotOtherCad = (bucketTotals.other.usd + bucketTotals.other.cad) * kgShare;
+        const lotFreightUsd = bucketTotals.freight.usd * kgShare;
+        const lotFreightCadRaw = bucketTotals.freight.cad * kgShare;
+        const lotDutiesUsd = bucketTotals.duties.usd * kgShare;
+        const lotDutiesCadRaw = bucketTotals.duties.cad * kgShare;
+        const lotFeesUsd = bucketTotals.fees.usd * kgShare;
+        const lotFeesCadRaw = bucketTotals.fees.cad * kgShare;
+        const lotOtherUsd = bucketTotals.other.usd * kgShare;
+        const lotOtherCadRaw = bucketTotals.other.cad * kgShare;
 
-        const newBookKg = bookValuePerKgUsd(l.price_per_lb_usd, sharedShareUsdPerKg);
+        // Determine whether this lot has any USD cost → inherit the placeholder FX rate
+        const lotHasUsdCost =
+          coffeeCostUsd != null ||
+          (carryIsUsd && lotCarryUsd > 0) ||
+          (freightIsUsd && lotFreightUsd > 0) ||
+          (dutiesIsUsd && lotDutiesUsd > 0) ||
+          (feesIsUsd && lotFeesUsd > 0) ||
+          (otherIsUsd && lotOtherUsd > 0);
+
+        const lotFxRate = lotHasUsdCost ? placeholderFxRate : null;
+
+        // Convert each cost to CAD using the placeholder rate (null if USD cost but no rate)
+        const coffeeCostCad = coffeeCostUsd != null && lotFxRate != null
+          ? coffeeCostUsd * lotFxRate
+          : null;
+
+        const carryFeesCad = carryIsUsd
+          ? (lotFxRate != null ? lotCarryUsd * lotFxRate : null)
+          : (lotCarryCad > 0 ? lotCarryCad : null);
+
+        const freightCad = freightIsUsd
+          ? (lotFxRate != null ? lotFreightUsd * lotFxRate : null)
+          : (lotFreightCadRaw > 0 ? lotFreightCadRaw : null);
+
+        const dutiesCad = dutiesIsUsd
+          ? (lotFxRate != null ? lotDutiesUsd * lotFxRate : null)
+          : (lotDutiesCadRaw > 0 ? lotDutiesCadRaw : null);
+
+        const feesCad = feesIsUsd
+          ? (lotFxRate != null ? lotFeesUsd * lotFxRate : null)
+          : (lotFeesCadRaw > 0 ? lotFeesCadRaw : null);
+
+        const otherCad = otherIsUsd
+          ? (lotFxRate != null ? lotOtherUsd * lotFxRate : null)
+          : (lotOtherCadRaw > 0 ? lotOtherCadRaw : null);
+
+        // Book value in CAD using the placeholder rate
+        const totalCad = (coffeeCostCad ?? 0) + (carryFeesCad ?? 0) + (freightCad ?? 0) + (dutiesCad ?? 0) + (feesCad ?? 0) + (otherCad ?? 0);
+        const newBookKgCad = lineKg > 0 && totalCad > 0 ? totalCad / lineKg : null;
 
         const lotPatch: any = {
           // Arrival
           status: editArrival === 'RECEIVED' ? 'RECEIVED' : 'EN_ROUTE',
-          // Costs (mirror USD into *_cad with fx_rate=1 placeholder for surfacing on the lot detail panel)
-          fx_rate: 1,
+          // FX rate: placeholder if any USD cost; null if all CAD
+          fx_rate: lotFxRate,
+          // Invoice (coffee cost — always USD when price_per_lb_usd is set)
           invoice_amount_usd: coffeeCostUsd,
-          invoice_amount_cad: coffeeCostUsd,
-          invoice_is_usd: true,
-          carry_fees_usd: lotCarryUsd > 0 ? lotCarryUsd : null,
-          carry_fees_cad: (lotCarryUsd + lotCarryCad) > 0 ? (lotCarryUsd + lotCarryCad) : null,
-          carry_fees_is_usd: lotCarryUsd >= lotCarryCad,
-          freight_cad: lotFreightCad > 0 ? lotFreightCad : null,
-          freight_is_usd: false,
-          duties_cad: lotDutiesCad > 0 ? lotDutiesCad : null,
-          transaction_fees_cad: lotFeesCad > 0 ? lotFeesCad : null,
-          other_costs_cad: lotOtherCad > 0 ? lotOtherCad : null,
-          book_value_per_kg: newBookKg > 0 ? newBookKg : null,
-          market_value_per_kg: newBookKg > 0 ? newBookKg : null,
+          invoice_amount_cad: coffeeCostCad,
+          invoice_is_usd: coffeeCostUsd != null,
+          // Carry fees — currency preserved from release form
+          carry_fees_usd: carryIsUsd && lotCarryUsd > 0 ? lotCarryUsd : null,
+          carry_fees_cad: carryFeesCad,
+          carry_fees_is_usd: carryIsUsd,
+          // Freight — currency preserved from release form
+          freight_cad: freightCad,
+          freight_is_usd: freightIsUsd,
+          // Other shared costs (CAD-only columns; USD amounts converted via placeholder rate)
+          duties_cad: dutiesCad,
+          transaction_fees_cad: feesCad,
+          other_costs_cad: otherCad,
+          // Book value in CAD (estimate using placeholder rate)
+          book_value_per_kg: newBookKgCad,
+          market_value_per_kg: newBookKgCad,
         };
 
         if (editArrival === 'RECEIVED' && editReceived) {

--- a/src/pages/internal/SourcingLots.tsx
+++ b/src/pages/internal/SourcingLots.tsx
@@ -738,6 +738,7 @@ function LotDetailPanel({
   const toCad = useCallback((val: number | null, isUsd: boolean, rate: number | null) => {
     if (val == null) return null;
     if (isUsd && rate) return val * rate;
+    if (isUsd && !rate) return null; // USD cost with no FX rate — cannot convert
     return val;
   }, []);
 
@@ -891,6 +892,9 @@ function LotDetailPanel({
     !!lot.freight_confirmed_at && !!lot.duties_confirmed_at && !!lot.transaction_fees_confirmed_at &&
     !!lot.other_costs_confirmed_at
   ) : false;
+
+  // Prevent confirming costs when any USD-flagged cost has no FX rate
+  const hasUsdCostWithoutRate = (invoiceIsUsd || carryFeesIsUsd || freightIsUsd) && !fxRate;
 
   // Notes
   const [noteText, setNoteText] = useState('');
@@ -1331,7 +1335,7 @@ function LotDetailPanel({
                   <Button size="sm" variant="outline" onClick={saveCostValues} disabled={fieldSaveMutation.isPending}>
                     Save Draft
                   </Button>
-                  <Button onClick={() => confirmCostsMutation.mutate()} disabled={confirmCostsMutation.isPending}>
+                  <Button onClick={() => confirmCostsMutation.mutate()} disabled={confirmCostsMutation.isPending || hasUsdCostWithoutRate} title={hasUsdCostWithoutRate ? 'Set an FX rate before confirming — one or more costs are in USD' : undefined}>
                     {confirmCostsMutation.isPending ? 'Confirming…' : 'Confirm Costs'}
                   </Button>
                 </div>

--- a/supabase/migrations/20260506000000_seed_placeholder_fx_rate.sql
+++ b/supabase/migrations/20260506000000_seed_placeholder_fx_rate.sql
@@ -1,0 +1,6 @@
+-- Seed the placeholder FX rate setting used during green lot cost entry.
+-- This rate is applied when any release cost is in USD (coffee price or shared costs).
+-- It is a manually-maintained estimate, replaced at Confirm Costs time by the actual rate.
+INSERT INTO public.app_settings (key, value_json)
+VALUES ('placeholder_fx_rate_usd_to_cad', '{"rate": 1.38}'::jsonb)
+ON CONFLICT (key) DO NOTHING;


### PR DESCRIPTION
Fixes #3 three bugs corrupting book values on received green lots.

## Changes

- DB migration: seeds `placeholder_fx_rate_usd_to_cad` (1.38) in `app_settings`
- Pricing → Defaults: new global FX rate card editable by ADMIN/OPS
- ReleaseDetail: stop writing fx_rate=1; use placeholder; preserve currency flags; compute book value in CAD
- SourcingLots: fix toCad null guard; disable Confirm Costs if USD cost has no FX rate

Closes #12

Generated with [Claude Code](https://claude.ai/code)