### PR TITLE
fix: post-Lovable code scan bugs

### DIFF
--- a/src/components/bookings/BookingFormDialog.tsx
+++ b/src/components/bookings/BookingFormDialog.tsx
@@ -204,7 +204,7 @@ export function BookingFormDialog({
         const { data: recurBlock, error: rbErr } = await supabase
           .from('coroast_recurring_blocks')
           .insert({
-            account_id: memberId,
+            member_id: memberId,
             day_of_week: recurringDay as any,
             start_time: formStartTime,
             end_time: formEndTime,

--- a/src/components/products/NewBlendProductModal.tsx
+++ b/src/components/products/NewBlendProductModal.tsx
@@ -274,6 +274,7 @@ export function NewBlendProductModal({ open, onOpenChange }: NewBlendProductModa
 
         if (error) {
           if (error.code === '23505' && error.message?.toLowerCase().includes('sku')) {
+            let resolved = false;
             for (let i = 2; i <= 50; i++) {
               const fallbackSku = `${skuData.sku}-${i}`;
               const { data: retryProduct, error: retryError } = await supabase
@@ -284,11 +285,15 @@ export function NewBlendProductModal({ open, onOpenChange }: NewBlendProductModa
 
               if (!retryError) {
                 createdProducts.push({ id: retryProduct.id, sku: retryProduct.sku, wasAdjusted: true });
+                resolved = true;
                 break;
               }
               if (retryError.code !== '23505') {
                 throw retryError;
               }
+            }
+            if (!resolved) {
+              throw new Error(`Could not generate unique SKU for ${skuData.sku} after 50 attempts.`);
             }
           } else {
             throw error;
@@ -316,7 +321,7 @@ export function NewBlendProductModal({ open, onOpenChange }: NewBlendProductModa
           .insert(priceInserts);
         
         if (priceError) {
-          console.error('Price insert failed:', priceError);
+          throw priceError;
         }
       }
       

--- a/src/components/products/NewSingleOriginProductModal.tsx
+++ b/src/components/products/NewSingleOriginProductModal.tsx
@@ -375,6 +375,7 @@ export function NewSingleOriginProductModal({ open, onOpenChange, initialLifecyc
         if (error) {
           // If SKU collision at DB level, try with suffix
           if (error.code === '23505' && error.message?.toLowerCase().includes('sku')) {
+            let resolved = false;
             for (let i = 2; i <= 50; i++) {
               const fallbackSku = `${skuData.sku}-${i}`;
               const { data: retryProduct, error: retryError } = await supabase
@@ -382,14 +383,18 @@ export function NewSingleOriginProductModal({ open, onOpenChange, initialLifecyc
                 .insert({ ...basePayload, sku: fallbackSku } as any)
                 .select('id, sku')
                 .single();
-              
+
               if (!retryError) {
                 createdProducts.push({ id: retryProduct.id, sku: retryProduct.sku, wasAdjusted: true });
+                resolved = true;
                 break;
               }
               if (retryError.code !== '23505') {
                 throw retryError;
               }
+            }
+            if (!resolved) {
+              throw new Error(`Could not generate unique SKU for ${skuData.sku} after 50 attempts.`);
             }
           } else {
             throw error;
@@ -417,7 +422,7 @@ export function NewSingleOriginProductModal({ open, onOpenChange, initialLifecyc
           .insert(priceInserts);
         
         if (priceError) {
-          console.error('Price insert failed:', priceError);
+          throw priceError;
         }
       }
       

--- a/src/pages/internal/AccountDetail.tsx
+++ b/src/pages/internal/AccountDetail.tsx
@@ -1374,21 +1374,6 @@ function CustomRateOverrides({ account, refetch }: { account: any; refetch: () =
   const isAdmin = authUser?.role === 'ADMIN';
   const hasCoroasting = account.programs?.includes('COROASTING');
 
-  if (!isAdmin || !hasCoroasting) return null;
-
-  const tier = account.coroast_tier ?? 'MEMBER';
-  const tierDefaults = TIER_DEFAULTS[tier] ?? TIER_DEFAULTS.MEMBER;
-
-  const startEdit = () => {
-    const f: Record<string, string> = {};
-    for (const field of OVERRIDE_FIELDS) {
-      const val = account[field.key];
-      f[field.key] = val != null ? String(val) : '';
-    }
-    setForm(f);
-    setEditing(true);
-  };
-
   const saveMutation = useMutation({
     mutationFn: async () => {
       const payload: Record<string, number | null> = {};
@@ -1407,6 +1392,21 @@ function CustomRateOverrides({ account, refetch }: { account: any; refetch: () =
     },
     onError: (err: Error) => toast.error(err.message),
   });
+
+  if (!isAdmin || !hasCoroasting) return null;
+
+  const tier = account.coroast_tier ?? 'MEMBER';
+  const tierDefaults = TIER_DEFAULTS[tier] ?? TIER_DEFAULTS.MEMBER;
+
+  const startEdit = () => {
+    const f: Record<string, string> = {};
+    for (const field of OVERRIDE_FIELDS) {
+      const val = account[field.key];
+      f[field.key] = val != null ? String(val) : '';
+    }
+    setForm(f);
+    setEditing(true);
+  };
 
   return (
     <Card>


### PR DESCRIPTION
## Summary
- **AccountDetail.tsx** — move `useMutation` above early return; previously violated rules-of-hooks and would crash when `isAdmin`/`hasCoroasting` toggled
- **BookingFormDialog.tsx** — write `member_id` instead of `account_id` to `coroast_recurring_blocks`; that table has no `account_id` column (per CLAUDE.md and generated types)
- **NewBlendProductModal.tsx / NewSingleOriginProductModal.tsx** — throw when SKU uniqueness retry exhausts 50 attempts (was silently dropping products); throw on `price_list` insert errors (was logging only, leaving products without prices)

## Not addressed (need decisions)
- `pricing.ts` margin formula — `cost_per_unit` excludes both `process_per_unit` and `pkg_labour`; unclear whether either should be in cost. Business decision required.
- CLAUDE.md hour-ledger sign convention note is stale (already fixed in commit `e4487c0`).
- Loose `tsconfig` (`strict: false`) lets schema mismatches like the BookingFormDialog bug slip past the compiler. Recommend enabling `strict: true`.

## Test plan
- [ ] Open AccountDetail for a non-admin or non-coroasting account; verify no crash
- [ ] Create a recurring booking via admin BookingFormDialog; verify row in `coroast_recurring_blocks` has `member_id` set
- [ ] Force a SKU collision past 50 retries; verify error toast instead of silent drop
- [ ] Force a `price_list` RLS denial; verify error surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)