### PR TITLE
feat: live USD/CAD rate via Bank of Canada API

### DIFF
--- a/src/components/admin/FxRateSettings.tsx
+++ b/src/components/admin/FxRateSettings.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Loader2, RefreshCw, TrendingUp } from 'lucide-react';
+import { supabase } from '@/integrations/supabase/client';
+import { toast } from 'sonner';
+import { format, parseISO } from 'date-fns';
+
+interface FxRateValue {
+  rate: number;
+  date: string | null;
+  source: string;
+  fetched_at: string | null;
+}
+
+export function FxRateSettings() {
+  const queryClient = useQueryClient();
+
+  const { data: setting, isLoading } = useQuery({
+    queryKey: ['app_settings', 'fx_rate_usd_to_cad'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('app_settings')
+        .select('value_json, updated_at')
+        .eq('key', 'fx_rate_usd_to_cad')
+        .maybeSingle();
+      if (error) throw error;
+      return data;
+    },
+  });
+
+  const fxValue = setting?.value_json as FxRateValue | undefined;
+  const isLive = fxValue?.source === 'bank-of-canada';
+
+  const refreshMutation = useMutation({
+    mutationFn: async () => {
+      const { data, error } = await supabase.functions.invoke('fetch-fx-rate');
+      if (error) throw error;
+      if (!data?.ok) throw new Error(data?.error ?? 'Unknown error from fetch-fx-rate');
+      return data as { ok: true; rate: number; date: string; fetched_at: string };
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['app_settings', 'fx_rate_usd_to_cad'] });
+      toast.success(`Rate updated: 1 USD = ${data.rate.toFixed(4)} CAD (${data.date})`);
+    },
+    onError: (err: Error) => {
+      toast.error(`Failed to refresh rate: ${err.message}`);
+    },
+  });
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <TrendingUp className="h-5 w-5 text-primary" />
+          <CardTitle className="text-lg">USD/CAD Exchange Rate</CardTitle>
+        </div>
+        <CardDescription>
+          Daily rate from the Bank of Canada, used for USD cost conversions in green lot sourcing.
+          Refreshes automatically at 5:30 PM UTC on business days.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-center justify-between gap-4">
+          <div className="space-y-1">
+            {isLoading ? (
+              <div className="flex items-center gap-2 text-muted-foreground text-sm">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Loading...
+              </div>
+            ) : fxValue ? (
+              <>
+                <p className="text-2xl font-semibold tabular-nums">
+                  {fxValue.rate.toFixed(4)}
+                  <span className="text-base font-normal text-muted-foreground ml-2">CAD / USD</span>
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {isLive && fxValue.date
+                    ? `Bank of Canada rate for ${fxValue.date}`
+                    : 'Seed / placeholder value — not yet fetched from Bank of Canada'}
+                  {fxValue.fetched_at && (
+                    <span className="ml-2">
+                      · Last fetched {format(parseISO(fxValue.fetched_at), 'MMM d, yyyy h:mm a')}
+                    </span>
+                  )}
+                </p>
+              </>
+            ) : (
+              <p className="text-sm text-muted-foreground">No rate found in app_settings.</p>
+            )}
+          </div>
+
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => refreshMutation.mutate()}
+            disabled={refreshMutation.isPending}
+          >
+            {refreshMutation.isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin mr-2" />
+            ) : (
+              <RefreshCw className="h-4 w-4 mr-2" />
+            )}
+            Refresh Now
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/pages/internal/AdminTools.tsx
+++ b/src/pages/internal/AdminTools.tsx
@@ -12,6 +12,7 @@ import { GenericLaneConversion } from '@/components/admin/GenericLaneConversion'
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
 import { OrderNotificationSettings } from '@/components/admin/OrderNotificationSettings';
+import { FxRateSettings } from '@/components/admin/FxRateSettings';
 import { BuildInfoPanel } from '@/components/admin/BuildInfoPanel';
 import { PackagingTypesManager } from '@/components/admin/PackagingTypesManager';
 import { buildSku, getOriginCode, generateFgNameCode, formatGramsSuffix } from '@/lib/skuGenerator';
@@ -347,6 +348,9 @@ export default function AdminTools() {
 
       {/* Packaging Types Manager */}
       <PackagingTypesManager />
+
+      {/* USD/CAD Exchange Rate */}
+      <FxRateSettings />
 
       {/* Order Submit Notifications */}
       <OrderNotificationSettings />

--- a/src/pages/internal/ReleaseDetail.tsx
+++ b/src/pages/internal/ReleaseDetail.tsx
@@ -153,12 +153,12 @@ export default function ReleaseDetail() {
   }, [contracts]);
 
   const { data: fxRateSetting } = useQuery({
-    queryKey: ['app_settings', 'placeholder_fx_rate_usd_to_cad'],
+    queryKey: ['app_settings', 'fx_rate_usd_to_cad'],
     queryFn: async () => {
       const { data, error } = await supabase
         .from('app_settings')
         .select('value_json')
-        .eq('key', 'placeholder_fx_rate_usd_to_cad')
+        .eq('key', 'fx_rate_usd_to_cad')
         .maybeSingle();
       if (error) throw error;
       return data;

--- a/src/pages/internal/SourcingLots.tsx
+++ b/src/pages/internal/SourcingLots.tsx
@@ -711,6 +711,20 @@ function LotDetailPanel({
     },
   });
 
+  const { data: liveFxRateSetting } = useQuery({
+    queryKey: ['app_settings', 'fx_rate_usd_to_cad'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('app_settings')
+        .select('value_json')
+        .eq('key', 'fx_rate_usd_to_cad')
+        .maybeSingle();
+      if (error) throw error;
+      return data;
+    },
+  });
+  const liveFxRate: number | null = Number((liveFxRateSetting?.value_json as any)?.rate) || null;
+
   // ─── Local cost state ────────────────────────────────────
   const [fxRate, setFxRate] = useState<number | null>(null);
   const [invoiceAmt, setInvoiceAmt] = useState<number>(0);
@@ -735,7 +749,8 @@ function LotDetailPanel({
   // Sync from DB
   useEffect(() => {
     if (lot) {
-      setFxRate(lot.fx_rate);
+      // Prefill with live BoC rate when lot has no confirmed fx_rate yet
+      setFxRate(lot.fx_rate ?? liveFxRate);
       if (lot.invoice_is_usd && lot.fx_rate && lot.invoice_amount_cad != null) {
         setInvoiceAmt(lot.invoice_amount_cad / lot.fx_rate);
       } else {
@@ -765,7 +780,7 @@ function LotDetailPanel({
       setEditVendorInvoice(lot.vendor_invoice_number || '');
       setEditLotNumber(lot.lot_number || '');
     }
-  }, [lot]);
+  }, [lot, liveFxRate]);
 
   const toCad = useCallback((val: number | null, isUsd: boolean, rate: number | null) => {
     if (val == null) return null;

--- a/supabase/functions/fetch-fx-rate/index.ts
+++ b/supabase/functions/fetch-fx-rate/index.ts
@@ -1,0 +1,103 @@
+import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.91.0";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+};
+
+const BOC_URL =
+  "https://www.bankofcanada.ca/valet/observations/FXUSDCAD/json?recent=1";
+
+serve(async (req: Request) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+    const adminClient = createClient(supabaseUrl, serviceRoleKey);
+
+    // Accept service_role calls (pg_cron / scheduler) OR ADMIN user calls (manual refresh)
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader) {
+      return new Response(
+        JSON.stringify({ ok: false, error: "Missing authorization header" }),
+        { status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
+    const token = authHeader.replace("Bearer ", "");
+    const isServiceRole = token === serviceRoleKey;
+
+    if (!isServiceRole) {
+      const { data: { user }, error: authError } = await adminClient.auth.getUser(token);
+      if (authError || !user) {
+        return new Response(
+          JSON.stringify({ ok: false, error: "Invalid token" }),
+          { status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+        );
+      }
+
+      const { data: roleData } = await adminClient
+        .from("user_roles")
+        .select("role")
+        .eq("user_id", user.id)
+        .single();
+
+      if (roleData?.role !== "ADMIN") {
+        return new Response(
+          JSON.stringify({ ok: false, error: "ADMIN role required" }),
+          { status: 403, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+        );
+      }
+    }
+
+    // Fetch from Bank of Canada Valet API
+    console.log("[fetch-fx-rate] Fetching USD/CAD rate from Bank of Canada");
+    const bocRes = await fetch(BOC_URL);
+    if (!bocRes.ok) {
+      throw new Error(`Bank of Canada API returned ${bocRes.status}`);
+    }
+
+    const bocData = await bocRes.json();
+    const obs = bocData.observations?.[0];
+    if (!obs?.FXUSDCAD?.v) {
+      throw new Error("Unexpected response shape from Bank of Canada API");
+    }
+
+    const rate = parseFloat(obs.FXUSDCAD.v);
+    const date: string = obs.d; // "YYYY-MM-DD"
+    const fetchedAt = new Date().toISOString();
+
+    console.log(`[fetch-fx-rate] Rate: ${rate} as of ${date}`);
+
+    const { error: upsertError } = await adminClient
+      .from("app_settings")
+      .upsert({
+        key: "fx_rate_usd_to_cad",
+        value_json: { rate, date, source: "bank-of-canada", fetched_at: fetchedAt },
+        updated_at: fetchedAt,
+      });
+
+    if (upsertError) {
+      throw new Error(`DB upsert failed: ${upsertError.message}`);
+    }
+
+    console.log("[fetch-fx-rate] Rate upserted successfully");
+
+    return new Response(
+      JSON.stringify({ ok: true, rate, date, fetched_at: fetchedAt }),
+      { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    console.error("[fetch-fx-rate] Error:", message);
+    return new Response(
+      JSON.stringify({ ok: false, error: message }),
+      { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  }
+});

--- a/supabase/migrations/20260508170000_seed_live_fx_rate.sql
+++ b/supabase/migrations/20260508170000_seed_live_fx_rate.sql
@@ -1,0 +1,9 @@
+-- Seed the live FX rate key populated daily by the fetch-fx-rate edge function.
+-- Distinct from placeholder_fx_rate_usd_to_cad (manual estimate).
+-- value_json shape: { rate: number, date: "YYYY-MM-DD", source: string, fetched_at: ISO string }
+INSERT INTO public.app_settings (key, value_json)
+VALUES (
+  'fx_rate_usd_to_cad',
+  '{"rate": 1.38, "date": null, "source": "seed", "fetched_at": null}'::jsonb
+)
+ON CONFLICT (key) DO NOTHING;


### PR DESCRIPTION
## Summary

- **New edge function** `fetch-fx-rate`: calls the Bank of Canada Valet API (`FXUSDCAD`), upserts `{ rate, date, source, fetched_at }` into `app_settings` under key `fx_rate_usd_to_cad`. Accepts service_role key (scheduled cron) or ADMIN user token (manual refresh).
- **Seed migration** `20260508170000_seed_live_fx_rate.sql`: inserts initial `fx_rate_usd_to_cad` row so consumers never get a null.
- **`FxRateSettings` admin component**: displays current rate, BoC date, last fetched timestamp, and a "Refresh Now" button. Added to AdminTools page.
- **`ReleaseDetail.tsx`**: switched query key from `placeholder_fx_rate_usd_to_cad` → `fx_rate_usd_to_cad`.
- **`SourcingLots.tsx`**: fetches live rate from `app_settings` and prefills the lot `fx_rate` field when a new lot has no saved rate yet.

## Cron setup (manual post-deploy step)

pg_cron/pg_net status was unknown so the schedule is not in a migration. After deploying the function, add in **Supabase Dashboard → Database → Cron Jobs**:

- **Name**: `fetch-fx-rate-daily`
- **Schedule**: `30 17 * * 1-5` (5:30 PM UTC, weekdays — BoC closed weekends)
- **Command**:
  ```sql
  SELECT net.http_post(
    url     := '<SUPABASE_URL>/functions/v1/fetch-fx-rate',
    headers := '{"Authorization": "Bearer <SERVICE_ROLE_KEY>", "Content-Type": "application/json"}'::jsonb,
    body    := '{}'::jsonb
  );
  ```

## Test plan

- [ ] Deploy edge function: `supabase functions deploy fetch-fx-rate`
- [ ] Manual curl with service_role key → confirm `app_settings.fx_rate_usd_to_cad` updates
- [ ] Click "Refresh Now" in AdminTools as ADMIN user → toast shows new rate + date
- [ ] Open a green lot with no saved fx_rate → FX Rate field prefills with live rate
- [ ] Open ReleaseDetail for a release with USD shared costs → rate converts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)