### PR TITLE
Multi-vendor / multi-source releases

### DIFF
--- a/src/components/sourcing/releases/CreateReleaseModal.tsx
+++ b/src/components/sourcing/releases/CreateReleaseModal.tsx
@@ -15,9 +15,10 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { Calendar } from '@/components/ui/calendar';
 import { Card, CardContent } from '@/components/ui/card';
 import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@/components/ui/table';
-import { CalendarIcon, Copy, Check } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { CalendarIcon, Copy, Check, Plus, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { formatPerKg, formatPerLb, formatMoney } from '@/lib/formatMoney';
+import { formatPerKg, formatPerLb } from '@/lib/formatMoney';
 import { getCountryName } from '@/lib/coffeeOrigins';
 import { allocatePoNumber, allocateSingleLotNumber } from '@/lib/lotNumberGenerator';
 import {
@@ -27,12 +28,14 @@ import {
   SHARED_COST_KEYS,
   SHARED_COST_LABELS,
   SharedCostKey,
+  SelectedLine,
   emptySharedCosts,
   totalSharedCostsUsd,
   bookValuePerKgUsd,
   bookValuePerLbUsd,
-  priceUsdPerLbToUsdPerKg,
 } from './releaseUtils';
+
+// ─── Local types ─────────────────────────────────────────────────────────────
 
 interface Vendor { id: string; name: string; abbreviation: string | null; }
 
@@ -54,22 +57,34 @@ interface ContractRow {
   vendor_id: string | null;
 }
 
-interface SelectedLine {
-  contract_id: string;
-  contract: ContractRow;
-  bags_requested: number;
-  arrival_status: 'EN_ROUTE' | 'RECEIVED';
-  // Step 2 pricing
-  price_amount: string;       // editable, original unit
-  price_unit: string;         // e.g. "USD/lb", "USD/kg"
-  line_notes: string;
+interface PurchaseLineRow {
+  id: string;
+  purchase_id: string;
+  lot_id: string | null;
+  lot_identifier: string | null;
+  origin_country: string | null;
+  region: string | null;
+  producer: string | null;
+  variety: string | null;
+  bags: number | null;
+  bag_size_kg: number | null;
+  price_per_lb_usd: number | null;
+  purchase: {
+    id: string;
+    vendor_id: string | null;
+    invoice_number: string | null;
+  } | null;
 }
+
+type Step1Tab = 'contracts' | 'purchases' | 'adhoc';
 
 interface Props {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onSuccess?: (releaseId: string) => void;
 }
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function contractRef(c: ContractRow): string {
   return c.internal_contract_number || c.vendor_contract_number || c.name || '—';
@@ -81,35 +96,56 @@ function contractDescription(c: ContractRow): string {
     .join(' · ');
 }
 
-/** Convert an entered price + unit into USD/lb (best effort, no FX). */
 function toUsdPerLb(amount: number, unit: string): number {
   if (!amount) return 0;
   switch (unit) {
     case 'USD/lb': return amount;
     case 'USD/kg': return amount / KG_PER_LB;
-    case 'CAD/lb': return amount; // no FX context — store as-is
+    case 'CAD/lb': return amount;
     case 'CAD/kg': return amount / KG_PER_LB;
     default: return amount;
   }
 }
 
-function deriveOriginalPrice(c: ContractRow): { amount: string; unit: string } {
+function defaultPriceFromContract(c: ContractRow): { amount: string; unit: string } {
   if (c.contracted_price_per_kg == null) return { amount: '', unit: 'USD/lb' };
   const cur = (c.contracted_price_currency || 'USD').toUpperCase();
-  // Convert kg → lb so the user sees USD/lb by default
   const perLb = Number(c.contracted_price_per_kg) / KG_PER_LB;
   return { amount: perLb.toFixed(4), unit: `${cur}/lb` };
 }
+
+// ─── Component ───────────────────────────────────────────────────────────────
 
 export function CreateReleaseModal({ open, onOpenChange, onSuccess }: Props) {
   const { authUser } = useAuth();
   const queryClient = useQueryClient();
 
   const [step, setStep] = useState<1 | 2>(1);
+  const [tab, setTab] = useState<Step1Tab>('contracts');
 
-  // Step 1 state
-  const [vendorId, setVendorId] = useState('');
+  // selected lines: keyed by unique key
   const [selected, setSelected] = useState<Record<string, SelectedLine>>({});
+
+  // contract tab: filter by vendor
+  const [contractVendorFilter, setContractVendorFilter] = useState('');
+  const [contractSearch, setContractSearch] = useState('');
+
+  // purchase tab
+  const [purchaseSearch, setPurchaseSearch] = useState('');
+  const [showAllPurchaseLines, setShowAllPurchaseLines] = useState(false);
+
+  // ad-hoc tab form state
+  const [adhocVendorId, setAdhocVendorId] = useState('');
+  const [adhocLotId, setAdhocLotId] = useState('');
+  const [adhocOrigin, setAdhocOrigin] = useState('');
+  const [adhocRegion, setAdhocRegion] = useState('');
+  const [adhocProducer, setAdhocProducer] = useState('');
+  const [adhocVariety, setAdhocVariety] = useState('');
+  const [adhocBags, setAdhocBags] = useState('');
+  const [adhocBagSize, setAdhocBagSize] = useState('');
+  const [adhocPriceAmount, setAdhocPriceAmount] = useState('');
+  const [adhocPriceUnit, setAdhocPriceUnit] = useState('USD/lb');
+  const [adhocNotes, setAdhocNotes] = useState('');
 
   // Step 2 state
   const [etaDate, setEtaDate] = useState<Date | undefined>();
@@ -119,14 +155,28 @@ export function CreateReleaseModal({ open, onOpenChange, onSuccess }: Props) {
   const [invoiceNumber, setInvoiceNumber] = useState('');
   const [sharedCosts, setSharedCosts] = useState<SharedCostsJson>(emptySharedCosts('USD'));
   const [emailCopied, setEmailCopied] = useState(false);
-  const [saving, setSaving] = useState(false);
 
   // Reset on open
   useEffect(() => {
     if (!open) return;
     setStep(1);
-    setVendorId('');
+    setTab('contracts');
     setSelected({});
+    setContractVendorFilter('');
+    setContractSearch('');
+    setPurchaseSearch('');
+    setShowAllPurchaseLines(false);
+    setAdhocVendorId('');
+    setAdhocLotId('');
+    setAdhocOrigin('');
+    setAdhocRegion('');
+    setAdhocProducer('');
+    setAdhocVariety('');
+    setAdhocBags('');
+    setAdhocBagSize('');
+    setAdhocPriceAmount('');
+    setAdhocPriceUnit('USD/lb');
+    setAdhocNotes('');
     setEtaDate(undefined);
     setNotes('');
     setMarkReceived(true);
@@ -136,7 +186,8 @@ export function CreateReleaseModal({ open, onOpenChange, onSuccess }: Props) {
     setEmailCopied(false);
   }, [open]);
 
-  // Load vendors
+  // ── Data loading ──────────────────────────────────────────────────────────
+
   const { data: vendors = [] } = useQuery({
     queryKey: ['green-vendors-active-for-release'],
     queryFn: async () => {
@@ -151,23 +202,28 @@ export function CreateReleaseModal({ open, onOpenChange, onSuccess }: Props) {
     enabled: open,
   });
 
-  // Load active contracts for vendor
+  const vendorMap = useMemo(() => {
+    const m: Record<string, Vendor> = {};
+    vendors.forEach(v => { m[v.id] = v; });
+    return m;
+  }, [vendors]);
+
+  // All active contracts (all vendors)
   const { data: contracts = [], isLoading: loadingContracts } = useQuery({
-    queryKey: ['green-contracts-for-release', vendorId],
+    queryKey: ['green-contracts-for-release-all'],
     queryFn: async () => {
       const { data, error } = await supabase
         .from('green_contracts')
         .select('id, name, internal_contract_number, vendor_contract_number, lot_identifier, origin_country, origin, region, producer, variety, num_bags, bag_size_kg, contracted_price_per_kg, contracted_price_currency, vendor_id')
-        .eq('vendor_id', vendorId)
         .eq('status', 'ACTIVE')
         .order('name');
       if (error) throw error;
       return data as ContractRow[];
     },
-    enabled: open && !!vendorId,
+    enabled: open && tab === 'contracts',
   });
 
-  // Bags already released per contract (from green_release_lines)
+  // Bags already released per contract
   const contractIds = contracts.map(c => c.id);
   const { data: releasedByContract = {} } = useQuery({
     queryKey: ['green-release-lines-by-contract', contractIds],
@@ -188,74 +244,216 @@ export function CreateReleaseModal({ open, onOpenChange, onSuccess }: Props) {
     enabled: open && contractIds.length > 0,
   });
 
+  // Purchase lines
+  const { data: purchaseLines = [], isLoading: loadingPurchaseLines } = useQuery({
+    queryKey: ['green-purchase-lines-for-release', showAllPurchaseLines],
+    queryFn: async () => {
+      let q = supabase
+        .from('green_purchase_lines')
+        .select('id, purchase_id, lot_id, lot_identifier, origin_country, region, producer, variety, bags, bag_size_kg, price_per_lb_usd, purchase:green_purchases(id, vendor_id, invoice_number)')
+        .order('created_at', { ascending: false });
+      if (!showAllPurchaseLines) {
+        q = q.is('lot_id', null);
+      }
+      const { data, error } = await q;
+      if (error) throw error;
+      return (data || []) as unknown as PurchaseLineRow[];
+    },
+    enabled: open && tab === 'purchases',
+  });
+
+  // ── Line management ───────────────────────────────────────────────────────
+
   function bagsRemaining(c: ContractRow): number {
-    const total = c.num_bags || 0;
-    const used = releasedByContract[c.id] || 0;
-    return Math.max(0, total - used);
+    return Math.max(0, (c.num_bags || 0) - (releasedByContract[c.id] || 0));
   }
 
   function toggleContract(c: ContractRow, checked: boolean) {
+    const key = `contract:${c.id}`;
     setSelected(prev => {
       const next = { ...prev };
       if (checked) {
-        const orig = deriveOriginalPrice(c);
-        next[c.id] = {
+        const orig = defaultPriceFromContract(c);
+        const vendor = c.vendor_id ? vendorMap[c.vendor_id] : null;
+        next[key] = {
+          key,
+          source_type: 'CONTRACT',
+          vendor_id: c.vendor_id,
+          vendor_name: vendor?.name || '—',
+          vendor_abbr: vendor?.abbreviation || null,
           contract_id: c.id,
-          contract: c,
+          contract_name: c.name,
+          internal_contract_number: c.internal_contract_number,
+          vendor_contract_number: c.vendor_contract_number,
+          purchase_line_id: null,
+          purchase_id: null,
+          existing_lot_id: null,
+          lot_identifier: c.lot_identifier,
+          origin_country: c.origin_country,
+          region: c.region,
+          producer: c.producer,
+          variety: c.variety,
+          bag_size_kg: Number(c.bag_size_kg || 0),
           bags_requested: bagsRemaining(c),
-          arrival_status: 'EN_ROUTE',
           price_amount: orig.amount,
           price_unit: orig.unit,
           line_notes: '',
         };
       } else {
-        delete next[c.id];
+        delete next[key];
       }
       return next;
     });
   }
 
-  function updateLine(contractId: string, patch: Partial<SelectedLine>) {
+  function togglePurchaseLine(pl: PurchaseLineRow, checked: boolean) {
+    const key = `purchase:${pl.id}`;
+    const vendorId = pl.purchase?.vendor_id || null;
+    const vendor = vendorId ? vendorMap[vendorId] : null;
+    setSelected(prev => {
+      const next = { ...prev };
+      if (checked) {
+        next[key] = {
+          key,
+          source_type: 'PURCHASE',
+          vendor_id: vendorId,
+          vendor_name: vendor?.name || '—',
+          vendor_abbr: vendor?.abbreviation || null,
+          contract_id: null,
+          contract_name: null,
+          internal_contract_number: null,
+          vendor_contract_number: null,
+          purchase_line_id: pl.id,
+          purchase_id: pl.purchase_id,
+          existing_lot_id: pl.lot_id || null,
+          lot_identifier: pl.lot_identifier,
+          origin_country: pl.origin_country,
+          region: pl.region,
+          producer: pl.producer,
+          variety: pl.variety,
+          bag_size_kg: Number(pl.bag_size_kg || 0),
+          bags_requested: pl.bags || 0,
+          price_amount: pl.price_per_lb_usd != null ? String(pl.price_per_lb_usd) : '',
+          price_unit: 'USD/lb',
+          line_notes: '',
+        };
+      } else {
+        delete next[key];
+      }
+      return next;
+    });
+  }
+
+  function addAdhocLine() {
+    const bags = parseInt(adhocBags) || 0;
+    const bagSize = parseFloat(adhocBagSize) || 0;
+    if (bags <= 0 || bagSize <= 0) {
+      toast.error('Bags and bag size required for ad-hoc line');
+      return;
+    }
+    const vendor = adhocVendorId ? vendorMap[adhocVendorId] : null;
+    const key = `adhoc:${Date.now()}`;
     setSelected(prev => ({
       ...prev,
-      [contractId]: { ...prev[contractId], ...patch },
+      [key]: {
+        key,
+        source_type: 'ADHOC',
+        vendor_id: adhocVendorId || null,
+        vendor_name: vendor?.name || '—',
+        vendor_abbr: vendor?.abbreviation || null,
+        contract_id: null,
+        contract_name: null,
+        internal_contract_number: null,
+        vendor_contract_number: null,
+        purchase_line_id: null,
+        purchase_id: null,
+        existing_lot_id: null,
+        lot_identifier: adhocLotId.trim() || null,
+        origin_country: adhocOrigin.trim() || null,
+        region: adhocRegion.trim() || null,
+        producer: adhocProducer.trim() || null,
+        variety: adhocVariety.trim() || null,
+        bag_size_kg: bagSize,
+        bags_requested: bags,
+        price_amount: adhocPriceAmount,
+        price_unit: adhocPriceUnit,
+        line_notes: adhocNotes,
+      },
+    }));
+    // reset adhoc form
+    setAdhocLotId('');
+    setAdhocOrigin('');
+    setAdhocRegion('');
+    setAdhocProducer('');
+    setAdhocVariety('');
+    setAdhocBags('');
+    setAdhocBagSize('');
+    setAdhocPriceAmount('');
+    setAdhocNotes('');
+  }
+
+  function removeLine(key: string) {
+    setSelected(prev => {
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
+  }
+
+  function updateLine(key: string, patch: Partial<SelectedLine>) {
+    setSelected(prev => ({
+      ...prev,
+      [key]: { ...prev[key], ...patch },
     }));
   }
 
   const selectedList = useMemo(() => Object.values(selected), [selected]);
-  const totalKgAll = selectedList.reduce((s, l) => s + l.bags_requested * Number(l.contract.bag_size_kg || 0), 0);
+  const totalKgAll = selectedList.reduce((s, l) => s + l.bags_requested * l.bag_size_kg, 0);
   const totalSharedUsd = totalSharedCostsUsd(sharedCosts);
 
+  // ── Validation ────────────────────────────────────────────────────────────
+
   function step1Valid(): boolean {
-    if (!vendorId) return false;
     if (selectedList.length === 0) return false;
     for (const l of selectedList) {
       if (!l.bags_requested || l.bags_requested <= 0) return false;
-      if (l.bags_requested > bagsRemaining(l.contract)) return false;
+      if (l.source_type === 'CONTRACT') {
+        const c = contracts.find(c => c.id === l.contract_id);
+        if (c && l.bags_requested > bagsRemaining(c)) return false;
+      }
     }
     return true;
   }
 
-  // Build email draft
-  const vendorName = vendors.find(v => v.id === vendorId)?.name || '';
+  // ── Email draft ───────────────────────────────────────────────────────────
+
   const emailBody = useMemo(() => {
-    const lines = selectedList.map(l => {
-      const ref = contractRef(l.contract);
-      const desc = contractDescription(l.contract);
-      return `- Contract: ${ref} | ${desc} | ${l.bags_requested} x ${l.contract.bag_size_kg}kg`;
-    }).join('\n');
+    // Group by vendor
+    const byVendor: Record<string, { name: string; lines: SelectedLine[] }> = {};
+    for (const l of selectedList) {
+      const vid = l.vendor_id || '_unknown';
+      if (!byVendor[vid]) byVendor[vid] = { name: l.vendor_name, lines: [] };
+      byVendor[vid].lines.push(l);
+    }
     const userName = authUser?.profile?.name || authUser?.email || '';
-    return `Hi ${vendorName ? `[${vendorName} contact]` : '[vendor contact]'},
+    return Object.values(byVendor).map(({ name, lines }) => {
+      const lineText = lines.map(l => {
+        const ref = l.internal_contract_number || l.vendor_contract_number || l.lot_identifier || '—';
+        const desc = [getCountryName(l.origin_country), l.region, l.producer, l.variety].filter(Boolean).join(' · ');
+        return `- ${ref} | ${desc} | ${l.bags_requested} x ${l.bag_size_kg}kg`;
+      }).join('\n');
+      return `To: [${name} contact]
 
-We'd like to request a release from the following contracts:
+We'd like to request a release from the following:
 
-${lines}
+${lineText}
 
-Please let us know the expected ship date and invoice details at your convenience.
+Please let us know the expected ship date and invoice details.
 
 Thanks,
 ${userName}`;
-  }, [selectedList, vendorName, authUser]);
+    }).join('\n\n---\n\n');
+  }, [selectedList, authUser]);
 
   async function copyEmail() {
     try {
@@ -268,26 +466,30 @@ ${userName}`;
     }
   }
 
-  // Save mutation
+  // ── Save ──────────────────────────────────────────────────────────────────
+
   const saveMutation = useMutation({
     mutationFn: async () => {
-      // Defensive: never allow save unless user reached Step 2
       if (step !== 2) throw new Error('Please complete Step 2 before saving.');
 
-      // 1. Allocate PO number for the release (atomic)
-      const vendorAbbrForPo = vendors.find(v => v.id === vendorId)?.abbreviation || null;
-      const po = await allocatePoNumber(vendorAbbrForPo);
+      // Compute release-level vendor: single vendor if all lines share one, else null
+      const uniqueVendorIds = [...new Set(selectedList.map(l => l.vendor_id).filter(Boolean))];
+      const releaseVendorId = uniqueVendorIds.length === 1 ? uniqueVendorIds[0]! : null;
+      const primaryVendorAbbr = releaseVendorId ? (vendorMap[releaseVendorId]?.abbreviation || null) : null;
 
-      // 2. Insert release
+      // Allocate PO
+      const po = await allocatePoNumber(primaryVendorAbbr);
+
       const status = invoiceNumber.trim() ? 'INVOICED' : 'PENDING';
       const arrival: 'RECEIVED' | 'EN_ROUTE' = markReceived ? 'RECEIVED' : 'EN_ROUTE';
       const etaStr = etaDate ? format(etaDate, 'yyyy-MM-dd') : null;
       const recStr = receivedDate ? format(receivedDate, 'yyyy-MM-dd') : null;
 
+      // Insert release
       const { data: rel, error: relErr } = await supabase
         .from('green_releases')
         .insert({
-          vendor_id: vendorId,
+          vendor_id: releaseVendorId,
           status,
           invoice_number: invoiceNumber.trim() || null,
           eta_date: arrival === 'EN_ROUTE' ? etaStr : null,
@@ -303,10 +505,7 @@ ${userName}`;
       if (relErr) throw relErr;
       const releaseId = rel!.id;
 
-      // 2. Insert release lines + create lots
-      // Per-kg shared cost share, prorated by weighted kg average across all lines.
-      // Compute totals per shared cost bucket so we can map to the lot's
-      // currency-specific cost columns (USD vs CAD).
+      // Bucket totals for prorating into lot cost columns
       const bucketTotals = SHARED_COST_KEYS.reduce<Record<SharedCostKey, { usd: number; cad: number }>>((acc, k) => {
         const line = sharedCosts[k];
         const amt = Number(line?.amount) || 0;
@@ -318,77 +517,90 @@ ${userName}`;
       for (const l of selectedList) {
         const priceAmount = parseFloat(l.price_amount) || 0;
         const priceUsdPerLb = toUsdPerLb(priceAmount, l.price_unit);
-        const bagSize = Number(l.contract.bag_size_kg || 0);
-        const totalKg = l.bags_requested * bagSize;
-
-        // Weight share for proration (kg fraction of full release)
+        const totalKg = l.bags_requested * l.bag_size_kg;
         const kgShare = totalKgAll > 0 ? totalKg / totalKgAll : 0;
 
-        // Coffee cost (invoice) — total USD for this lot's coffee
         const coffeeCostUsd = priceUsdPerLb > 0 ? priceUsdPerLb * KG_PER_LB * totalKg : null;
-
-        // Prorated shared costs by bucket (USD or CAD), per lot
         const lotCarryUsd = bucketTotals.carry.usd * kgShare;
         const lotCarryCad = bucketTotals.carry.cad * kgShare;
-        const lotFreightCad = (bucketTotals.freight.usd + bucketTotals.freight.cad) * kgShare; // freight column is CAD only — fold any USD freight in (best-effort, no FX context)
+        const lotFreightCad = (bucketTotals.freight.usd + bucketTotals.freight.cad) * kgShare;
         const lotDutiesCad = (bucketTotals.duties.usd + bucketTotals.duties.cad) * kgShare;
         const lotFeesCad = (bucketTotals.fees.usd + bucketTotals.fees.cad) * kgShare;
         const lotOtherCad = (bucketTotals.other.usd + bucketTotals.other.cad) * kgShare;
-
-        // Book value (USD/kg) using the global per-kg shared share
         const sharedShareUsdPerKg = totalKgAll > 0 ? totalSharedUsd / totalKgAll : 0;
         const bookPerKg = bookValuePerKgUsd(priceUsdPerLb, sharedShareUsdPerKg);
 
-        // Generate lot number under the just-allocated PO
-        const lotNumber = await allocateSingleLotNumber(po, l.contract.origin_country);
-
         const isReceived = arrival === 'RECEIVED';
 
-        // Create lot — arrival status is global (Step 2 toggle).
-        // We store costs in both _usd columns AND mirror into _cad columns (with
-        // _is_usd=true and fx_rate=1 placeholder) so the lot detail panel —
-        // which back-converts from the *_cad columns — surfaces non-zero values
-        // before any FX has been confirmed.
-        const { data: lot, error: lotErr } = await supabase
-          .from('green_lots')
-          .insert({
-            lot_number: lotNumber,
-            contract_id: l.contract_id,
-            release_id: releaseId,
-            lot_identifier: l.contract.lot_identifier || null,
-            bag_size_kg: bagSize,
-            bags_released: l.bags_requested,
-            kg_on_hand: isReceived ? totalKg : 0,
-            kg_received: isReceived ? totalKg : null,
-            received_date: isReceived ? recStr : null,
-            expected_delivery_date: !isReceived ? etaStr : null,
-            status: isReceived ? 'RECEIVED' : 'EN_ROUTE',
-            // FX placeholder so mirrored *_cad values back-convert cleanly to original USD
-            fx_rate: 1,
-            // Coffee cost
-            invoice_amount_usd: coffeeCostUsd,
-            invoice_amount_cad: coffeeCostUsd,
-            invoice_is_usd: true,
-            // Prorated shared costs (mirror USD into CAD column with is_usd=true)
-            carry_fees_usd: lotCarryUsd > 0 ? lotCarryUsd : null,
-            carry_fees_cad: (lotCarryUsd + lotCarryCad) > 0 ? (lotCarryUsd + lotCarryCad) : null,
-            carry_fees_is_usd: lotCarryUsd >= lotCarryCad,
-            freight_cad: lotFreightCad > 0 ? lotFreightCad : null,
-            freight_is_usd: false,
-            duties_cad: lotDutiesCad > 0 ? lotDutiesCad : null,
-            transaction_fees_cad: lotFeesCad > 0 ? lotFeesCad : null,
-            other_costs_cad: lotOtherCad > 0 ? lotOtherCad : null,
-            // Computed values
-            book_value_per_kg: bookPerKg > 0 ? bookPerKg : null,
-            market_value_per_kg: bookPerKg > 0 ? bookPerKg : null,
-            costing_status: invoiceNumber.trim() ? 'COMPLETE' : 'INCOMPLETE',
-            costing_complete: !!invoiceNumber.trim(),
-            notes_internal: l.line_notes.trim() || null,
-            created_by: authUser?.id || null,
-          })
-          .select('id')
-          .single();
-        if (lotErr) throw lotErr;
+        let lotId: string;
+
+        if (l.source_type === 'PURCHASE' && l.existing_lot_id) {
+          // Lot already exists from the purchase — link it to this release
+          const { error: updateErr } = await supabase
+            .from('green_lots')
+            .update({
+              release_id: releaseId,
+              status: isReceived ? 'RECEIVED' : 'EN_ROUTE',
+              kg_on_hand: isReceived ? totalKg : 0,
+              kg_received: isReceived ? totalKg : null,
+              received_date: isReceived ? recStr : null,
+              expected_delivery_date: !isReceived ? etaStr : null,
+              book_value_per_kg: bookPerKg > 0 ? bookPerKg : null,
+              market_value_per_kg: bookPerKg > 0 ? bookPerKg : null,
+            })
+            .eq('id', l.existing_lot_id);
+          if (updateErr) throw updateErr;
+          lotId = l.existing_lot_id;
+        } else {
+          // Create a new lot
+          const lotNumber = await allocateSingleLotNumber(po, l.origin_country, l.vendor_abbr);
+          const { data: lot, error: lotErr } = await supabase
+            .from('green_lots')
+            .insert({
+              lot_number: lotNumber,
+              contract_id: l.contract_id,
+              purchase_id: l.purchase_id,
+              release_id: releaseId,
+              lot_identifier: l.lot_identifier || null,
+              bag_size_kg: l.bag_size_kg,
+              bags_released: l.bags_requested,
+              kg_on_hand: isReceived ? totalKg : 0,
+              kg_received: isReceived ? totalKg : null,
+              received_date: isReceived ? recStr : null,
+              expected_delivery_date: !isReceived ? etaStr : null,
+              status: isReceived ? 'RECEIVED' : 'EN_ROUTE',
+              fx_rate: 1,
+              invoice_amount_usd: coffeeCostUsd,
+              invoice_amount_cad: coffeeCostUsd,
+              invoice_is_usd: true,
+              carry_fees_usd: lotCarryUsd > 0 ? lotCarryUsd : null,
+              carry_fees_cad: (lotCarryUsd + lotCarryCad) > 0 ? (lotCarryUsd + lotCarryCad) : null,
+              carry_fees_is_usd: lotCarryUsd >= lotCarryCad,
+              freight_cad: lotFreightCad > 0 ? lotFreightCad : null,
+              freight_is_usd: false,
+              duties_cad: lotDutiesCad > 0 ? lotDutiesCad : null,
+              transaction_fees_cad: lotFeesCad > 0 ? lotFeesCad : null,
+              other_costs_cad: lotOtherCad > 0 ? lotOtherCad : null,
+              book_value_per_kg: bookPerKg > 0 ? bookPerKg : null,
+              market_value_per_kg: bookPerKg > 0 ? bookPerKg : null,
+              costing_status: invoiceNumber.trim() ? 'COMPLETE' : 'INCOMPLETE',
+              costing_complete: !!invoiceNumber.trim(),
+              notes_internal: l.line_notes.trim() || null,
+              created_by: authUser?.id || null,
+            } as any)
+            .select('id')
+            .single();
+          if (lotErr) throw lotErr;
+          lotId = lot!.id;
+
+          // If this was a PURCHASE line, update the purchase line's lot_id
+          if (l.source_type === 'PURCHASE' && l.purchase_line_id) {
+            await supabase
+              .from('green_purchase_lines')
+              .update({ lot_id: lotId })
+              .eq('id', l.purchase_line_id);
+          }
+        }
 
         // Insert release line
         const { error: lineErr } = await supabase
@@ -396,13 +608,21 @@ ${userName}`;
           .insert({
             release_id: releaseId,
             contract_id: l.contract_id,
-            lot_id: lot!.id,
+            lot_id: lotId,
             bags_requested: l.bags_requested,
-            bag_size_kg: bagSize,
+            bag_size_kg: l.bag_size_kg,
             price_per_lb_usd: priceUsdPerLb || null,
-            original_price: { amount: priceAmount, unit: l.price_unit } as any,
+            original_price: { amount: parseFloat(l.price_amount) || 0, unit: l.price_unit } as any,
             notes: l.line_notes.trim() || null,
-          });
+            source_type: l.source_type,
+            purchase_line_id: l.purchase_line_id || null,
+            vendor_id: l.vendor_id || null,
+            lot_identifier: l.lot_identifier || null,
+            origin_country: l.origin_country || null,
+            region: l.region || null,
+            producer: l.producer || null,
+            variety: l.variety || null,
+          } as any);
         if (lineErr) throw lineErr;
       }
 
@@ -413,6 +633,7 @@ ${userName}`;
       queryClient.invalidateQueries({ queryKey: ['green-releases'] });
       queryClient.invalidateQueries({ queryKey: ['green-release-lines'] });
       queryClient.invalidateQueries({ queryKey: ['green-lots'] });
+      queryClient.invalidateQueries({ queryKey: ['green-purchase-lines-for-release'] });
       onOpenChange(false);
       onSuccess?.(releaseId);
     },
@@ -421,75 +642,129 @@ ${userName}`;
     },
   });
 
+  // ── Filtered contract list ────────────────────────────────────────────────
+
+  const filteredContracts = useMemo(() => {
+    return contracts.filter(c => {
+      if (contractVendorFilter && c.vendor_id !== contractVendorFilter) return false;
+      if (contractSearch) {
+        const q = contractSearch.toLowerCase();
+        const haystack = [
+          c.name, c.internal_contract_number, c.vendor_contract_number,
+          c.lot_identifier, c.origin_country, c.region, c.producer, c.variety,
+        ].filter(Boolean).join(' ').toLowerCase();
+        if (!haystack.includes(q)) return false;
+      }
+      return true;
+    });
+  }, [contracts, contractVendorFilter, contractSearch]);
+
+  const filteredPurchaseLines = useMemo(() => {
+    return purchaseLines.filter(pl => {
+      if (!purchaseSearch) return true;
+      const q = purchaseSearch.toLowerCase();
+      const vendorName = pl.purchase?.vendor_id ? (vendorMap[pl.purchase.vendor_id]?.name || '') : '';
+      const haystack = [
+        pl.lot_identifier, pl.origin_country, pl.region, pl.producer, pl.variety,
+        pl.purchase?.invoice_number, vendorName,
+      ].filter(Boolean).join(' ').toLowerCase();
+      return haystack.includes(q);
+    });
+  }, [purchaseLines, purchaseSearch, vendorMap]);
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-6xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle>{step === 1 ? 'New Release — Select Contracts' : 'New Release — Details & Pricing'}</DialogTitle>
+          <DialogTitle>
+            {step === 1 ? 'New Release — Select Lines' : 'New Release — Details & Pricing'}
+          </DialogTitle>
         </DialogHeader>
 
         {step === 1 && (
           <div className="space-y-4">
-            <div>
-              <Label>Vendor</Label>
-              <Select value={vendorId} onValueChange={(v) => { setVendorId(v); setSelected({}); }}>
-                <SelectTrigger><SelectValue placeholder="Select vendor…" /></SelectTrigger>
-                <SelectContent>
-                  {vendors.map(v => (
-                    <SelectItem key={v.id} value={v.id}>{v.name}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+            {/* Tab switcher */}
+            <div className="inline-flex rounded-md border border-input overflow-hidden">
+              {(['contracts', 'purchases', 'adhoc'] as Step1Tab[]).map(t => (
+                <button
+                  key={t}
+                  type="button"
+                  onClick={() => setTab(t)}
+                  className={cn(
+                    'px-4 py-1.5 text-sm font-medium transition-colors',
+                    tab === t ? 'bg-primary text-primary-foreground' : 'bg-background hover:bg-muted',
+                  )}
+                >
+                  {t === 'contracts' ? 'Forward Contracts' : t === 'purchases' ? 'Spot Purchases' : 'Ad-hoc'}
+                </button>
+              ))}
             </div>
 
-            {vendorId && (
-              <div>
-                <Label className="mb-2 block">Active Forward Contracts</Label>
+            {/* ── Forward Contracts tab ── */}
+            {tab === 'contracts' && (
+              <div className="space-y-3">
+                <div className="flex gap-2 flex-wrap">
+                  <Select value={contractVendorFilter} onValueChange={setContractVendorFilter}>
+                    <SelectTrigger className="h-9 w-48">
+                      <SelectValue placeholder="All vendors" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="">All vendors</SelectItem>
+                      {vendors.map(v => <SelectItem key={v.id} value={v.id}>{v.name}</SelectItem>)}
+                    </SelectContent>
+                  </Select>
+                  <Input
+                    value={contractSearch}
+                    onChange={e => setContractSearch(e.target.value)}
+                    placeholder="Search contracts…"
+                    className="h-9 flex-1 min-w-40"
+                  />
+                </div>
                 {loadingContracts ? (
                   <p className="text-sm text-muted-foreground">Loading…</p>
-                ) : contracts.length === 0 ? (
-                  <p className="text-sm text-muted-foreground">No active contracts for this vendor.</p>
+                ) : filteredContracts.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">No active contracts match.</p>
                 ) : (
                   <div className="border rounded-md overflow-hidden">
                     <Table>
                       <TableHeader>
                         <TableRow>
                           <TableHead className="w-10"></TableHead>
+                          <TableHead>Vendor</TableHead>
                           <TableHead>Contract</TableHead>
-                          <TableHead>Vendor Contract #</TableHead>
                           <TableHead>Lot ID</TableHead>
-                          <TableHead>Name / Description</TableHead>
-                          <TableHead>Origin / Description</TableHead>
-                          <TableHead className="text-right">Bags Remaining</TableHead>
+                          <TableHead>Description</TableHead>
+                          <TableHead className="text-right">Remaining</TableHead>
                           <TableHead className="text-right">Bag Size</TableHead>
                           <TableHead className="text-right">Price</TableHead>
-                          <TableHead className="text-right w-32">Bags Requested</TableHead>
+                          <TableHead className="text-right w-32">Bags</TableHead>
                         </TableRow>
                       </TableHeader>
                       <TableBody>
-                        {contracts.map(c => {
-                          const sel = selected[c.id];
+                        {filteredContracts.map(c => {
+                          const key = `contract:${c.id}`;
+                          const sel = selected[key];
                           const remaining = bagsRemaining(c);
-                          const orig = deriveOriginalPrice(c);
+                          const orig = defaultPriceFromContract(c);
+                          const vendorName = c.vendor_id ? (vendorMap[c.vendor_id]?.name || '—') : '—';
                           return (
                             <TableRow key={c.id}>
                               <TableCell>
                                 <Checkbox
                                   checked={!!sel}
-                                  onCheckedChange={(chk) => toggleContract(c, !!chk)}
+                                  onCheckedChange={chk => toggleContract(c, !!chk)}
                                   disabled={remaining <= 0 && !sel}
                                 />
                               </TableCell>
-                              <TableCell className="font-medium">{contractRef(c)}</TableCell>
-                              <TableCell className="text-sm">{c.vendor_contract_number || '—'}</TableCell>
+                              <TableCell className="text-sm">{vendorName}</TableCell>
+                              <TableCell className="font-medium text-sm">{contractRef(c)}</TableCell>
                               <TableCell className="text-sm">{c.lot_identifier || '—'}</TableCell>
-                              <TableCell className="text-sm">{c.name || '—'}</TableCell>
                               <TableCell className="text-sm">{contractDescription(c) || '—'}</TableCell>
-                              <TableCell className="text-right">{remaining} / {c.num_bags || 0}</TableCell>
-                              <TableCell className="text-right">{c.bag_size_kg ? `${c.bag_size_kg} kg` : '—'}</TableCell>
-                              <TableCell className="text-right text-xs">
-                                {orig.amount ? `${orig.amount} ${orig.unit}` : '—'}
-                              </TableCell>
+                              <TableCell className="text-right text-sm">{remaining} / {c.num_bags || 0}</TableCell>
+                              <TableCell className="text-right text-sm">{c.bag_size_kg ? `${c.bag_size_kg} kg` : '—'}</TableCell>
+                              <TableCell className="text-right text-xs">{orig.amount ? `${orig.amount} ${orig.unit}` : '—'}</TableCell>
                               <TableCell className="text-right">
                                 {sel ? (
                                   <Input
@@ -497,7 +772,7 @@ ${userName}`;
                                     min={1}
                                     max={remaining}
                                     value={sel.bags_requested}
-                                    onChange={(e) => updateLine(c.id, { bags_requested: parseInt(e.target.value) || 0 })}
+                                    onChange={e => updateLine(key, { bags_requested: parseInt(e.target.value) || 0 })}
                                     className={cn('h-8 text-right', sel.bags_requested > remaining && 'border-destructive')}
                                   />
                                 ) : <span className="text-muted-foreground">—</span>}
@@ -512,28 +787,225 @@ ${userName}`;
               </div>
             )}
 
+            {/* ── Spot Purchases tab ── */}
+            {tab === 'purchases' && (
+              <div className="space-y-3">
+                <div className="flex items-center gap-3 flex-wrap">
+                  <Input
+                    value={purchaseSearch}
+                    onChange={e => setPurchaseSearch(e.target.value)}
+                    placeholder="Search purchase lines…"
+                    className="h-9 flex-1 min-w-40"
+                  />
+                  <label className="flex items-center gap-2 text-sm cursor-pointer">
+                    <Checkbox
+                      checked={showAllPurchaseLines}
+                      onCheckedChange={v => setShowAllPurchaseLines(!!v)}
+                    />
+                    Show lines with existing lots
+                  </label>
+                </div>
+                {loadingPurchaseLines ? (
+                  <p className="text-sm text-muted-foreground">Loading…</p>
+                ) : filteredPurchaseLines.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">
+                    No purchase lines available.{!showAllPurchaseLines && ' Try enabling "Show lines with existing lots".'}
+                  </p>
+                ) : (
+                  <div className="border rounded-md overflow-hidden">
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead className="w-10"></TableHead>
+                          <TableHead>Vendor</TableHead>
+                          <TableHead>Invoice #</TableHead>
+                          <TableHead>Lot ID</TableHead>
+                          <TableHead>Description</TableHead>
+                          <TableHead className="text-right">Bags</TableHead>
+                          <TableHead className="text-right">Bag Size</TableHead>
+                          <TableHead className="text-right">Price</TableHead>
+                          <TableHead>Status</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {filteredPurchaseLines.map(pl => {
+                          const key = `purchase:${pl.id}`;
+                          const sel = selected[key];
+                          const vendorId = pl.purchase?.vendor_id || null;
+                          const vendorName = vendorId ? (vendorMap[vendorId]?.name || '—') : '—';
+                          const desc = [getCountryName(pl.origin_country), pl.region, pl.producer, pl.variety].filter(Boolean).join(' · ');
+                          return (
+                            <TableRow key={pl.id}>
+                              <TableCell>
+                                <Checkbox
+                                  checked={!!sel}
+                                  onCheckedChange={chk => togglePurchaseLine(pl, !!chk)}
+                                />
+                              </TableCell>
+                              <TableCell className="text-sm">{vendorName}</TableCell>
+                              <TableCell className="text-sm font-mono">{pl.purchase?.invoice_number || '—'}</TableCell>
+                              <TableCell className="text-sm">{pl.lot_identifier || '—'}</TableCell>
+                              <TableCell className="text-sm">{desc || '—'}</TableCell>
+                              <TableCell className="text-right text-sm">{pl.bags ?? '—'}</TableCell>
+                              <TableCell className="text-right text-sm">{pl.bag_size_kg ? `${pl.bag_size_kg} kg` : '—'}</TableCell>
+                              <TableCell className="text-right text-xs">{pl.price_per_lb_usd ? `${pl.price_per_lb_usd} USD/lb` : '—'}</TableCell>
+                              <TableCell>
+                                {pl.lot_id
+                                  ? <Badge variant="outline" className="text-xs bg-blue-500/10 text-blue-700 border-blue-500/30">Has lot</Badge>
+                                  : <Badge variant="outline" className="text-xs bg-amber-500/10 text-amber-700 border-amber-500/30">No lot</Badge>}
+                              </TableCell>
+                            </TableRow>
+                          );
+                        })}
+                      </TableBody>
+                    </Table>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* ── Ad-hoc tab ── */}
+            {tab === 'adhoc' && (
+              <div className="border rounded-md p-4 space-y-3">
+                <p className="text-sm font-semibold">Add ad-hoc line</p>
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <Label className="text-xs">Vendor (optional)</Label>
+                    <Select value={adhocVendorId} onValueChange={setAdhocVendorId}>
+                      <SelectTrigger className="h-9"><SelectValue placeholder="Select vendor…" /></SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="">No vendor</SelectItem>
+                        {vendors.map(v => <SelectItem key={v.id} value={v.id}>{v.name}</SelectItem>)}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div>
+                    <Label className="text-xs">Lot Identifier</Label>
+                    <Input value={adhocLotId} onChange={e => setAdhocLotId(e.target.value)} className="h-9" placeholder="e.g. LOT-001" />
+                  </div>
+                  <div>
+                    <Label className="text-xs">Origin Country (ISO-3)</Label>
+                    <Input value={adhocOrigin} onChange={e => setAdhocOrigin(e.target.value)} className="h-9" placeholder="e.g. COL" />
+                  </div>
+                  <div>
+                    <Label className="text-xs">Region</Label>
+                    <Input value={adhocRegion} onChange={e => setAdhocRegion(e.target.value)} className="h-9" />
+                  </div>
+                  <div>
+                    <Label className="text-xs">Producer</Label>
+                    <Input value={adhocProducer} onChange={e => setAdhocProducer(e.target.value)} className="h-9" />
+                  </div>
+                  <div>
+                    <Label className="text-xs">Variety</Label>
+                    <Input value={adhocVariety} onChange={e => setAdhocVariety(e.target.value)} className="h-9" />
+                  </div>
+                  <div>
+                    <Label className="text-xs">Bags <span className="text-destructive">*</span></Label>
+                    <Input type="number" min={1} value={adhocBags} onChange={e => setAdhocBags(e.target.value)} className="h-9" />
+                  </div>
+                  <div>
+                    <Label className="text-xs">Bag Size (kg) <span className="text-destructive">*</span></Label>
+                    <Input type="number" min={1} step="0.1" value={adhocBagSize} onChange={e => setAdhocBagSize(e.target.value)} className="h-9" />
+                  </div>
+                  <div>
+                    <Label className="text-xs">Price</Label>
+                    <Input type="number" step="0.0001" value={adhocPriceAmount} onChange={e => setAdhocPriceAmount(e.target.value)} className="h-9" />
+                  </div>
+                  <div>
+                    <Label className="text-xs">Unit</Label>
+                    <Select value={adhocPriceUnit} onValueChange={setAdhocPriceUnit}>
+                      <SelectTrigger className="h-9"><SelectValue /></SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="USD/lb">USD/lb</SelectItem>
+                        <SelectItem value="USD/kg">USD/kg</SelectItem>
+                        <SelectItem value="CAD/lb">CAD/lb</SelectItem>
+                        <SelectItem value="CAD/kg">CAD/kg</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="col-span-2">
+                    <Label className="text-xs">Notes</Label>
+                    <Input value={adhocNotes} onChange={e => setAdhocNotes(e.target.value)} className="h-9" />
+                  </div>
+                </div>
+                <Button size="sm" onClick={addAdhocLine} className="gap-1.5">
+                  <Plus className="h-4 w-4" /> Add Line
+                </Button>
+              </div>
+            )}
+
+            {/* ── Selected lines summary ── */}
+            {selectedList.length > 0 && (
+              <div className="border rounded-md overflow-hidden">
+                <div className="bg-muted/50 px-3 py-2 text-sm font-semibold">
+                  Selected Lines ({selectedList.length})
+                </div>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Source</TableHead>
+                      <TableHead>Vendor</TableHead>
+                      <TableHead>Description</TableHead>
+                      <TableHead className="text-right">Bags</TableHead>
+                      <TableHead className="text-right">Total kg</TableHead>
+                      <TableHead className="w-8"></TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {selectedList.map(l => {
+                      const desc = [getCountryName(l.origin_country), l.region, l.producer, l.variety].filter(Boolean).join(' · ');
+                      const ref = l.internal_contract_number || l.vendor_contract_number || l.lot_identifier || '—';
+                      return (
+                        <TableRow key={l.key}>
+                          <TableCell>
+                            <Badge variant="outline" className="text-xs">
+                              {l.source_type === 'CONTRACT' ? 'Contract' : l.source_type === 'PURCHASE' ? 'Purchase' : 'Ad-hoc'}
+                            </Badge>
+                          </TableCell>
+                          <TableCell className="text-sm">{l.vendor_name}</TableCell>
+                          <TableCell className="text-sm">
+                            <span className="font-medium">{ref}</span>
+                            {desc && <span className="text-muted-foreground ml-1">· {desc}</span>}
+                          </TableCell>
+                          <TableCell className="text-right text-sm">{l.bags_requested}</TableCell>
+                          <TableCell className="text-right text-sm">{(l.bags_requested * l.bag_size_kg).toLocaleString()} kg</TableCell>
+                          <TableCell>
+                            <button type="button" onClick={() => removeLine(l.key)} className="text-muted-foreground hover:text-destructive transition-colors">
+                              <X className="h-4 w-4" />
+                            </button>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+
             <DialogFooter>
               <Button variant="outline" onClick={() => onOpenChange(false)}>Cancel</Button>
-              <Button onClick={() => setStep(2)} disabled={!step1Valid()}>Advance to Details &amp; Pricing</Button>
+              <Button onClick={() => setStep(2)} disabled={!step1Valid()}>
+                Advance to Details &amp; Pricing
+              </Button>
             </DialogFooter>
           </div>
         )}
 
         {step === 2 && (
           <div className="space-y-5">
-            {/* Header section */}
+            {/* Header */}
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <Label>Invoice Number (optional — sets status to Invoiced)</Label>
-                <Input value={invoiceNumber} onChange={(e) => setInvoiceNumber(e.target.value)} placeholder="e.g. INV-12345" />
+                <Input value={invoiceNumber} onChange={e => setInvoiceNumber(e.target.value)} placeholder="e.g. INV-12345" />
               </div>
               <div>
                 <Label>Notes (optional)</Label>
-                <Input value={notes} onChange={(e) => setNotes(e.target.value)} placeholder="Internal notes…" />
+                <Input value={notes} onChange={e => setNotes(e.target.value)} placeholder="Internal notes…" />
               </div>
             </div>
 
-            {/* Before you save */}
+            {/* Arrival status */}
             <div className="border rounded-md p-3 bg-muted/30 space-y-3">
               <p className="text-sm font-semibold">Before you save</p>
               <div className="space-y-2">
@@ -542,18 +1014,12 @@ ${userName}`;
                   <button
                     type="button"
                     onClick={() => setMarkReceived(false)}
-                    className={cn(
-                      'px-3 py-1.5 text-xs font-medium transition-colors',
-                      !markReceived ? 'bg-primary text-primary-foreground' : 'bg-background hover:bg-muted',
-                    )}
+                    className={cn('px-3 py-1.5 text-xs font-medium transition-colors', !markReceived ? 'bg-primary text-primary-foreground' : 'bg-background hover:bg-muted')}
                   >En Route</button>
                   <button
                     type="button"
                     onClick={() => setMarkReceived(true)}
-                    className={cn(
-                      'px-3 py-1.5 text-xs font-medium transition-colors',
-                      markReceived ? 'bg-primary text-primary-foreground' : 'bg-background hover:bg-muted',
-                    )}
+                    className={cn('px-3 py-1.5 text-xs font-medium transition-colors', markReceived ? 'bg-primary text-primary-foreground' : 'bg-background hover:bg-muted')}
                   >Received</button>
                 </div>
               </div>
@@ -568,7 +1034,7 @@ ${userName}`;
                       </Button>
                     </PopoverTrigger>
                     <PopoverContent className="w-auto p-0" align="start">
-                      <Calendar mode="single" selected={receivedDate} onSelect={setReceivedDate} initialFocus className={cn('p-3 pointer-events-auto')} />
+                      <Calendar mode="single" selected={receivedDate} onSelect={setReceivedDate} initialFocus className="p-3 pointer-events-auto" />
                     </PopoverContent>
                   </Popover>
                 </div>
@@ -583,7 +1049,7 @@ ${userName}`;
                       </Button>
                     </PopoverTrigger>
                     <PopoverContent className="w-auto p-0" align="start">
-                      <Calendar mode="single" selected={etaDate} onSelect={setEtaDate} initialFocus className={cn('p-3 pointer-events-auto')} />
+                      <Calendar mode="single" selected={etaDate} onSelect={setEtaDate} initialFocus className="p-3 pointer-events-auto" />
                     </PopoverContent>
                   </Popover>
                 </div>
@@ -594,27 +1060,26 @@ ${userName}`;
             <div className="space-y-3">
               <p className="text-sm font-semibold">Coffee Lines</p>
               {selectedList.map(l => {
-                const totalKg = l.bags_requested * Number(l.contract.bag_size_kg || 0);
+                const totalKg = l.bags_requested * l.bag_size_kg;
+                const desc = [getCountryName(l.origin_country), l.region, l.producer, l.variety].filter(Boolean).join(' · ');
+                const ref = l.internal_contract_number || l.vendor_contract_number || l.lot_identifier || '—';
                 return (
-                  <Card key={l.contract_id}>
+                  <Card key={l.key}>
                     <CardContent className="p-3 space-y-2">
                       <div className="flex items-start justify-between gap-3">
                         <div className="space-y-0.5 min-w-0">
                           <div className="flex flex-wrap items-baseline gap-x-3 gap-y-0.5">
-                            <p className="font-medium text-sm">{contractRef(l.contract)}</p>
-                            {l.contract.lot_identifier && (
-                              <p className="text-xs text-muted-foreground"><span className="font-medium">Lot:</span> {l.contract.lot_identifier}</p>
-                            )}
-                            {l.contract.vendor_contract_number && (
-                              <p className="text-xs text-muted-foreground"><span className="font-medium">Vendor #:</span> {l.contract.vendor_contract_number}</p>
-                            )}
-                            {l.contract.name && (
-                              <p className="text-xs text-muted-foreground"><span className="font-medium">Name:</span> {l.contract.name}</p>
-                            )}
+                            <p className="font-medium text-sm">{ref}</p>
+                            <Badge variant="outline" className="text-xs">
+                              {l.source_type === 'CONTRACT' ? 'Contract' : l.source_type === 'PURCHASE' ? 'Purchase' : 'Ad-hoc'}
+                            </Badge>
+                            <p className="text-xs text-muted-foreground">{l.vendor_name}</p>
                           </div>
-                          <p className="text-xs text-muted-foreground">{contractDescription(l.contract) || '—'}</p>
+                          {desc && <p className="text-xs text-muted-foreground">{desc}</p>}
                         </div>
-                        <p className="text-xs text-muted-foreground whitespace-nowrap">{l.bags_requested} bags × {l.contract.bag_size_kg} kg = <span className="font-medium text-foreground">{totalKg.toLocaleString()} kg</span></p>
+                        <p className="text-xs text-muted-foreground whitespace-nowrap">
+                          {l.bags_requested} bags × {l.bag_size_kg} kg = <span className="font-medium text-foreground">{totalKg.toLocaleString()} kg</span>
+                        </p>
                       </div>
                       <div className="grid grid-cols-3 gap-2 items-end">
                         <div>
@@ -623,13 +1088,13 @@ ${userName}`;
                             type="number"
                             step="0.0001"
                             value={l.price_amount}
-                            onChange={(e) => updateLine(l.contract_id, { price_amount: e.target.value })}
+                            onChange={e => updateLine(l.key, { price_amount: e.target.value })}
                             className="h-9"
                           />
                         </div>
                         <div>
                           <Label className="text-xs">Unit</Label>
-                          <Select value={l.price_unit} onValueChange={(v) => updateLine(l.contract_id, { price_unit: v })}>
+                          <Select value={l.price_unit} onValueChange={v => updateLine(l.key, { price_unit: v })}>
                             <SelectTrigger className="h-9"><SelectValue /></SelectTrigger>
                             <SelectContent>
                               <SelectItem value="USD/lb">USD/lb</SelectItem>
@@ -639,9 +1104,9 @@ ${userName}`;
                             </SelectContent>
                           </Select>
                         </div>
-                        <div className="col-span-1">
+                        <div>
                           <Label className="text-xs">Line Notes</Label>
-                          <Input value={l.line_notes} onChange={(e) => updateLine(l.contract_id, { line_notes: e.target.value })} className="h-9" />
+                          <Input value={l.line_notes} onChange={e => updateLine(l.key, { line_notes: e.target.value })} className="h-9" />
                         </div>
                       </div>
                     </CardContent>
@@ -653,6 +1118,7 @@ ${userName}`;
             {/* Shared costs */}
             <div className="border rounded-md p-3 space-y-2">
               <p className="text-sm font-semibold">Shared Costs</p>
+              <p className="text-xs text-muted-foreground">Prorated across all lines by weight.</p>
               <div className="grid grid-cols-2 gap-3">
                 {SHARED_COST_KEYS.map(key => (
                   <div key={key}>
@@ -662,7 +1128,7 @@ ${userName}`;
                         type="number"
                         step="0.01"
                         value={sharedCosts[key]?.amount ?? 0}
-                        onChange={(e) => setSharedCosts(prev => ({
+                        onChange={e => setSharedCosts(prev => ({
                           ...prev,
                           [key]: { amount: parseFloat(e.target.value) || 0, currency: prev[key]?.currency || 'USD' },
                         }))}
@@ -670,7 +1136,7 @@ ${userName}`;
                       />
                       <Select
                         value={sharedCosts[key]?.currency || 'USD'}
-                        onValueChange={(v) => setSharedCosts(prev => ({
+                        onValueChange={v => setSharedCosts(prev => ({
                           ...prev,
                           [key]: { amount: prev[key]?.amount || 0, currency: v as Currency },
                         }))}
@@ -687,7 +1153,7 @@ ${userName}`;
               </div>
             </div>
 
-            {/* Live book value table */}
+            {/* Live book value */}
             {selectedList.length > 0 && (
               <div className="border rounded-md overflow-hidden">
                 <div className="bg-muted/50 px-3 py-2 text-sm font-semibold">Estimated Book Value (live)</div>
@@ -695,6 +1161,7 @@ ${userName}`;
                   <TableHeader>
                     <TableRow>
                       <TableHead>Coffee</TableHead>
+                      <TableHead>Vendor</TableHead>
                       <TableHead className="text-right">Bags</TableHead>
                       <TableHead className="text-right">Total kg</TableHead>
                       <TableHead className="text-right">Coffee $/lb</TableHead>
@@ -706,13 +1173,15 @@ ${userName}`;
                   <TableBody>
                     {selectedList.map(l => {
                       const priceUsdPerLb = toUsdPerLb(parseFloat(l.price_amount) || 0, l.price_unit);
-                      const lineKg = l.bags_requested * Number(l.contract.bag_size_kg || 0);
+                      const lineKg = l.bags_requested * l.bag_size_kg;
                       const sharedShare = totalKgAll > 0 ? totalSharedUsd / totalKgAll : 0;
                       const bookKg = bookValuePerKgUsd(priceUsdPerLb, sharedShare);
                       const bookLb = bookValuePerLbUsd(priceUsdPerLb, sharedShare);
+                      const ref = l.internal_contract_number || l.vendor_contract_number || l.lot_identifier || '—';
                       return (
-                        <TableRow key={l.contract_id}>
-                          <TableCell className="text-sm">{contractRef(l.contract)}</TableCell>
+                        <TableRow key={l.key}>
+                          <TableCell className="text-sm">{ref}</TableCell>
+                          <TableCell className="text-sm text-muted-foreground">{l.vendor_name}</TableCell>
                           <TableCell className="text-right">{l.bags_requested}</TableCell>
                           <TableCell className="text-right">{lineKg.toLocaleString()} kg</TableCell>
                           <TableCell className="text-right">{formatPerLb(priceUsdPerLb, 'USD')}</TableCell>
@@ -730,23 +1199,20 @@ ${userName}`;
             {/* Email draft */}
             <div className="border rounded-md p-3 space-y-2">
               <div className="flex items-center justify-between">
-                <p className="text-sm font-semibold">Email Draft to Vendor</p>
+                <p className="text-sm font-semibold">Email Draft to Vendor(s)</p>
                 <Button size="sm" variant="outline" onClick={copyEmail} className="gap-1.5">
                   {emailCopied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
                   {emailCopied ? 'Copied' : 'Copy'}
                 </Button>
               </div>
-              <Textarea readOnly value={emailBody} rows={8} className="font-mono text-xs" />
+              <Textarea readOnly value={emailBody} rows={10} className="font-mono text-xs" />
             </div>
 
             <DialogFooter>
               <Button variant="outline" onClick={() => setStep(1)}>Back</Button>
               <Button
-                onClick={() => {
-                  if (step !== 2) return;
-                  saveMutation.mutate();
-                }}
-                disabled={step !== 2 || saving || saveMutation.isPending}
+                onClick={() => { if (step !== 2) return; saveMutation.mutate(); }}
+                disabled={step !== 2 || saveMutation.isPending}
               >
                 {saveMutation.isPending ? 'Saving…' : 'Save Release'}
               </Button>

--- a/src/components/sourcing/releases/releaseUtils.ts
+++ b/src/components/sourcing/releases/releaseUtils.ts
@@ -87,6 +87,41 @@ export function bookValuePerLbUsd(
   return bookValuePerKgUsd(pricePerLbUsd, sharedShareUsdPerKg) / KG_PER_LB;
 }
 
+// ─── Multi-source line types ───────────────────────────────────────────────
+
+export type SelectedLineSource = 'CONTRACT' | 'PURCHASE' | 'ADHOC';
+
+export interface SelectedLine {
+  // key — unique within the modal's selected map
+  key: string;
+  source_type: SelectedLineSource;
+  // vendor resolution
+  vendor_id: string | null;
+  vendor_name: string;
+  vendor_abbr: string | null;
+  // contract source (source_type === 'CONTRACT')
+  contract_id: string | null;
+  contract_name: string | null;
+  internal_contract_number: string | null;
+  vendor_contract_number: string | null;
+  // purchase source (source_type === 'PURCHASE')
+  purchase_line_id: string | null;
+  purchase_id: string | null;
+  existing_lot_id: string | null; // non-null if the purchase line already has a lot
+  // origin / display (populated for all source types)
+  lot_identifier: string | null;
+  origin_country: string | null;
+  region: string | null;
+  producer: string | null;
+  variety: string | null;
+  bag_size_kg: number;
+  // user-editable
+  bags_requested: number;
+  price_amount: string;
+  price_unit: string;
+  line_notes: string;
+}
+
 export function statusBadgeClass(status: string): string {
   if (status === 'INVOICED') return 'bg-emerald-500/15 text-emerald-700 border-emerald-500/30';
   return 'bg-amber-500/15 text-amber-700 border-amber-500/30';

--- a/src/lib/lotNumberGenerator.ts
+++ b/src/lib/lotNumberGenerator.ts
@@ -96,13 +96,21 @@ export async function allocateLotNumbers(
   });
 }
 
-/** Allocate a single lot number under an existing PO. */
+/**
+ * Allocate a single lot number under an existing PO.
+ * Pass `vendorAbbrOverride` to use a different vendor prefix than the PO's own vendor
+ * (needed for multi-vendor releases where each line has its own vendor).
+ */
 export async function allocateSingleLotNumber(
   po: AllocatedPo,
   originCode: string | null | undefined,
+  vendorAbbrOverride?: string | null,
 ): Promise<string> {
-  const [lot] = await allocateLotNumbers(po, [originCode]);
-  return lot.lotNumber;
+  const iso3 = normalizeOrigin(originCode);
+  const vendorAbbr = normalizeVendor(vendorAbbrOverride ?? po.vendorAbbr);
+  const start = await allocateSequence('lot_sequence', 1);
+  const lotSeq = pad(start, 4);
+  return `${vendorAbbr}-P${po.poDigits}-${iso3}-L${lotSeq}`;
 }
 
 /**

--- a/src/pages/internal/ReleaseDetail.tsx
+++ b/src/pages/internal/ReleaseDetail.tsx
@@ -58,6 +58,13 @@ interface LineRow {
   price_per_lb_usd: number | null;
   original_price: any;
   notes: string | null;
+  source_type: string | null;
+  vendor_id: string | null;
+  lot_identifier: string | null;
+  origin_country: string | null;
+  region: string | null;
+  producer: string | null;
+  variety: string | null;
 }
 
 interface LotRow {
@@ -116,6 +123,23 @@ export default function ReleaseDetail() {
     },
     enabled: !!id,
   });
+
+  const lineVendorIds = useMemo(() => [...new Set(lines.map(l => l.vendor_id).filter(Boolean) as string[])], [lines]);
+  const { data: lineVendors = [] } = useQuery({
+    queryKey: ['green-vendors-by-ids', lineVendorIds],
+    queryFn: async () => {
+      if (lineVendorIds.length === 0) return [] as { id: string; name: string }[];
+      const { data, error } = await supabase.from('green_vendors').select('id, name').in('id', lineVendorIds);
+      if (error) throw error;
+      return data as { id: string; name: string }[];
+    },
+    enabled: lineVendorIds.length > 0,
+  });
+  const lineVendorMap = useMemo(() => {
+    const m: Record<string, string> = {};
+    lineVendors.forEach(v => { m[v.id] = v.name; });
+    return m;
+  }, [lineVendors]);
 
   const lotIds = lines.map(l => l.lot_id).filter(Boolean) as string[];
   const { data: lots = [] } = useQuery({
@@ -389,7 +413,11 @@ export default function ReleaseDetail() {
       <Card>
         <CardContent className="p-5 space-y-4">
           <div className="flex items-center gap-3 flex-wrap">
-            <h1 className="text-2xl font-bold">{vendor?.name || 'Release'}</h1>
+            <h1 className="text-2xl font-bold">
+              {release.vendor_id
+                ? (vendor?.name || 'Release')
+                : (lineVendorIds.length > 1 ? 'Multiple vendors' : (lineVendorIds.length === 1 ? (lineVendorMap[lineVendorIds[0]] || 'Release') : 'Release'))}
+            </h1>
             {release.po_number && (
               <Badge variant="outline" className="font-mono text-sm">{release.po_number}</Badge>
             )}
@@ -506,7 +534,9 @@ export default function ReleaseDetail() {
               <TableHeader>
                 <TableRow>
                   <TableHead>Lot #</TableHead>
+                  <TableHead>Vendor</TableHead>
                   <TableHead>Origin</TableHead>
+                  <TableHead>Source</TableHead>
                   <TableHead className="text-right">Bags</TableHead>
                   <TableHead className="text-right">Total kg</TableHead>
                   <TableHead className="text-right">Coffee $/lb</TableHead>
@@ -524,10 +554,18 @@ export default function ReleaseDetail() {
                   const lineKg = (l.bags_requested || 0) * Number(l.bag_size_kg || 0);
                   const bookKg = bookValuePerKgUsd(l.price_per_lb_usd, sharedShareUsdPerKg);
                   const bookLb = bookValuePerLbUsd(l.price_per_lb_usd, sharedShareUsdPerKg);
+                  // Origin: use line-level field first (PURCHASE/ADHOC), fall back to contract
+                  const originDisplay = l.origin_country || contract?.origin_country || contract?.origin || '—';
+                  const vendorName = l.vendor_id ? (lineVendorMap[l.vendor_id] || '—') : (vendor?.name || '—');
+                  const sourceLabel = l.source_type === 'PURCHASE' ? 'Purchase' : l.source_type === 'ADHOC' ? 'Ad-hoc' : 'Contract';
                   return (
                     <TableRow key={l.id}>
                       <TableCell className="font-mono text-xs">{lot?.lot_number || '—'}</TableCell>
-                      <TableCell className="text-sm">{contract?.origin_country || contract?.origin || '—'}</TableCell>
+                      <TableCell className="text-sm">{vendorName}</TableCell>
+                      <TableCell className="text-sm">{originDisplay}</TableCell>
+                      <TableCell>
+                        <Badge variant="outline" className="text-xs">{sourceLabel}</Badge>
+                      </TableCell>
                       <TableCell className="text-right">{l.bags_requested}</TableCell>
                       <TableCell className="text-right">{lineKg.toLocaleString()} kg</TableCell>
                       <TableCell className="text-right">{l.price_per_lb_usd != null ? formatPerLb(Number(l.price_per_lb_usd), 'USD') : '—'}</TableCell>
@@ -548,8 +586,7 @@ export default function ReleaseDetail() {
               </TableBody>
               <tfoot className="bg-muted/30 border-t font-medium text-sm">
                 <tr>
-                  <td className="p-2"></td>
-                  <td className="p-2 text-right">Total</td>
+                  <td className="p-2" colSpan={4}></td>
                   <td className="p-2 text-right">{totalBags}</td>
                   <td className="p-2 text-right">{totalKg.toLocaleString()} kg</td>
                   <td className="p-2"></td>

--- a/src/pages/internal/SourcingReleases.tsx
+++ b/src/pages/internal/SourcingReleases.tsx
@@ -36,6 +36,7 @@ interface ReleaseLineRow {
   bags_requested: number;
   bag_size_kg: number;
   lot_id: string | null;
+  vendor_id: string | null;
 }
 
 type Filter = 'ALL' | 'PENDING' | 'INVOICED';
@@ -64,7 +65,7 @@ export default function SourcingReleases() {
     queryFn: async () => {
       const { data, error } = await supabase
         .from('green_release_lines')
-        .select('id, release_id, bags_requested, bag_size_kg, lot_id');
+        .select('id, release_id, bags_requested, bag_size_kg, lot_id, vendor_id');
       if (error) throw error;
       return data as ReleaseLineRow[];
     },
@@ -102,19 +103,38 @@ export default function SourcingReleases() {
       if (filter !== 'ALL' && r.status !== filter) return false;
       if (search) {
         const q = search.toLowerCase();
-        const vname = (r.vendor_id ? vendorMap[r.vendor_id] : '') || '';
-        const inv = r.invoice_number || '';
-        if (!vname.toLowerCase().includes(q) && !inv.toLowerCase().includes(q)) return false;
+        const inv = (r.invoice_number || '').toLowerCase();
+        const po = (r.po_number || '').toLowerCase();
+        // Match against all vendor names on the release lines
+        const lineVendorIds = (linesByRelease[r.id] || []).map(l => l.vendor_id).filter(Boolean) as string[];
+        const releaseVendorIds = r.vendor_id ? [r.vendor_id, ...lineVendorIds] : lineVendorIds;
+        const vendorNames = [...new Set(releaseVendorIds)].map(id => (vendorMap[id] || '').toLowerCase());
+        const vendorMatch = vendorNames.some(n => n.includes(q));
+        if (!vendorMatch && !inv.includes(q) && !po.includes(q)) return false;
       }
       return true;
     });
-  }, [releases, filter, search, vendorMap]);
+  }, [releases, filter, search, vendorMap, linesByRelease]);
 
   function summary(r: ReleaseRow) {
     const ls = linesByRelease[r.id] || [];
     const lots = ls.length;
     const totalKg = ls.reduce((s, l) => s + (l.bags_requested || 0) * Number(l.bag_size_kg || 0), 0);
-    return { lots, totalKg };
+    // Determine vendor label: use release.vendor_id if set (single vendor), else check line vendor_ids
+    let vendorLabel: string;
+    if (r.vendor_id) {
+      vendorLabel = vendorMap[r.vendor_id] || '—';
+    } else {
+      const distinctVendors = [...new Set(ls.map(l => l.vendor_id).filter(Boolean))];
+      if (distinctVendors.length === 1) {
+        vendorLabel = vendorMap[distinctVendors[0]!] || '—';
+      } else if (distinctVendors.length > 1) {
+        vendorLabel = 'Multiple vendors';
+      } else {
+        vendorLabel = '—';
+      }
+    }
+    return { lots, totalKg, vendorLabel };
   }
 
   return (
@@ -179,7 +199,7 @@ export default function SourcingReleases() {
               </TableHeader>
               <TableBody>
                 {filtered.map(r => {
-                  const { lots, totalKg } = summary(r);
+                  const { lots, totalKg, vendorLabel } = summary(r);
                   const dateLabel = r.received_date
                     ? `Received ${format(parseISO(r.received_date), 'MMM d, yyyy')}`
                     : r.eta_date
@@ -188,7 +208,7 @@ export default function SourcingReleases() {
                   return (
                     <TableRow key={r.id}>
                       <TableCell className="font-mono text-xs">{r.po_number || <span className="text-muted-foreground">—</span>}</TableCell>
-                      <TableCell className="font-medium">{(r.vendor_id && vendorMap[r.vendor_id]) || '—'}</TableCell>
+                      <TableCell className="font-medium">{vendorLabel}</TableCell>
                       <TableCell>
                         <Badge variant="outline" className={statusBadgeClass(r.status)}>{r.status}</Badge>
                       </TableCell>
@@ -209,7 +229,7 @@ export default function SourcingReleases() {
         ) : (
           <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
             {filtered.map(r => {
-              const { lots, totalKg } = summary(r);
+              const { lots, totalKg, vendorLabel } = summary(r);
               const dateLabel = r.received_date
                 ? `Received ${format(parseISO(r.received_date), 'MMM d, yyyy')}`
                 : r.eta_date
@@ -219,7 +239,7 @@ export default function SourcingReleases() {
                 <Card key={r.id} className="cursor-pointer hover:bg-muted/30 transition-colors" onClick={() => navigate(`/sourcing/releases/${r.id}`)}>
                   <CardContent className="p-4 space-y-2">
                     <div className="flex items-start justify-between gap-2">
-                      <p className="font-semibold text-base leading-tight">{(r.vendor_id && vendorMap[r.vendor_id]) || '—'}</p>
+                      <p className="font-semibold text-base leading-tight">{vendorLabel}</p>
                       <Badge variant="outline" className={statusBadgeClass(r.status)}>{r.status}</Badge>
                     </div>
                     {r.po_number && <p className="text-xs font-mono text-foreground">{r.po_number}</p>}

--- a/supabase/migrations/20260508120000_358ba5a6-6ce4-43e1-96d2-be6116bfaa12.sql
+++ b/supabase/migrations/20260508120000_358ba5a6-6ce4-43e1-96d2-be6116bfaa12.sql
@@ -1,0 +1,33 @@
+-- Multi-vendor / multi-source releases
+-- Allow release lines to originate from forward contracts, existing spot purchase lines,
+-- or ad-hoc entries. Denormalize vendor + origin fields onto the line so the release
+-- detail view doesn't need to join multiple tables per source type.
+
+ALTER TABLE public.green_release_lines
+  ADD COLUMN source_type TEXT NOT NULL DEFAULT 'CONTRACT'
+    CONSTRAINT green_release_lines_source_type_check
+      CHECK (source_type IN ('CONTRACT', 'PURCHASE', 'ADHOC')),
+  ADD COLUMN purchase_line_id UUID
+    REFERENCES public.green_purchase_lines(id) ON DELETE SET NULL,
+  ADD COLUMN vendor_id UUID
+    REFERENCES public.green_vendors(id) ON DELETE SET NULL,
+  ADD COLUMN lot_identifier TEXT,
+  ADD COLUMN origin_country TEXT,
+  ADD COLUMN region TEXT,
+  ADD COLUMN producer TEXT,
+  ADD COLUMN variety TEXT;
+
+CREATE INDEX idx_green_release_lines_purchase_line
+  ON public.green_release_lines(purchase_line_id)
+  WHERE purchase_line_id IS NOT NULL;
+
+CREATE INDEX idx_green_release_lines_vendor
+  ON public.green_release_lines(vendor_id)
+  WHERE vendor_id IS NOT NULL;
+
+COMMENT ON COLUMN public.green_release_lines.source_type IS
+  'CONTRACT = forward contract line; PURCHASE = existing green_purchase_line; ADHOC = manually entered';
+COMMENT ON COLUMN public.green_release_lines.purchase_line_id IS
+  'Set when source_type = PURCHASE; FK to the originating purchase line';
+COMMENT ON COLUMN public.green_release_lines.vendor_id IS
+  'Denormalized vendor for this line — derived from contract, purchase, or ad-hoc entry';


### PR DESCRIPTION
## Summary

- Releases can now mix lines from multiple vendors and from three sources: forward contracts, existing spot purchase lines, or ad-hoc entries.
- Shared costs (freight, carry, duties, fees, other) prorate across the full pallet weight regardless of source — matches how mixed-pallet shipments are actually invoiced.
- `release.vendor_id` resolves to a single vendor when all lines agree, otherwise `NULL`; UI shows "Multiple vendors" in that case.

## What changed

**Migration** — `supabase/migrations/20260508120000_358ba5a6...sql`
Adds to `green_release_lines`: `source_type` (CONTRACT/PURCHASE/ADHOC), `purchase_line_id`, `vendor_id`, plus denormalized origin fields (`lot_identifier`, `origin_country`, `region`, `producer`, `variety`). Two partial indexes on `purchase_line_id` and `vendor_id`.

**`CreateReleaseModal.tsx`** — major refactor
- Step 1: vendor gate removed. Picker is tabbed: **Forward Contracts** (all active across vendors), **Spot Purchases** (open `green_purchase_lines`), **Ad-hoc** (inline form for vendor + origin + bags + price).
- Selected lines accumulate in a panel below the tabs and can be removed.
- Step 2: each Coffee Line card shows vendor; email draft groups by vendor.

**Save logic**
- Release `vendor_id` = single vendor if all lines agree, else `NULL`.
- Per-line `vendor_abbr` flows through new optional `vendorAbbrOverride` param on `allocateSingleLotNumber` so each lot gets its own vendor prefix even under a shared PO.
- For `source_type = PURCHASE` lines that already have a `lot_id` on the purchase line, the existing lot is reused (UPDATE `release_id`) rather than re-created.
- Each `green_release_lines` insert populates the new columns.

**Display**
- `SourcingReleases.tsx`: list/card show "Multiple vendors" when the release spans more than one vendor; search matches across all vendors on the release.
- `ReleaseDetail.tsx`: per-line vendor + source-type badge; header shows "Multiple vendors" when applicable.

## Reviewer notes

- `green_releases.vendor_id` was already nullable, so no schema change there.
- Default `source_type = 'CONTRACT'` keeps existing rows valid without backfill.
- Lot numbers for ad-hoc/purchase lines without a known vendor abbreviation fall back to `???-P####-...` via the existing `VENDOR_FALLBACK` path in `lotNumberGenerator`.
- Regenerate `src/integrations/supabase/types.ts` after applying the migration.

## Test plan

- [ ] Apply migration locally, regenerate Supabase types.
- [ ] `npm run build` clean.
- [ ] Create release mixing two vendors' forward contracts → list shows "Multiple vendors", shared costs prorate by kg.
- [ ] Create release with one forward contract + one spot purchase line → existing lot's `release_id` updated, no duplicate lot.
- [ ] Create release with ad-hoc line only → lot created with vendor abbr from picker.
- [ ] Single-vendor release behaves as before (vendor name in list, single email draft).
- [ ] Open existing pre-migration release in detail view → no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)