### PR TITLE
Manufacturing client portal pages + order confirmation email scaffold

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,6 +56,7 @@ import AdminFeedback from "@/pages/internal/AdminFeedback";
 import Portal from "@/pages/client/Portal";
 import NewOrder from "@/pages/client/NewOrder";
 import OrderHistory from "@/pages/client/OrderHistory";
+import Products from "@/pages/client/Products";
 import Account from "@/pages/client/Account";
 import MemberSchedule from "@/pages/member/MemberSchedule";
 import MemberBilling from "@/pages/member/MemberBilling";
@@ -303,6 +304,11 @@ const App = () => (
             <Route path="/portal/orders" element={
               <ProtectedRoute allowedRoles={['CLIENT']}>
                 <ClientLayout><OrderHistory /></ClientLayout>
+              </ProtectedRoute>
+            } />
+            <Route path="/portal/products" element={
+              <ProtectedRoute allowedRoles={['CLIENT']}>
+                <ClientLayout><Products /></ClientLayout>
               </ProtectedRoute>
             } />
             <Route path="/portal/account" element={

--- a/src/components/internal/OrderEditModal.tsx
+++ b/src/components/internal/OrderEditModal.tsx
@@ -165,6 +165,19 @@ export function OrderEditModal({
       }
     },
     onSuccess: () => {
+      // Fire confirmation email when order transitions to CONFIRMED.
+      // Only triggers when the new status IS 'CONFIRMED' (covers any → CONFIRMED).
+      // TODO: Deploy supabase/functions/confirm-order-email before this goes live.
+      if (status === 'CONFIRMED') {
+        supabase.functions.invoke('confirm-order-email', {
+          body: { order_id: order.id },
+        }).then(({ error }) => {
+          if (error) console.warn('[confirm-order-email] Failed to invoke:', error);
+        }).catch((err) => {
+          console.warn('[confirm-order-email] Invocation error:', err);
+        });
+      }
+
       toast.success('Order updated successfully');
       queryClient.invalidateQueries({ queryKey: ['order', order.id] });
       queryClient.invalidateQueries({ queryKey: ['order-line-items', order.id] });

--- a/src/components/layout/ClientLayout.tsx
+++ b/src/components/layout/ClientLayout.tsx
@@ -10,7 +10,8 @@ import {
   User,
   LogOut,
   Menu,
-  X
+  X,
+  ShoppingBag
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import hiIcon from '@/assets/home-island-icon.png';
@@ -23,7 +24,8 @@ interface ClientLayoutProps {
 const navItems = [
   { to: '/portal', label: 'Home', icon: Home, end: true },
   { to: '/portal/new-order', label: 'New Order', icon: PlusCircle },
-  { to: '/portal/orders', label: 'Order History', icon: ClipboardList },
+  { to: '/portal/orders', label: 'My Orders', icon: ClipboardList },
+  { to: '/portal/products', label: 'My Products', icon: ShoppingBag },
   { to: '/portal/account', label: 'Account', icon: User },
 ];
 

--- a/src/pages/client/OrderHistory.tsx
+++ b/src/pages/client/OrderHistory.tsx
@@ -13,6 +13,7 @@ interface Order {
   order_number: string;
   status: string;
   requested_ship_date: string | null;
+  work_deadline_at: string | null;
   delivery_method: string;
   client_po: string | null;
   client_notes: string | null;
@@ -20,11 +21,9 @@ interface Order {
   location_id: string | null;
 }
 
-interface LineItem {
-  id: string;
+interface LineItemSummary {
+  order_id: string;
   quantity_units: number;
-  grind: string | null;
-  unit_price_locked: number;
   product: { product_name: string } | null;
 }
 
@@ -37,13 +36,40 @@ export default function OrderHistory() {
     queryFn: async () => {
       const { data, error } = await supabase
         .from('orders')
-        .select('id, order_number, status, requested_ship_date, delivery_method, client_po, client_notes, created_at, location_id')
+        .select('id, order_number, status, requested_ship_date, work_deadline_at, delivery_method, client_po, client_notes, created_at, location_id')
         .order('created_at', { ascending: false });
 
       if (error) throw error;
       return (data ?? []) as Order[];
     },
   });
+
+  // Fetch line item summaries for all orders in the list view
+  const { data: allLineItems } = useQuery({
+    queryKey: ['client-orders-line-items', orders?.map(o => o.id)],
+    queryFn: async () => {
+      const orderIds = (orders ?? []).map(o => o.id);
+      if (orderIds.length === 0) return [] as LineItemSummary[];
+      const { data, error } = await supabase
+        .from('order_line_items')
+        .select('order_id, quantity_units, product:products(product_name)')
+        .in('order_id', orderIds);
+      if (error) throw error;
+      return (data ?? []) as LineItemSummary[];
+    },
+    enabled: (orders ?? []).length > 0,
+  });
+
+  // Build map: orderId → summary strings
+  const lineItemMap = React.useMemo(() => {
+    const map: Record<string, string[]> = {};
+    for (const li of allLineItems ?? []) {
+      if (!map[li.order_id]) map[li.order_id] = [];
+      const name = li.product?.product_name ?? 'Unknown';
+      map[li.order_id].push(`${name} — ${li.quantity_units} units`);
+    }
+    return map;
+  }, [allLineItems]);
 
   const { data: lineItems } = useQuery({
     queryKey: ['client-order-line-items', selectedOrderId],
@@ -55,30 +81,30 @@ export default function OrderHistory() {
         .order('created_at', { ascending: true });
 
       if (error) throw error;
-      return (data ?? []) as LineItem[];
+      return (data ?? []) as { id: string; quantity_units: number; grind: string | null; unit_price_locked: number; product: { product_name: string } | null }[];
     },
     enabled: !!selectedOrderId,
   });
 
   const cancelMutation = useMutation({
     mutationFn: async (orderId: string) => {
-      const { data, error, count } = await supabase
+      const { data, error } = await supabase
         .from('orders')
         .update({ status: 'CANCELLED' })
         .eq('id', orderId)
         .eq('status', 'SUBMITTED')
         .select();
-      
+
       if (error) {
         console.error('Cancel error:', error.code, error.message, error.details);
         throw new Error(`${error.code}: ${error.message}`);
       }
-      
+
       if (!data || data.length === 0) {
         console.error('Cancel returned 0 rows - permission or status mismatch');
         throw new Error('No rows updated — order may already be processed or you lack permission');
       }
-      
+
       return data;
     },
     onSuccess: () => {
@@ -116,6 +142,12 @@ export default function OrderHistory() {
               <div><strong>Status:</strong> {selectedOrder.status}</div>
               <div><strong>Delivery:</strong> {selectedOrder.delivery_method}</div>
               <div><strong>Client PO:</strong> {selectedOrder.client_po || '—'}</div>
+              <div>
+                <strong>Planned Roast Day:</strong>{' '}
+                {selectedOrder.work_deadline_at
+                  ? format(new Date(selectedOrder.work_deadline_at), 'MMM d, yyyy')
+                  : '—'}
+              </div>
               <div>
                 <strong>Requested Ship Date:</strong>{' '}
                 {selectedOrder.requested_ship_date
@@ -199,7 +231,7 @@ export default function OrderHistory() {
   return (
     <div className="page-container">
       <div className="page-header">
-        <h1 className="page-title">Order History</h1>
+        <h1 className="page-title">My Orders</h1>
       </div>
       <Card>
         <CardHeader><CardTitle>Your Orders</CardTitle></CardHeader>
@@ -208,38 +240,78 @@ export default function OrderHistory() {
             <p className="text-muted-foreground">Loading…</p>
           ) : error ? (
             <p className="text-destructive">Failed to load: {error instanceof Error ? error.message : String(error)}</p>
-          ) : orders.length === 0 ? (
+          ) : (orders ?? []).length === 0 ? (
             <p className="text-muted-foreground">No orders yet.</p>
           ) : (
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b text-left">
-                  <th className="pb-2">Order #</th>
-                  <th className="pb-2">Date</th>
-                  <th className="pb-2">Ship Date</th>
-                  <th className="pb-2">Status</th>
+                  <th className="pb-2 pr-4">Order #</th>
+                  <th className="pb-2 pr-4">Status</th>
+                  <th className="pb-2 pr-4">Planned Roast Day</th>
+                  <th className="pb-2 pr-4">Ship Date</th>
+                  <th className="pb-2">Items</th>
                   <th className="pb-2"></th>
                 </tr>
               </thead>
               <tbody>
-                {orders.map((o) => (
-                  <tr key={o.id} className="border-b last:border-0 cursor-pointer hover:bg-muted/50" onClick={() => setSelectedOrderId(o.id)}>
-                    <td className="py-2">
-                      <span className="font-medium">{o.order_number}</span>
-                      <LocationCodeDisplay locationId={o.location_id} />
-                    </td>
-                    <td className="py-2">{format(new Date(o.created_at), 'MMM d, yyyy')}</td>
-                    <td className="py-2">{o.requested_ship_date ? format(new Date(o.requested_ship_date), 'MMM d') : '—'}</td>
-                    <td className="py-2">
-                      <span className={`rounded px-2 py-0.5 text-xs ${o.status === 'SUBMITTED' ? 'bg-amber-100 text-amber-800' : o.status === 'CANCELLED' ? 'bg-red-100 text-red-800' : ''}`}>
-                        {o.status}
-                      </span>
-                    </td>
-                    <td className="py-2 text-right">
-                      <Button size="sm" variant="ghost">View</Button>
-                    </td>
-                  </tr>
-                ))}
+                {(orders ?? []).map((o) => {
+                  const summaries = lineItemMap[o.id] ?? [];
+                  const displaySummaries = summaries.slice(0, 2);
+                  const overflow = summaries.length - displaySummaries.length;
+                  return (
+                    <tr
+                      key={o.id}
+                      className="border-b last:border-0 cursor-pointer hover:bg-muted/50"
+                      onClick={() => setSelectedOrderId(o.id)}
+                    >
+                      <td className="py-3 pr-4">
+                        <span className="font-medium">{o.order_number}</span>
+                        <LocationCodeDisplay locationId={o.location_id} />
+                      </td>
+                      <td className="py-3 pr-4">
+                        <span className={`rounded px-2 py-0.5 text-xs font-medium ${
+                          o.status === 'SUBMITTED' ? 'bg-amber-100 text-amber-800'
+                          : o.status === 'CONFIRMED' ? 'bg-blue-100 text-blue-800'
+                          : o.status === 'IN_PRODUCTION' ? 'bg-orange-100 text-orange-800'
+                          : o.status === 'READY' ? 'bg-green-100 text-green-800'
+                          : o.status === 'SHIPPED' ? 'bg-green-100 text-green-800'
+                          : o.status === 'CANCELLED' ? 'bg-red-100 text-red-800'
+                          : 'bg-muted text-muted-foreground'
+                        }`}>
+                          {o.status}
+                        </span>
+                      </td>
+                      <td className="py-3 pr-4 text-muted-foreground">
+                        {o.work_deadline_at
+                          ? format(new Date(o.work_deadline_at), 'MMM d, yyyy')
+                          : '—'}
+                      </td>
+                      <td className="py-3 pr-4 text-muted-foreground">
+                        {o.requested_ship_date
+                          ? format(new Date(o.requested_ship_date), 'MMM d, yyyy')
+                          : '—'}
+                      </td>
+                      <td className="py-3">
+                        {displaySummaries.length === 0 ? (
+                          <span className="text-muted-foreground">—</span>
+                        ) : (
+                          <div className="space-y-0.5">
+                            {displaySummaries.map((s, i) => (
+                              <div key={i} className="text-xs text-muted-foreground">{s}</div>
+                            ))}
+                            {overflow > 0 && (
+                              <div className="text-xs text-muted-foreground">+{overflow} more</div>
+                            )}
+                          </div>
+                        )}
+                      </td>
+                      <td className="py-3 text-right">
+                        <Button size="sm" variant="ghost">View</Button>
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           )}

--- a/src/pages/client/Products.tsx
+++ b/src/pages/client/Products.tsx
@@ -1,0 +1,158 @@
+import React from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from '@/contexts/AuthContext';
+import { Package } from 'lucide-react';
+
+interface AllowedProduct {
+  product_id: string;
+  products: {
+    id: string;
+    product_name: string;
+    sku: string | null;
+    bag_size_g: number;
+    format: string | null;
+    packaging_variant: string | null;
+  } | null;
+}
+
+export default function Products() {
+  const { authUser } = useAuth();
+
+  // TODO: Wire this query once RLS is confirmed for client_allowed_products reads by account_id.
+  // Fetches all products this account is allowed to order.
+  // Query pattern:
+  //   supabase
+  //     .from('client_allowed_products')
+  //     .select('product_id, products(id, product_name, sku, bag_size_g, format, packaging_variant)')
+  //     .eq('account_id', authUser?.accountId)
+  const { data: allowedProducts, isLoading: productsLoading } = useQuery({
+    queryKey: ['client-allowed-products', authUser?.accountId],
+    queryFn: async () => {
+      // account_id column was added via migration after types were generated,
+      // so cast to any to avoid stale type error.
+      const { data, error } = await (supabase as any)
+        .from('client_allowed_products')
+        .select('product_id, products(id, product_name, sku, bag_size_g, format, packaging_variant)')
+        .eq('account_id', authUser!.accountId!);
+      if (error) throw error;
+      return (data ?? []) as AllowedProduct[];
+    },
+    enabled: !!authUser?.accountId,
+  });
+
+  // TODO: Wire price lookup. Fetches latest price per product from price_list.
+  // Query pattern:
+  //   supabase
+  //     .from('price_list')
+  //     .select('product_id, unit_price, effective_date')
+  //     .in('product_id', productIds)
+  //     .order('effective_date', { ascending: false })
+  // Then deduplicate: first occurrence per product_id = current price.
+  const productIds = (allowedProducts ?? [])
+    .map(ap => ap.product_id)
+    .filter(Boolean);
+
+  const { data: priceData } = useQuery({
+    queryKey: ['client-product-prices', productIds],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('price_list')
+        .select('product_id, unit_price, effective_date')
+        .in('product_id', productIds)
+        .order('effective_date', { ascending: false });
+      if (error) throw error;
+      // Deduplicate: first entry per product_id is most recent
+      const priceMap: Record<string, number> = {};
+      for (const row of data ?? []) {
+        if (!(row.product_id in priceMap)) {
+          priceMap[row.product_id] = row.unit_price;
+        }
+      }
+      return priceMap;
+    },
+    enabled: productIds.length > 0,
+  });
+
+  const formatBagSize = (grams: number) => {
+    if (grams >= 1000) return `${(grams / 1000).toFixed(grams % 1000 === 0 ? 0 : 1)} kg`;
+    return `${grams} g`;
+  };
+
+  const formatVariant = (variant: string | null) => {
+    if (!variant) return '—';
+    return variant.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+  };
+
+  const formatFormat = (fmt: string | null) => {
+    if (!fmt) return '—';
+    return fmt.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+  };
+
+  const products = (allowedProducts ?? [])
+    .map(ap => ap.products)
+    .filter((p): p is NonNullable<AllowedProduct['products']> => !!p);
+
+  return (
+    <div className="page-container">
+      <div className="page-header">
+        <h1 className="page-title">My Products</h1>
+        <p className="text-muted-foreground">Products available for your account to order</p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Package className="h-5 w-5" />
+            Product Catalogue
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {productsLoading ? (
+            <p className="text-muted-foreground">Loading products…</p>
+          ) : products.length === 0 ? (
+            <div className="py-8 text-center">
+              <Package className="mx-auto mb-4 h-12 w-12 text-muted-foreground/50" />
+              <p className="text-muted-foreground">No products linked to your account yet.</p>
+              <p className="mt-1 text-sm text-muted-foreground">Contact your Home Island rep to get products added.</p>
+            </div>
+          ) : (
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b text-left">
+                  <th className="pb-2 pr-4">Product</th>
+                  <th className="pb-2 pr-4">SKU</th>
+                  <th className="pb-2 pr-4">Bag Size</th>
+                  <th className="pb-2 pr-4">Format</th>
+                  <th className="pb-2 pr-4">Packaging</th>
+                  <th className="pb-2 text-right">Current Price</th>
+                </tr>
+              </thead>
+              <tbody>
+                {products.map((p) => {
+                  const price = priceData?.[p.id];
+                  return (
+                    <tr key={p.id} className="border-b last:border-0">
+                      <td className="py-3 pr-4 font-medium">{p.product_name}</td>
+                      <td className="py-3 pr-4 font-mono text-xs text-muted-foreground">{p.sku ?? '—'}</td>
+                      <td className="py-3 pr-4 text-muted-foreground">{formatBagSize(p.bag_size_g)}</td>
+                      <td className="py-3 pr-4 text-muted-foreground">{formatFormat(p.format)}</td>
+                      <td className="py-3 pr-4 text-muted-foreground">{formatVariant(p.packaging_variant)}</td>
+                      <td className="py-3 text-right">
+                        {price != null
+                          ? `$${price.toFixed(2)}`
+                          : <span className="text-muted-foreground">—</span>
+                        }
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/supabase/functions/confirm-order-email/index.ts
+++ b/supabase/functions/confirm-order-email/index.ts
@@ -1,0 +1,232 @@
+import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.91.0";
+
+// TODO: Deploy this function via `supabase functions deploy confirm-order-email`
+// before the email trigger in OrderEditModal.tsx goes live.
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type, x-supabase-client-platform, x-supabase-client-platform-version, x-supabase-client-runtime, x-supabase-client-runtime-version",
+};
+
+const FROM_ADDRESS = "noreply@homeislandcoffee.com";
+const FROM_DISPLAY = "Home Island Manufacturing <noreply@homeislandcoffee.com>";
+const CC_ADDRESS = "orders@homeislandcoffee.com";
+
+// TODO: Confirm that the enqueue_email RPC payload supports a `cc` field.
+// If the RPC / process-email-queue function does not forward `cc` to Resend,
+// either extend the RPC payload schema or send a second enqueue call to CC_ADDRESS.
+
+interface ConfirmRequest {
+  order_id: string;
+}
+
+function formatDate(dateStr: string | null): string {
+  if (!dateStr) return "TBD";
+  const d = new Date(dateStr);
+  return d.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" });
+}
+
+serve(async (req: Request) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+    const adminClient = createClient(supabaseUrl, serviceRoleKey);
+
+    // ========== AUTHENTICATION ==========
+    // Only ADMIN/OPS users can change order status to CONFIRMED, so we verify
+    // the caller is authenticated with an internal role.
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader) {
+      return new Response(
+        JSON.stringify({ ok: false, error: "Missing authorization header" }),
+        { status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
+    const token = authHeader.replace("Bearer ", "");
+    const { data: { user }, error: authError } = await adminClient.auth.getUser(token);
+    if (authError || !user) {
+      console.error("[confirm-order-email] Invalid token:", authError?.message);
+      return new Response(
+        JSON.stringify({ ok: false, error: "Invalid token" }),
+        { status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
+    const { data: roleData } = await adminClient
+      .from("user_roles")
+      .select("role")
+      .eq("user_id", user.id)
+      .single();
+
+    if (!roleData || !["ADMIN", "OPS"].includes(roleData.role)) {
+      return new Response(
+        JSON.stringify({ ok: false, error: "Forbidden — internal role required" }),
+        { status: 403, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
+    const { order_id }: ConfirmRequest = await req.json();
+    if (!order_id) {
+      return new Response(
+        JSON.stringify({ ok: false, error: "order_id is required" }),
+        { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
+    console.log(`[confirm-order-email] Processing order_id=${order_id}`);
+
+    // ========== FETCH ORDER ==========
+    const { data: order, error: orderError } = await adminClient
+      .from("orders")
+      .select("id, order_number, requested_ship_date, work_deadline_at, account_id, status")
+      .eq("id", order_id)
+      .maybeSingle();
+
+    if (orderError || !order) {
+      console.error("[confirm-order-email] Order not found:", orderError?.message);
+      return new Response(
+        JSON.stringify({ ok: false, error: "Order not found" }),
+        { status: 404, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
+    if (order.status !== "CONFIRMED") {
+      console.warn(`[confirm-order-email] Order ${order_id} status is ${order.status}, not CONFIRMED — skipping`);
+      return new Response(
+        JSON.stringify({ ok: false, error: "Order is not in CONFIRMED status" }),
+        { status: 422, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
+    // ========== FETCH ACCOUNT ==========
+    // TODO: Verify the accounts table has `billing_email` and `account_name` populated
+    // for this account before going live. If billing_email is null, the email will be skipped.
+    const { data: account, error: accountError } = await adminClient
+      .from("accounts")
+      .select("account_name, billing_email")
+      .eq("id", order.account_id)
+      .maybeSingle();
+
+    if (accountError || !account) {
+      console.error("[confirm-order-email] Account not found for order:", order_id);
+      return new Response(
+        JSON.stringify({ ok: false, error: "Account not found" }),
+        { status: 404, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
+    if (!account.billing_email) {
+      console.warn(`[confirm-order-email] Account ${order.account_id} has no billing_email — cannot send`);
+      return new Response(
+        JSON.stringify({ ok: false, error: "Account has no billing email" }),
+        { status: 422, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
+    // ========== FETCH LINE ITEMS ==========
+    const { data: lineItems, error: lineError } = await adminClient
+      .from("order_line_items")
+      .select("quantity_units, product:products(product_name)")
+      .eq("order_id", order_id)
+      .order("created_at", { ascending: true });
+
+    if (lineError) {
+      console.error("[confirm-order-email] Failed to fetch line items:", lineError.message);
+    }
+
+    // ========== BUILD EMAIL BODY ==========
+    const accountName = account.account_name;
+    const orderNumber = order.order_number;
+    const roastDay = formatDate(order.work_deadline_at);
+    const shipDate = formatDate(order.requested_ship_date);
+
+    const itemLines = (lineItems ?? [])
+      .map((li) => {
+        // deno-lint-ignore no-explicit-any
+        const productName = (li.product as any)?.product_name ?? "Unknown Product";
+        return `  * ${productName} — ${li.quantity_units} units`;
+      })
+      .join("\n");
+
+    const emailText = `Hi ${accountName},
+
+Your order has been confirmed. Here are the details:
+
+Order Number: ${orderNumber}
+Planned Roast Day: ${roastDay}
+Requested Ship Date: ${shipDate}
+
+Items:
+${itemLines || "  (No items)"}
+
+If you have any questions, reply to this email or contact us at orders@homeislandcoffee.com.
+
+Thank you,
+Home Island Manufacturing`;
+
+    const subject = `Order Confirmed — ${orderNumber} — ${accountName}`;
+
+    // ========== ENQUEUE EMAIL ==========
+    const messageId = crypto.randomUUID();
+
+    await adminClient.from("email_send_log").insert({
+      message_id: messageId,
+      template_name: "order_confirmation",
+      recipient_email: account.billing_email,
+      status: "pending",
+    });
+
+    const { error: enqueueError } = await adminClient.rpc("enqueue_email", {
+      queue_name: "transactional_emails",
+      payload: {
+        message_id: messageId,
+        to: account.billing_email,
+        // TODO: Verify enqueue_email RPC and process-email-queue forward `cc` to Resend.
+        // If not supported yet, remove this field and handle CC separately.
+        cc: CC_ADDRESS,
+        from: FROM_DISPLAY,
+        sender_domain: FROM_ADDRESS.split("@")[1],
+        subject,
+        text: emailText,
+        purpose: "transactional",
+        label: "order_confirmation",
+        queued_at: new Date().toISOString(),
+      },
+    });
+
+    if (enqueueError) {
+      console.error("[confirm-order-email] Failed to enqueue:", enqueueError.message);
+      await adminClient.from("email_send_log").insert({
+        message_id: messageId,
+        template_name: "order_confirmation",
+        recipient_email: account.billing_email,
+        status: "failed",
+        error_message: "Failed to enqueue",
+      });
+      return new Response(
+        JSON.stringify({ ok: false, error: "Failed to enqueue email" }),
+        { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
+    console.log(`[confirm-order-email] Enqueued confirmation for order ${orderNumber} → ${account.billing_email}`);
+
+    return new Response(
+      JSON.stringify({ ok: true, message_id: messageId }),
+      { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  } catch (err) {
+    console.error("[confirm-order-email] Unhandled error:", err);
+    return new Response(
+      JSON.stringify({ ok: false, error: String(err) }),
+      { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  }
+});


### PR DESCRIPTION
## Summary

- Adds **My Products** page at `/portal/products` (read-only catalogue of `client_allowed_products` joined with current `price_list`, scaffolded with TODOs)
- Extends **My Orders** (`/portal/orders`) list with Planned Roast Day (`work_deadline_at`) column and inline line-item summaries (up to 2 per row, `+N more` overflow)
- Adds **My Products** nav item to `ClientLayout`
- Triggers a new `confirm-order-email` edge function (fire-and-forget) from `OrderEditModal` whenever an order is saved with status `CONFIRMED`
- New `supabase/functions/confirm-order-email/index.ts` scaffold — verifies caller is ADMIN/OPS, fetches order + account + line items, builds the spec'd plain-text body, and enqueues to the `transactional_emails` queue

## Constraints honoured

- No DB schema changes / no new migrations (existing `client_allowed_products.account_id` migration already applied)
- No RLS policy changes
- Member portal (`/member-portal`) untouched
- ADMIN/OPS navigation untouched
- Existing `/portal/new-order` flow untouched (already wired)

## Follow-ups required before email goes live

1. `supabase functions deploy confirm-order-email`
2. Add `cc` field forwarding to `process-email-queue` + the shared `sendLovableEmail` helper, OR enqueue a second message addressed `to: orders@homeislandcoffee.com`. Currently `cc` is included in the payload but `process-email-queue` drops it.
3. Regenerate `src/integrations/supabase/types.ts` so `client_allowed_products.account_id` is typed — then drop the `(supabase as any)` cast in `Products.tsx` (matches existing pattern in `useClientOrderingConstraints.ts`)
4. Decide DRAFT vs SUBMITTED initial status in `NewOrder.tsx` (existing flow uses SUBMITTED; manufacturing spec calls for DRAFT)

## Test plan

- [ ] Log in as CLIENT user → `/portal/orders` shows Planned Roast Day column and line item summaries
- [ ] `/portal/products` route loads (no crash) and renders product table or empty state
- [ ] "My Products" appears in sidebar between "My Orders" and "Account"
- [ ] In OPS portal, change an order to CONFIRMED → browser console shows `[confirm-order-email]` invoke (will fail until function deployed — expected)
- [ ] After deploy: confirm `email_send_log` row created with `template_name = 'order_confirmation'`
- [ ] Member portal `/member-portal` unchanged
- [ ] ADMIN/OPS navigation unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)