### PR TITLE
feat: account owner self-service management

### DIFF
--- a/src/components/account-management/AccountInfoForm.tsx
+++ b/src/components/account-management/AccountInfoForm.tsx
@@ -1,0 +1,167 @@
+import { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ownerRpc } from './ownerRpc';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { toast } from 'sonner';
+import { Pencil, Save, X } from 'lucide-react';
+
+export interface AccountInfoValues {
+  account_name: string;
+  billing_contact_name: string | null;
+  billing_email: string | null;
+  billing_phone: string | null;
+  billing_address: string | null;
+}
+
+interface AccountInfoFormProps {
+  accountId: string;
+  initialValues: AccountInfoValues;
+  canEdit: boolean;
+}
+
+export function AccountInfoForm({ accountId, initialValues, canEdit }: AccountInfoFormProps) {
+  const queryClient = useQueryClient();
+  const [editing, setEditing] = useState(false);
+  const [values, setValues] = useState<AccountInfoValues>(initialValues);
+
+  const mutation = useMutation({
+    mutationFn: async (next: AccountInfoValues) => {
+      const { error } = await ownerRpc('owner_update_account', {
+        p_account_id: accountId,
+        p_account_name: next.account_name,
+        p_billing_contact_name: next.billing_contact_name,
+        p_billing_email: next.billing_email,
+        p_billing_phone: next.billing_phone,
+        p_billing_address: next.billing_address,
+      });
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      toast.success('Account updated');
+      setEditing(false);
+      queryClient.invalidateQueries({ queryKey: ['client-account', accountId] });
+      queryClient.invalidateQueries({ queryKey: ['my-coroast-account', accountId] });
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || 'Failed to update account');
+    },
+  });
+
+  const handleCancel = () => {
+    setValues(initialValues);
+    setEditing(false);
+  };
+
+  const handleSave = () => {
+    if (!values.account_name.trim()) {
+      toast.error('Account name is required');
+      return;
+    }
+    mutation.mutate({
+      account_name: values.account_name.trim(),
+      billing_contact_name: values.billing_contact_name?.trim() || null,
+      billing_email: values.billing_email?.trim() || null,
+      billing_phone: values.billing_phone?.trim() || null,
+      billing_address: values.billing_address?.trim() || null,
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle>Account Information</CardTitle>
+        {canEdit && !editing && (
+          <Button variant="outline" size="sm" onClick={() => setEditing(true)}>
+            <Pencil className="h-3.5 w-3.5 mr-1" /> Edit
+          </Button>
+        )}
+        {editing && (
+          <div className="flex gap-2">
+            <Button variant="ghost" size="sm" onClick={handleCancel} disabled={mutation.isPending}>
+              <X className="h-3.5 w-3.5 mr-1" /> Cancel
+            </Button>
+            <Button size="sm" onClick={handleSave} disabled={mutation.isPending}>
+              <Save className="h-3.5 w-3.5 mr-1" /> {mutation.isPending ? 'Saving…' : 'Save'}
+            </Button>
+          </div>
+        )}
+      </CardHeader>
+      <CardContent>
+        {editing ? (
+          <div className="grid gap-4">
+            <Field label="Business Name" required>
+              <Input
+                value={values.account_name}
+                onChange={(e) => setValues({ ...values, account_name: e.target.value })}
+              />
+            </Field>
+            <Field label="Billing Contact Name">
+              <Input
+                value={values.billing_contact_name ?? ''}
+                onChange={(e) => setValues({ ...values, billing_contact_name: e.target.value })}
+              />
+            </Field>
+            <div className="grid sm:grid-cols-2 gap-4">
+              <Field label="Billing Email">
+                <Input
+                  type="email"
+                  value={values.billing_email ?? ''}
+                  onChange={(e) => setValues({ ...values, billing_email: e.target.value })}
+                />
+              </Field>
+              <Field label="Billing Phone">
+                <Input
+                  value={values.billing_phone ?? ''}
+                  onChange={(e) => setValues({ ...values, billing_phone: e.target.value })}
+                />
+              </Field>
+            </div>
+            <Field label="Billing Address">
+              <Textarea
+                rows={3}
+                value={values.billing_address ?? ''}
+                onChange={(e) => setValues({ ...values, billing_address: e.target.value })}
+              />
+            </Field>
+          </div>
+        ) : (
+          <dl className="grid sm:grid-cols-2 gap-x-6 gap-y-3 text-sm">
+            <Row label="Business Name" value={initialValues.account_name} />
+            <Row label="Billing Contact" value={initialValues.billing_contact_name} />
+            <Row label="Billing Email" value={initialValues.billing_email} />
+            <Row label="Billing Phone" value={initialValues.billing_phone} />
+            <div className="sm:col-span-2">
+              <dt className="text-xs text-muted-foreground">Billing Address</dt>
+              <dd className="whitespace-pre-wrap mt-0.5">{initialValues.billing_address || '—'}</dd>
+            </div>
+          </dl>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function Field({ label, required, children }: { label: string; required?: boolean; children: React.ReactNode }) {
+  return (
+    <div className="space-y-1">
+      <Label>
+        {label}
+        {required && <span className="text-destructive ml-0.5">*</span>}
+      </Label>
+      {children}
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string | null }) {
+  return (
+    <div>
+      <dt className="text-xs text-muted-foreground">{label}</dt>
+      <dd className="mt-0.5">{value || '—'}</dd>
+    </div>
+  );
+}

--- a/src/components/account-management/EditUserPermissionsDialog.tsx
+++ b/src/components/account-management/EditUserPermissionsDialog.tsx
@@ -1,0 +1,209 @@
+import { useEffect, useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { ownerRpc } from './ownerRpc';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
+import { Lock } from 'lucide-react';
+import { toast } from 'sonner';
+import { useAccountLocations } from '@/hooks/useAccountLocations';
+
+export interface PermissionValues {
+  is_owner: boolean;
+  can_place_orders: boolean;
+  can_book_roaster: boolean;
+  can_manage_locations: boolean;
+  can_invite_users: boolean;
+  location_access: string;
+  assigned_location_ids: string[];
+}
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  accountId: string;
+  accountUserId: string;
+  targetName: string;
+  programs: string[];
+  isOnlyOwner: boolean;
+  initialValues: PermissionValues;
+}
+
+export function EditUserPermissionsDialog({
+  open,
+  onOpenChange,
+  accountId,
+  accountUserId,
+  targetName,
+  programs,
+  isOnlyOwner,
+  initialValues,
+}: Props) {
+  const queryClient = useQueryClient();
+  const [values, setValues] = useState<PermissionValues>(initialValues);
+
+  useEffect(() => {
+    if (open) setValues(initialValues);
+  }, [open, initialValues]);
+
+  const { data: locations = [] } = useAccountLocations(accountId);
+
+  const hasManufacturing = programs.includes('MANUFACTURING');
+  const hasCoroasting = programs.includes('COROASTING');
+
+  const mutation = useMutation({
+    mutationFn: async (next: PermissionValues) => {
+      const { error } = await ownerRpc('owner_update_user_permissions', {
+        p_account_id: accountId,
+        p_account_user_id: accountUserId,
+        p_is_owner: next.is_owner,
+        p_can_place_orders: hasManufacturing && next.can_place_orders,
+        p_can_book_roaster: hasCoroasting && next.can_book_roaster,
+        p_can_manage_locations: next.can_manage_locations,
+        p_can_invite_users: next.can_invite_users,
+        p_location_access: next.location_access,
+        p_assigned_location_ids: next.location_access === 'ASSIGNED' ? next.assigned_location_ids : [],
+      });
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      toast.success('Permissions updated');
+      queryClient.invalidateQueries({ queryKey: ['account-team', accountId] });
+      onOpenChange(false);
+    },
+    onError: (err: Error) => toast.error(err.message || 'Failed to update permissions'),
+  });
+
+  const toggleAssignedLocation = (id: string, checked: boolean) => {
+    setValues((v) => ({
+      ...v,
+      assigned_location_ids: checked
+        ? [...v.assigned_location_ids, id]
+        : v.assigned_location_ids.filter((x) => x !== id),
+    }));
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Edit {targetName}</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 pt-2">
+          <div className="flex items-center gap-2">
+            {isOnlyOwner ? (
+              <Tooltip>
+                <TooltipTrigger className="flex items-center gap-2">
+                  <Switch checked disabled />
+                  <Label className="text-muted-foreground">Owner</Label>
+                  <Lock className="h-3 w-3 text-muted-foreground" />
+                </TooltipTrigger>
+                <TooltipContent className="text-xs max-w-xs">
+                  An account must have at least one Owner. Promote another user to Owner first.
+                </TooltipContent>
+              </Tooltip>
+            ) : (
+              <>
+                <Switch
+                  checked={values.is_owner}
+                  onCheckedChange={(v) => setValues({ ...values, is_owner: v })}
+                />
+                <Label>Owner</Label>
+              </>
+            )}
+          </div>
+
+          <div>
+            <Label className="mb-2 block">Permissions</Label>
+            <div className="grid grid-cols-1 gap-2">
+              {hasManufacturing && (
+                <label className="flex items-center gap-2 text-sm">
+                  <Checkbox
+                    checked={values.can_place_orders}
+                    onCheckedChange={(v) => setValues({ ...values, can_place_orders: !!v })}
+                  />
+                  Place orders
+                </label>
+              )}
+              {hasCoroasting && (
+                <label className="flex items-center gap-2 text-sm">
+                  <Checkbox
+                    checked={values.can_book_roaster}
+                    onCheckedChange={(v) => setValues({ ...values, can_book_roaster: !!v })}
+                  />
+                  Book roaster
+                </label>
+              )}
+              {hasManufacturing && (
+                <label className="flex items-center gap-2 text-sm">
+                  <Checkbox
+                    checked={values.can_manage_locations}
+                    onCheckedChange={(v) => setValues({ ...values, can_manage_locations: !!v })}
+                  />
+                  Manage locations
+                </label>
+              )}
+              <label className="flex items-center gap-2 text-sm">
+                <Checkbox
+                  checked={values.can_invite_users}
+                  onCheckedChange={(v) => setValues({ ...values, can_invite_users: !!v })}
+                />
+                Invite team members
+              </label>
+            </div>
+          </div>
+
+          {hasManufacturing && (
+            <div>
+              <Label>Location access</Label>
+              <Select
+                value={values.location_access}
+                onValueChange={(v) => setValues({ ...values, location_access: v })}
+              >
+                <SelectTrigger className="w-48 mt-1">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="ALL">All Locations</SelectItem>
+                  <SelectItem value="ASSIGNED">Assigned Only</SelectItem>
+                </SelectContent>
+              </Select>
+
+              {values.location_access === 'ASSIGNED' && (
+                <div className="mt-2 space-y-1.5 pl-2 border-l-2 border-border">
+                  <Label className="text-xs text-muted-foreground">Assigned locations</Label>
+                  {locations.length === 0 ? (
+                    <p className="text-xs text-muted-foreground">No locations exist yet.</p>
+                  ) : (
+                    locations.map((loc) => (
+                      <label key={loc.id} className="flex items-center gap-2 text-sm">
+                        <Checkbox
+                          checked={values.assigned_location_ids.includes(loc.id)}
+                          onCheckedChange={(v) => toggleAssignedLocation(loc.id, !!v)}
+                        />
+                        <span className="font-mono text-xs">{loc.location_code}</span>
+                        <span>{loc.location_name}</span>
+                      </label>
+                    ))
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={mutation.isPending}>
+            Cancel
+          </Button>
+          <Button onClick={() => mutation.mutate(values)} disabled={mutation.isPending}>
+            {mutation.isPending ? 'Saving…' : 'Save'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/account-management/InviteUserDialog.tsx
+++ b/src/components/account-management/InviteUserDialog.tsx
@@ -1,0 +1,212 @@
+import { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
+import { toast } from 'sonner';
+import { useAccountLocations } from '@/hooks/useAccountLocations';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  accountId: string;
+  programs: string[];
+}
+
+interface InviteForm {
+  email: string;
+  can_place_orders: boolean;
+  can_book_roaster: boolean;
+  can_manage_locations: boolean;
+  can_invite_users: boolean;
+  location_access: string;
+  assigned_locations: string[];
+}
+
+const initialForm = (programs: string[]): InviteForm => ({
+  email: '',
+  can_place_orders: programs.includes('MANUFACTURING'),
+  can_book_roaster: false,
+  can_manage_locations: false,
+  can_invite_users: false,
+  location_access: 'ALL',
+  assigned_locations: [],
+});
+
+export function InviteUserDialog({ open, onOpenChange, accountId, programs }: Props) {
+  const queryClient = useQueryClient();
+  const [form, setForm] = useState<InviteForm>(initialForm(programs));
+  const { data: locations = [] } = useAccountLocations(accountId);
+
+  const hasManufacturing = programs.includes('MANUFACTURING');
+  const hasCoroasting = programs.includes('COROASTING');
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const trimmed = form.email.trim();
+      if (!trimmed) throw new Error('Email is required');
+
+      const { data, error } = await supabase.functions.invoke('owner-invite-user', {
+        body: {
+          email: trimmed,
+          account_id: accountId,
+          can_place_orders: form.can_place_orders,
+          can_book_roaster: form.can_book_roaster,
+          can_manage_locations: form.can_manage_locations,
+          can_invite_users: form.can_invite_users,
+          location_access: form.location_access,
+          assigned_locations: form.location_access === 'ASSIGNED' ? form.assigned_locations : [],
+        },
+      });
+
+      // supabase-js returns FunctionsHttpError on non-2xx; surface server message
+      if (error) {
+        // Try to extract { error: '...' } body shape
+        const body = (data ?? (error as unknown as { context?: { body?: string } })?.context?.body) as
+          | { error?: string }
+          | string
+          | undefined;
+        let msg: string | undefined;
+        if (typeof body === 'string') {
+          try { msg = (JSON.parse(body) as { error?: string }).error; } catch { msg = body; }
+        } else if (body && typeof body === 'object') {
+          msg = body.error;
+        }
+        throw new Error(msg || error.message || 'Invitation failed');
+      }
+
+      if (data && typeof data === 'object' && 'error' in data && data.error) {
+        throw new Error(String(data.error));
+      }
+      return data;
+    },
+    onSuccess: (data: { message?: string } | null | undefined) => {
+      toast.success(data?.message || 'Invitation sent');
+      queryClient.invalidateQueries({ queryKey: ['account-team', accountId] });
+      setForm(initialForm(programs));
+      onOpenChange(false);
+    },
+    onError: (err: Error) => toast.error(err.message),
+  });
+
+  const toggleAssigned = (id: string, checked: boolean) => {
+    setForm((f) => ({
+      ...f,
+      assigned_locations: checked
+        ? [...f.assigned_locations, id]
+        : f.assigned_locations.filter((x) => x !== id),
+    }));
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) setForm(initialForm(programs)); onOpenChange(o); }}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Invite Team Member</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 pt-2">
+          <div className="space-y-1">
+            <Label>Email address</Label>
+            <Input
+              type="email"
+              value={form.email}
+              onChange={(e) => setForm({ ...form, email: e.target.value })}
+              placeholder="teammate@company.com"
+            />
+            <p className="text-xs text-muted-foreground">
+              An invitation email will be sent. The user sets their own password.
+            </p>
+          </div>
+
+          <div>
+            <Label className="mb-2 block">Permissions</Label>
+            <div className="grid grid-cols-1 gap-2">
+              {hasManufacturing && (
+                <label className="flex items-center gap-2 text-sm">
+                  <Checkbox
+                    checked={form.can_place_orders}
+                    onCheckedChange={(v) => setForm({ ...form, can_place_orders: !!v })}
+                  />
+                  Place orders
+                </label>
+              )}
+              {hasCoroasting && (
+                <label className="flex items-center gap-2 text-sm">
+                  <Checkbox
+                    checked={form.can_book_roaster}
+                    onCheckedChange={(v) => setForm({ ...form, can_book_roaster: !!v })}
+                  />
+                  Book roaster
+                </label>
+              )}
+              {hasManufacturing && (
+                <label className="flex items-center gap-2 text-sm">
+                  <Checkbox
+                    checked={form.can_manage_locations}
+                    onCheckedChange={(v) => setForm({ ...form, can_manage_locations: !!v })}
+                  />
+                  Manage locations
+                </label>
+              )}
+              <label className="flex items-center gap-2 text-sm">
+                <Checkbox
+                  checked={form.can_invite_users}
+                  onCheckedChange={(v) => setForm({ ...form, can_invite_users: !!v })}
+                />
+                Invite team members
+              </label>
+            </div>
+          </div>
+
+          {hasManufacturing && (
+            <div>
+              <Label>Location access</Label>
+              <Select
+                value={form.location_access}
+                onValueChange={(v) => setForm({ ...form, location_access: v })}
+              >
+                <SelectTrigger className="w-48 mt-1"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="ALL">All Locations</SelectItem>
+                  <SelectItem value="ASSIGNED">Assigned Only</SelectItem>
+                </SelectContent>
+              </Select>
+
+              {form.location_access === 'ASSIGNED' && (
+                <div className="mt-2 space-y-1.5 pl-2 border-l-2 border-border">
+                  <Label className="text-xs text-muted-foreground">Assigned locations</Label>
+                  {locations.length === 0 ? (
+                    <p className="text-xs text-muted-foreground">No locations exist yet.</p>
+                  ) : (
+                    locations.map((loc) => (
+                      <label key={loc.id} className="flex items-center gap-2 text-sm">
+                        <Checkbox
+                          checked={form.assigned_locations.includes(loc.id)}
+                          onCheckedChange={(v) => toggleAssigned(loc.id, !!v)}
+                        />
+                        <span className="font-mono text-xs">{loc.location_code}</span>
+                        <span>{loc.location_name}</span>
+                      </label>
+                    ))
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={mutation.isPending}>
+            Cancel
+          </Button>
+          <Button onClick={() => mutation.mutate()} disabled={mutation.isPending || !form.email.trim()}>
+            {mutation.isPending ? 'Sending…' : 'Send Invitation'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/account-management/LocationManagementSection.tsx
+++ b/src/components/account-management/LocationManagementSection.tsx
@@ -1,0 +1,197 @@
+import { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ownerRpc } from './ownerRpc';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Switch } from '@/components/ui/switch';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { MapPin, Plus, Info } from 'lucide-react';
+import { toast } from 'sonner';
+import { useAccountLocations } from '@/hooks/useAccountLocations';
+
+interface Props {
+  accountId: string;
+  canManage: boolean;
+}
+
+interface LocationForm {
+  location_name: string;
+  location_code: string;
+  address: string;
+  bill_separately: boolean;
+  qbo_billing_entity: string;
+}
+
+const initialForm: LocationForm = {
+  location_name: '',
+  location_code: '',
+  address: '',
+  bill_separately: false,
+  qbo_billing_entity: '',
+};
+
+export function LocationManagementSection({ accountId, canManage }: Props) {
+  const queryClient = useQueryClient();
+  const { data: locations = [], isLoading } = useAccountLocations(accountId);
+  const [showCreate, setShowCreate] = useState(false);
+  const [form, setForm] = useState<LocationForm>(initialForm);
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!form.location_name.trim()) throw new Error('Location name is required');
+      if (!form.location_code.trim()) throw new Error('Location code is required');
+      if (form.bill_separately && !form.qbo_billing_entity.trim()) {
+        throw new Error('QuickBooks billing name is required when billing separately');
+      }
+
+      const { error } = await ownerRpc('owner_create_location', {
+        p_account_id: accountId,
+        p_location_name: form.location_name.trim(),
+        p_location_code: form.location_code.trim(),
+        p_address: form.address.trim() || null,
+        p_qbo_billing_entity: form.bill_separately ? form.qbo_billing_entity.trim() : null,
+      });
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      const msg = form.bill_separately
+        ? 'Location created. Our team will configure separate QuickBooks billing for it shortly.'
+        : 'Location created';
+      toast.success(msg);
+      queryClient.invalidateQueries({ queryKey: ['account-locations', accountId] });
+      setForm(initialForm);
+      setShowCreate(false);
+    },
+    onError: (err: Error) => toast.error(err.message || 'Failed to create location'),
+  });
+
+  return (
+    <>
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle>Locations</CardTitle>
+          {canManage && (
+            <Button size="sm" onClick={() => setShowCreate(true)}>
+              <Plus className="h-3.5 w-3.5 mr-1" /> Add Location
+            </Button>
+          )}
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <p className="text-sm text-muted-foreground">Loading…</p>
+          ) : locations.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No locations yet.</p>
+          ) : (
+            <div className="space-y-2">
+              {locations.map((loc) => (
+                <div key={loc.id} className="flex items-start gap-3 border rounded-md p-3">
+                  <MapPin className="h-4 w-4 text-muted-foreground mt-0.5" />
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="font-mono text-xs bg-muted px-1.5 py-0.5 rounded">{loc.location_code}</span>
+                      <span className="text-sm font-medium">{loc.location_name}</span>
+                      {!loc.is_active && (
+                        <span className="text-[10px] uppercase text-muted-foreground">Inactive</span>
+                      )}
+                    </div>
+                    {loc.address && (
+                      <p className="text-xs text-muted-foreground whitespace-pre-wrap mt-0.5">{loc.address}</p>
+                    )}
+                    {loc.qbo_billing_entity && (
+                      <p className="text-xs text-muted-foreground mt-0.5">
+                        Billed separately as: <span className="font-medium">{loc.qbo_billing_entity}</span>
+                      </p>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog open={showCreate} onOpenChange={(open) => { if (!open) setForm(initialForm); setShowCreate(open); }}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Add Location</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 pt-2">
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1 col-span-2">
+                <Label>Location Name <span className="text-destructive">*</span></Label>
+                <Input
+                  value={form.location_name}
+                  onChange={(e) => setForm({ ...form, location_name: e.target.value })}
+                  placeholder="Downtown Cafe"
+                />
+              </div>
+              <div className="space-y-1">
+                <Label>Code <span className="text-destructive">*</span></Label>
+                <Input
+                  value={form.location_code}
+                  onChange={(e) => setForm({ ...form, location_code: e.target.value.toUpperCase() })}
+                  placeholder="DT01"
+                  maxLength={10}
+                />
+              </div>
+            </div>
+
+            <div className="space-y-1">
+              <Label>Address</Label>
+              <Textarea
+                rows={2}
+                value={form.address}
+                onChange={(e) => setForm({ ...form, address: e.target.value })}
+              />
+            </div>
+
+            <div className="flex items-center justify-between border-t pt-3">
+              <div>
+                <Label>Bill this location separately?</Label>
+                <p className="text-xs text-muted-foreground">
+                  Off = billing rolls up to your main account.
+                </p>
+              </div>
+              <Switch
+                checked={form.bill_separately}
+                onCheckedChange={(v) => setForm({ ...form, bill_separately: v })}
+              />
+            </div>
+
+            {form.bill_separately && (
+              <>
+                <div className="space-y-1">
+                  <Label>QuickBooks Billing Name <span className="text-destructive">*</span></Label>
+                  <Input
+                    value={form.qbo_billing_entity}
+                    onChange={(e) => setForm({ ...form, qbo_billing_entity: e.target.value })}
+                    placeholder="e.g. ACME Coffee — Downtown LLC"
+                  />
+                </div>
+                <Alert>
+                  <Info className="h-4 w-4" />
+                  <AlertDescription className="text-xs">
+                    Our team will set up a separate QuickBooks billing entry for this location.
+                    Invoices for this location will be sent separately once it's configured.
+                  </AlertDescription>
+                </Alert>
+              </>
+            )}
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setShowCreate(false)} disabled={mutation.isPending}>
+              Cancel
+            </Button>
+            <Button onClick={() => mutation.mutate()} disabled={mutation.isPending}>
+              {mutation.isPending ? 'Creating…' : 'Create Location'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/account-management/TeamMemberList.tsx
+++ b/src/components/account-management/TeamMemberList.tsx
@@ -1,0 +1,217 @@
+import { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ownerRpc } from './ownerRpc';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+  AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Pencil, ShieldCheck, UserPlus, UserX } from 'lucide-react';
+import { toast } from 'sonner';
+import { useAccountTeam, type AccountTeamMember } from '@/hooks/useAccountTeam';
+import { EditUserPermissionsDialog } from './EditUserPermissionsDialog';
+import { InviteUserDialog } from './InviteUserDialog';
+
+interface Props {
+  accountId: string;
+  programs: string[];
+  currentUserId: string;
+  isOwner: boolean;
+  canInviteUsers: boolean;
+  readOnly?: boolean;
+}
+
+export function TeamMemberList({
+  accountId,
+  programs,
+  currentUserId,
+  isOwner,
+  canInviteUsers,
+  readOnly = false,
+}: Props) {
+  const queryClient = useQueryClient();
+  const { data: members = [], isLoading } = useAccountTeam(accountId);
+
+  const [editTarget, setEditTarget] = useState<AccountTeamMember | null>(null);
+  const [deactivateTarget, setDeactivateTarget] = useState<AccountTeamMember | null>(null);
+  const [showInvite, setShowInvite] = useState(false);
+
+  const activeOwnerCount = members.filter((m) => m.is_owner && m.is_active).length;
+
+  const deactivateMutation = useMutation({
+    mutationFn: async (accountUserId: string) => {
+      const { error } = await ownerRpc('owner_deactivate_user', {
+        p_account_id: accountId,
+        p_account_user_id: accountUserId,
+      });
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      toast.success('Team member deactivated');
+      queryClient.invalidateQueries({ queryKey: ['account-team', accountId] });
+      setDeactivateTarget(null);
+    },
+    onError: (err: Error) => toast.error(err.message || 'Failed to deactivate'),
+  });
+
+  const showInviteButton = !readOnly && (isOwner || canInviteUsers);
+
+  return (
+    <>
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle>Team Members</CardTitle>
+          {showInviteButton && (
+            <Button size="sm" onClick={() => setShowInvite(true)}>
+              <UserPlus className="h-3.5 w-3.5 mr-1" /> Invite
+            </Button>
+          )}
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <p className="text-sm text-muted-foreground">Loading…</p>
+          ) : members.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No team members yet.</p>
+          ) : (
+            <div className="space-y-2">
+              {members.map((m) => (
+                <MemberRow
+                  key={m.id}
+                  member={m}
+                  isSelf={m.user_id === currentUserId}
+                  canEdit={!readOnly && isOwner}
+                  isOnlyOwner={m.is_owner && activeOwnerCount <= 1}
+                  onEdit={() => setEditTarget(m)}
+                  onDeactivate={() => setDeactivateTarget(m)}
+                />
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {editTarget && (
+        <EditUserPermissionsDialog
+          open={!!editTarget}
+          onOpenChange={(open) => !open && setEditTarget(null)}
+          accountId={accountId}
+          accountUserId={editTarget.id}
+          targetName={editTarget.profile?.name || editTarget.profile?.email || 'user'}
+          programs={programs}
+          isOnlyOwner={editTarget.is_owner && activeOwnerCount <= 1}
+          initialValues={{
+            is_owner: editTarget.is_owner,
+            can_place_orders: editTarget.can_place_orders,
+            can_book_roaster: editTarget.can_book_roaster,
+            can_manage_locations: editTarget.can_manage_locations,
+            can_invite_users: editTarget.can_invite_users,
+            location_access: editTarget.location_access,
+            assigned_location_ids: editTarget.assigned_location_ids,
+          }}
+        />
+      )}
+
+      <InviteUserDialog
+        open={showInvite}
+        onOpenChange={setShowInvite}
+        accountId={accountId}
+        programs={programs}
+      />
+
+      <AlertDialog open={!!deactivateTarget} onOpenChange={(open) => !open && setDeactivateTarget(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Deactivate team member?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {deactivateTarget?.profile?.name || deactivateTarget?.profile?.email} will lose
+              access to this account immediately. You can re-invite them later if needed.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => deactivateTarget && deactivateMutation.mutate(deactivateTarget.id)}
+              disabled={deactivateMutation.isPending}
+            >
+              {deactivateMutation.isPending ? 'Deactivating…' : 'Deactivate'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}
+
+interface RowProps {
+  member: AccountTeamMember;
+  isSelf: boolean;
+  canEdit: boolean;
+  isOnlyOwner: boolean;
+  onEdit: () => void;
+  onDeactivate: () => void;
+}
+
+function MemberRow({ member, isSelf, canEdit, isOnlyOwner, onEdit, onDeactivate }: RowProps) {
+  const profile = member.profile;
+  const profileMissing = !profile;
+  const email = profile?.email || '';
+  const name = profileMissing ? 'Unknown' : (profile?.name || 'Unknown');
+  const isPending = !!email && name === email.split('@')[0];
+
+  const permBadges: { label: string; on: boolean }[] = [
+    { label: 'Orders', on: member.can_place_orders },
+    { label: 'Roaster', on: member.can_book_roaster },
+    { label: 'Locations', on: member.can_manage_locations },
+    { label: 'Invite', on: member.can_invite_users },
+  ];
+
+  return (
+    <div className="flex items-center gap-3 border rounded-md p-3">
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="text-sm font-medium">{name}</span>
+          <span className="text-xs text-muted-foreground">{email}</span>
+          {member.is_owner && (
+            <Badge className="text-[10px] bg-primary">
+              <ShieldCheck className="h-3 w-3 mr-0.5" /> Owner
+            </Badge>
+          )}
+          {!member.is_active ? (
+            <Badge variant="secondary" className="text-[10px]">Inactive</Badge>
+          ) : isPending ? (
+            <Badge className="text-[10px] bg-amber-500 hover:bg-amber-500 text-white">Pending</Badge>
+          ) : null}
+          {isSelf && <Badge variant="outline" className="text-[10px]">You</Badge>}
+        </div>
+        <div className="flex gap-1 mt-1 flex-wrap">
+          {permBadges.filter((p) => p.on).map((p) => (
+            <Badge key={p.label} variant="secondary" className="text-[10px]">{p.label}</Badge>
+          ))}
+          <Badge variant="outline" className="text-[10px]">
+            {member.location_access === 'ALL' ? 'All Locations' : 'Assigned Only'}
+          </Badge>
+        </div>
+      </div>
+      {canEdit && member.is_active && (
+        <>
+          <Button variant="ghost" size="icon" className="h-7 w-7" onClick={onEdit}>
+            <Pencil className="h-3 w-3" />
+          </Button>
+          {!isSelf && !isOnlyOwner && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 text-destructive hover:text-destructive"
+              onClick={onDeactivate}
+              title="Deactivate"
+            >
+              <UserX className="h-3 w-3" />
+            </Button>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/account-management/ownerRpc.ts
+++ b/src/components/account-management/ownerRpc.ts
@@ -1,0 +1,22 @@
+import { supabase } from '@/integrations/supabase/client';
+
+// Thin wrapper for RPCs added by the account-owner self-service migration.
+// Types in src/integrations/supabase/types.ts are auto-generated and do not
+// yet include these functions; regenerate with `supabase gen types` to drop
+// this file. Until then, casting keeps the call sites tidy and type-safe at
+// the boundary while skipping the unknown-name compile error.
+type OwnerRpcName =
+  | 'owner_update_account'
+  | 'owner_update_user_permissions'
+  | 'owner_deactivate_user'
+  | 'owner_create_location';
+
+type OwnerRpcResult<T = unknown> = { data: T | null; error: { message: string } | null };
+
+export function ownerRpc<T = unknown>(
+  fn: OwnerRpcName,
+  args: Record<string, unknown>
+): Promise<OwnerRpcResult<T>> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (supabase.rpc as any)(fn, args);
+}

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -18,6 +18,7 @@ interface AuthUser {
   canManageLocations: boolean;
   canInviteUsers: boolean;
   locationAccess: string;
+  programs: string[];
 }
 
 interface AuthContextType {
@@ -79,6 +80,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       let canManageLocations = false;
       let canInviteUsers = false;
       let locationAccess = 'ALL';
+      let programs: string[] = [];
 
       // For CLIENT users, look up account_users record
       if (roleData.role === 'CLIENT') {
@@ -101,6 +103,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           canManageLocations = accountUser.can_manage_locations;
           canInviteUsers = accountUser.can_invite_users;
           locationAccess = accountUser.location_access;
+
+          // Fetch account programs (used by UI to gate permission checkboxes)
+          const { data: acct } = await supabase
+            .from('accounts')
+            .select('programs')
+            .eq('id', accountUser.account_id)
+            .maybeSingle();
+          programs = (acct?.programs as string[] | null) ?? [];
         }
       }
 
@@ -118,6 +128,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         canManageLocations,
         canInviteUsers,
         locationAccess,
+        programs,
       };
     } catch (error) {
       console.error('Error in fetchUserData:', error);

--- a/src/hooks/useAccountLocations.ts
+++ b/src/hooks/useAccountLocations.ts
@@ -1,0 +1,31 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+
+export interface AccountLocation {
+  id: string;
+  account_id: string;
+  location_name: string;
+  location_code: string;
+  address: string | null;
+  qbo_billing_entity: string | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export function useAccountLocations(accountId: string | null | undefined) {
+  return useQuery({
+    queryKey: ['account-locations', accountId],
+    enabled: !!accountId,
+    queryFn: async (): Promise<AccountLocation[]> => {
+      if (!accountId) return [];
+      const { data, error } = await supabase
+        .from('account_locations')
+        .select('*')
+        .eq('account_id', accountId)
+        .order('location_code', { ascending: true });
+      if (error) throw error;
+      return (data ?? []) as AccountLocation[];
+    },
+  });
+}

--- a/src/hooks/useAccountTeam.ts
+++ b/src/hooks/useAccountTeam.ts
@@ -1,0 +1,83 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+
+export interface AccountTeamMember {
+  id: string;
+  user_id: string;
+  account_id: string;
+  is_owner: boolean;
+  is_active: boolean;
+  can_place_orders: boolean;
+  can_book_roaster: boolean;
+  can_manage_locations: boolean;
+  can_invite_users: boolean;
+  location_access: string;
+  created_at: string;
+  updated_at: string;
+  profile: {
+    name: string | null;
+    email: string | null;
+    is_active: boolean | null;
+  } | null;
+  assigned_location_ids: string[];
+}
+
+export function useAccountTeam(accountId: string | null | undefined) {
+  return useQuery({
+    queryKey: ['account-team', accountId],
+    enabled: !!accountId,
+    queryFn: async (): Promise<AccountTeamMember[]> => {
+      if (!accountId) return [];
+
+      const { data: rows, error } = await supabase
+        .from('account_users')
+        .select('id, user_id, account_id, is_owner, is_active, can_place_orders, can_book_roaster, can_manage_locations, can_invite_users, location_access, created_at, updated_at')
+        .eq('account_id', accountId)
+        .order('created_at', { ascending: true });
+
+      if (error) throw error;
+      if (!rows || rows.length === 0) return [];
+
+      const userIds = rows.map((r) => r.user_id);
+
+      // Fetch profiles separately (no FK relationship in generated types)
+      const { data: profiles, error: profErr } = await supabase
+        .from('profiles')
+        .select('user_id, name, email, is_active')
+        .in('user_id', userIds);
+
+      if (profErr) throw profErr;
+
+      const profileMap = new Map(
+        (profiles ?? []).map((p) => [p.user_id, p])
+      );
+
+      const accountUserIds = rows.map((r) => r.id);
+      const { data: locRows, error: locErr } = await supabase
+        .from('account_user_locations')
+        .select('account_user_id, location_id')
+        .in('account_user_id', accountUserIds);
+
+      if (locErr) throw locErr;
+
+      const locMap = new Map<string, string[]>();
+      (locRows ?? []).forEach((row) => {
+        const arr = locMap.get(row.account_user_id) ?? [];
+        arr.push(row.location_id);
+        locMap.set(row.account_user_id, arr);
+      });
+
+      return rows.map((r) => ({
+        ...r,
+        profile: profileMap.get(r.user_id)
+          ? {
+              name: profileMap.get(r.user_id)!.name,
+              email: profileMap.get(r.user_id)!.email,
+              is_active: profileMap.get(r.user_id)!.is_active,
+            }
+          : null,
+        assigned_location_ids: locMap.get(r.id) ?? [],
+      }));
+    },
+  });
+}

--- a/src/pages/client/Account.tsx
+++ b/src/pages/client/Account.tsx
@@ -1,74 +1,115 @@
-import React from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useAuth } from '@/contexts/AuthContext';
 import { supabase } from '@/integrations/supabase/client';
+import { AccountInfoForm } from '@/components/account-management/AccountInfoForm';
+import { TeamMemberList } from '@/components/account-management/TeamMemberList';
+import { LocationManagementSection } from '@/components/account-management/LocationManagementSection';
 
 export default function Account() {
   const { authUser } = useAuth();
+  const accountId = authUser?.accountId ?? null;
 
-  const { data: client, isLoading } = useQuery({
-    queryKey: ['client-account', authUser?.accountId],
+  const { data: account, isLoading } = useQuery({
+    queryKey: ['client-account', accountId],
+    enabled: !!accountId,
     queryFn: async () => {
-      if (!authUser?.accountId) return null;
+      if (!accountId) return null;
       const { data, error } = await supabase
         .from('accounts')
-        .select('account_name, billing_contact_name, billing_email, billing_address')
-        .eq('id', authUser.accountId)
+        .select('account_name, billing_contact_name, billing_email, billing_phone, billing_address, programs')
+        .eq('id', accountId)
         .maybeSingle();
-
       if (error) throw error;
       return data;
     },
-    enabled: !!authUser?.accountId,
   });
+
+  if (!authUser) return null;
+
+  const programs: string[] = (account?.programs as string[] | null) ?? authUser.programs ?? [];
+  const showLocations = programs.includes('MANUFACTURING');
 
   return (
     <div className="page-container">
       <div className="page-header">
         <h1 className="page-title">Account</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Manage your account information, team, and locations.
+        </p>
       </div>
 
-      <div className="grid gap-6 md:grid-cols-2">
-        <Card>
-          <CardHeader><CardTitle>Your Information</CardTitle></CardHeader>
-          <CardContent className="space-y-2 text-sm">
-            <div><strong>Name:</strong> {authUser?.profile?.name || 'N/A'}</div>
-            <div><strong>Email:</strong> {authUser?.email || 'N/A'}</div>
-            <div><strong>Role:</strong> {authUser?.role || 'N/A'}</div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader><CardTitle>Company Information</CardTitle></CardHeader>
-          <CardContent className="space-y-2 text-sm">
-            {isLoading ? (
-              <p className="text-muted-foreground">Loading…</p>
-            ) : client ? (
-              <>
-                <div><strong>Company:</strong> {client.account_name}</div>
-                <div><strong>Billing Contact:</strong> {client.billing_contact_name || '—'}</div>
-                <div><strong>Billing Email:</strong> {client.billing_email || '—'}</div>
-                <div>
-                  <strong>Billing Address:</strong>
-                  <p className="text-muted-foreground whitespace-pre-wrap">{client.billing_address || '—'}</p>
-                </div>
-              </>
-            ) : (
-              <p className="text-muted-foreground">No company information available.</p>
-            )}
-          </CardContent>
-        </Card>
-      </div>
-
-      <Card className="mt-6">
-        <CardHeader><CardTitle>Need Changes?</CardTitle></CardHeader>
-        <CardContent>
-          <p className="text-sm text-muted-foreground">
-            To update your account or company information, please contact your account manager.
-          </p>
+      <Card className="mb-6">
+        <CardHeader><CardTitle>Your Profile</CardTitle></CardHeader>
+        <CardContent className="space-y-1.5 text-sm">
+          <div><span className="text-muted-foreground">Name:</span> {authUser.profile?.name || '—'}</div>
+          <div><span className="text-muted-foreground">Email:</span> {authUser.email}</div>
+          <div>
+            <span className="text-muted-foreground">Role:</span>{' '}
+            {authUser.isOwner ? 'Account Owner' : 'Team Member'}
+          </div>
         </CardContent>
       </Card>
+
+      {!accountId ? (
+        <Card>
+          <CardContent className="pt-6">
+            <p className="text-sm text-muted-foreground">
+              Your user is not linked to an account. Please contact your account administrator.
+            </p>
+          </CardContent>
+        </Card>
+      ) : isLoading ? (
+        <Card><CardContent className="pt-6 text-sm text-muted-foreground">Loading…</CardContent></Card>
+      ) : !account ? (
+        <Card>
+          <CardContent className="pt-6">
+            <p className="text-sm text-muted-foreground">No account information available.</p>
+          </CardContent>
+        </Card>
+      ) : (
+        <Tabs defaultValue="info" className="space-y-4">
+          <TabsList>
+            <TabsTrigger value="info">Account Info</TabsTrigger>
+            <TabsTrigger value="team">Team</TabsTrigger>
+            {showLocations && <TabsTrigger value="locations">Locations</TabsTrigger>}
+          </TabsList>
+
+          <TabsContent value="info">
+            <AccountInfoForm
+              accountId={accountId}
+              initialValues={{
+                account_name: account.account_name,
+                billing_contact_name: account.billing_contact_name,
+                billing_email: account.billing_email,
+                billing_phone: account.billing_phone,
+                billing_address: account.billing_address,
+              }}
+              canEdit={authUser.isOwner}
+            />
+          </TabsContent>
+
+          <TabsContent value="team">
+            <TeamMemberList
+              accountId={accountId}
+              programs={programs}
+              currentUserId={authUser.id}
+              isOwner={authUser.isOwner}
+              canInviteUsers={authUser.canInviteUsers}
+            />
+          </TabsContent>
+
+          {showLocations && (
+            <TabsContent value="locations">
+              <LocationManagementSection
+                accountId={accountId}
+                canManage={authUser.isOwner || authUser.canManageLocations}
+              />
+            </TabsContent>
+          )}
+        </Tabs>
+      )}
     </div>
   );
 }

--- a/src/pages/member/MemberAccount.tsx
+++ b/src/pages/member/MemberAccount.tsx
@@ -3,38 +3,48 @@ import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { usePreview } from '@/contexts/PreviewContext';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { Badge } from '@/components/ui/badge';
 import { format } from 'date-fns';
-import { ShieldCheck, Mail, Building2, CalendarDays } from 'lucide-react';
+import { ShieldCheck, CalendarDays } from 'lucide-react';
+import { AccountInfoForm } from '@/components/account-management/AccountInfoForm';
+import { TeamMemberList } from '@/components/account-management/TeamMemberList';
 
 export default function MemberAccount() {
   const { authUser } = useAuth();
   const { previewAccountId } = usePreview();
-  const effectiveAccountId = previewAccountId ?? authUser?.accountId;
+  const effectiveAccountId = previewAccountId ?? authUser?.accountId ?? null;
+  const isPreviewMode = !!previewAccountId;
+
   const { data: account, isLoading } = useQuery({
     queryKey: ['my-coroast-account', effectiveAccountId],
+    enabled: !!effectiveAccountId,
     queryFn: async () => {
       const { data, error } = await supabase
         .from('accounts')
-        .select('id, account_name, coroast_tier, coroast_certified, coroast_joined_date, billing_contact_name, billing_email')
+        .select('id, account_name, programs, coroast_tier, coroast_certified, coroast_joined_date, billing_contact_name, billing_email, billing_phone, billing_address')
         .eq('id', effectiveAccountId!)
         .maybeSingle();
       if (error) throw error;
       return data;
     },
-    enabled: !!effectiveAccountId,
   });
+
+  if (!authUser) return null;
 
   if (isLoading) {
     return <div className="p-6"><p className="text-muted-foreground">Loading…</p></div>;
   }
 
-  if (!account) {
+  if (!account || !effectiveAccountId) {
     return <div className="p-6"><p className="text-destructive">No account record found.</p></div>;
   }
 
+  const programs: string[] = (account.programs as string[] | null) ?? [];
+  const canEdit = authUser.isOwner && !isPreviewMode;
+
   return (
-    <div className="p-6 max-w-2xl mx-auto space-y-6">
+    <div className="p-6 max-w-3xl mx-auto space-y-6">
       <div>
         <h1 className="text-2xl font-bold">My Account</h1>
         <p className="text-sm text-muted-foreground">Your co-roasting membership details</p>
@@ -55,46 +65,53 @@ export default function MemberAccount() {
             </div>
           </div>
         </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            {account.billing_contact_name && (
-              <div className="flex items-start gap-3">
-                <Building2 className="h-4 w-4 mt-0.5 text-muted-foreground" />
-                <div>
-                  <p className="text-xs text-muted-foreground">Billing Contact</p>
-                  <p className="text-sm font-medium">{account.billing_contact_name}</p>
-                </div>
-              </div>
-            )}
-            {account.billing_email && (
-              <div className="flex items-start gap-3">
-                <Mail className="h-4 w-4 mt-0.5 text-muted-foreground" />
-                <div>
-                  <p className="text-xs text-muted-foreground">Email</p>
-                  <p className="text-sm font-medium">{account.billing_email}</p>
-                </div>
-              </div>
-            )}
-            {account.coroast_joined_date && (
-              <div className="flex items-start gap-3">
-                <CalendarDays className="h-4 w-4 mt-0.5 text-muted-foreground" />
-                <div>
-                  <p className="text-xs text-muted-foreground">Member Since</p>
-                  <p className="text-sm font-medium">
-                    {format(new Date(account.coroast_joined_date + 'T00:00:00'), 'MMMM d, yyyy')}
-                  </p>
-                </div>
-              </div>
-            )}
-          </div>
-
-          <div className="border-t pt-4 mt-4">
-            <p className="text-sm text-muted-foreground">
-              To update your account details, tier, or membership status, please contact Home Island Coffee Partners directly.
-            </p>
-          </div>
+        <CardContent>
+          {account.coroast_joined_date && (
+            <div className="flex items-center gap-2 text-sm">
+              <CalendarDays className="h-4 w-4 text-muted-foreground" />
+              <span className="text-muted-foreground">Member since</span>
+              <span className="font-medium">
+                {format(new Date(account.coroast_joined_date + 'T00:00:00'), 'MMMM d, yyyy')}
+              </span>
+            </div>
+          )}
+          <p className="text-xs text-muted-foreground mt-2">
+            To change your tier or membership status, contact Home Island Coffee Partners.
+          </p>
         </CardContent>
       </Card>
+
+      <Tabs defaultValue="info" className="space-y-4">
+        <TabsList>
+          <TabsTrigger value="info">Account Info</TabsTrigger>
+          <TabsTrigger value="team">Team</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="info">
+          <AccountInfoForm
+            accountId={effectiveAccountId}
+            initialValues={{
+              account_name: account.account_name,
+              billing_contact_name: account.billing_contact_name,
+              billing_email: account.billing_email,
+              billing_phone: account.billing_phone,
+              billing_address: account.billing_address,
+            }}
+            canEdit={canEdit}
+          />
+        </TabsContent>
+
+        <TabsContent value="team">
+          <TeamMemberList
+            accountId={effectiveAccountId}
+            programs={programs}
+            currentUserId={authUser.id}
+            isOwner={authUser.isOwner}
+            canInviteUsers={authUser.canInviteUsers}
+            readOnly={isPreviewMode}
+          />
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -7,6 +7,8 @@ project_id = "cgdzjkryygwlyygeznrb"
     verify_jwt = false
   [functions.invite-user]
     verify_jwt = false
+  [functions.owner-invite-user]
+    verify_jwt = false
   [functions.notify-new-order]
     verify_jwt = false
   [functions.process-email-queue]

--- a/supabase/functions/owner-invite-user/index.ts
+++ b/supabase/functions/owner-invite-user/index.ts
@@ -1,0 +1,348 @@
+// Edge function: owner-invite-user
+//
+// Allows an account owner (or member with can_invite_users=true) to invite
+// a new user into their own account. Mirrors the behavior of invite-account-user
+// but with caller-side authorization based on account_users membership rather
+// than ADMIN/OPS role. Never grants is_owner via this path — owner promotion
+// is done separately via the owner_update_user_permissions RPC after the user
+// exists.
+
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.49.1';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+const SITE_URL = Deno.env.get('SITE_URL') || 'https://homeislandcoffeepartners.lovable.app';
+
+interface OwnerInviteRequest {
+  email: string;
+  account_id: string;
+  can_place_orders: boolean;
+  can_book_roaster: boolean;
+  can_manage_locations: boolean;
+  can_invite_users: boolean;
+  location_access: string;
+  assigned_locations?: string[];
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+
+    const adminClient = createClient(supabaseUrl, supabaseServiceKey, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+
+    // ---- Authentication ----
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) {
+      return new Response(
+        JSON.stringify({ error: 'Missing authorization header' }),
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const token = authHeader.replace('Bearer ', '');
+    const { data: { user: callingUser }, error: authError } = await adminClient.auth.getUser(token);
+
+    if (authError || !callingUser) {
+      return new Response(
+        JSON.stringify({ error: 'Invalid token' }),
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // ---- Parse and validate body ----
+    const body: OwnerInviteRequest = await req.json();
+    const {
+      email,
+      account_id,
+      can_place_orders,
+      can_book_roaster,
+      can_manage_locations,
+      can_invite_users,
+      location_access,
+      assigned_locations = [],
+    } = body;
+
+    if (!email || !account_id) {
+      return new Response(
+        JSON.stringify({ error: 'Email and account_id are required' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // ---- Authorization: caller must be active owner OR have can_invite_users on this account ----
+    const { data: callerMembership, error: membershipError } = await adminClient
+      .from('account_users')
+      .select('is_owner, can_invite_users, is_active')
+      .eq('user_id', callingUser.id)
+      .eq('account_id', account_id)
+      .eq('is_active', true)
+      .maybeSingle();
+
+    if (membershipError) {
+      console.error('[owner-invite-user] membership lookup failed:', membershipError.message);
+      return new Response(
+        JSON.stringify({ error: 'Failed to verify caller membership' }),
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    if (!callerMembership || !(callerMembership.is_owner || callerMembership.can_invite_users)) {
+      return new Response(
+        JSON.stringify({ error: 'Not authorized to invite users to this account' }),
+        { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // ---- Verify account + fetch programs for permission filtering ----
+    const { data: account, error: accountError } = await adminClient
+      .from('accounts')
+      .select('id, account_name, programs')
+      .eq('id', account_id)
+      .single();
+
+    if (accountError || !account) {
+      return new Response(
+        JSON.stringify({ error: 'Account not found' }),
+        { status: 404, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const programs: string[] = (account.programs as string[] | null) ?? [];
+    const effectiveCanPlaceOrders = programs.includes('MANUFACTURING') ? !!can_place_orders : false;
+    const effectiveCanBookRoaster = programs.includes('COROASTING') ? !!can_book_roaster : false;
+
+    if (location_access !== 'ALL' && location_access !== 'ASSIGNED') {
+      return new Response(
+        JSON.stringify({ error: 'location_access must be ALL or ASSIGNED' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Validate assigned location IDs all belong to this account
+    if (location_access === 'ASSIGNED' && assigned_locations.length > 0) {
+      const { data: validLocs, error: locValError } = await adminClient
+        .from('account_locations')
+        .select('id')
+        .eq('account_id', account_id)
+        .in('id', assigned_locations);
+
+      if (locValError) {
+        return new Response(
+          JSON.stringify({ error: `Failed to validate locations: ${locValError.message}` }),
+          { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+
+      if ((validLocs?.length ?? 0) !== assigned_locations.length) {
+        return new Response(
+          JSON.stringify({ error: 'One or more locations do not belong to this account' }),
+          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+    }
+
+    const redirectTo = `${SITE_URL}/auth/callback`;
+    const normalizedEmail = email.toLowerCase().trim();
+
+    // ---- Find or create a legacy `clients` row mirroring this account ----
+    // user_roles requires CLIENT roles to have a client_id.
+    const findOrCreateClientId = async (): Promise<string | null> => {
+      const { data: existingClient } = await adminClient
+        .from('clients')
+        .select('id')
+        .eq('name', account.account_name)
+        .maybeSingle();
+      if (existingClient) return existingClient.id;
+
+      const baseCode = account.account_name
+        .replace(/[^A-Za-z0-9]/g, '')
+        .toUpperCase()
+        .slice(0, 3)
+        .padEnd(3, 'X') || 'CLT';
+      let code = baseCode;
+      for (let i = 0; i < 100; i++) {
+        const { data: existing } = await adminClient
+          .from('clients')
+          .select('id')
+          .eq('client_code', code)
+          .maybeSingle();
+        if (!existing) break;
+        code = baseCode.slice(0, 2) + i.toString(36).toUpperCase().slice(-1);
+      }
+
+      const { data: newClient, error: clientErr } = await adminClient
+        .from('clients')
+        .insert({ name: account.account_name, client_code: code, is_active: true })
+        .select('id')
+        .single();
+      if (clientErr) {
+        console.error('[owner-invite-user] mirror client create failed:', clientErr.message);
+        return null;
+      }
+      return newClient.id;
+    };
+
+    // ---- Find or create the user ----
+    const { data: existingProfile } = await adminClient
+      .from('profiles')
+      .select('user_id')
+      .eq('email', normalizedEmail)
+      .maybeSingle();
+
+    let userId: string;
+    let isNewUser = false;
+
+    if (existingProfile) {
+      userId = existingProfile.user_id;
+
+      // Already linked to this account?
+      const { data: existingAu } = await adminClient
+        .from('account_users')
+        .select('id')
+        .eq('user_id', userId)
+        .eq('account_id', account_id)
+        .maybeSingle();
+
+      if (existingAu) {
+        return new Response(
+          JSON.stringify({ error: 'This user is already linked to this account' }),
+          { status: 409, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+
+      // Ensure CLIENT role exists
+      const { data: existingRole } = await adminClient
+        .from('user_roles')
+        .select('id, role')
+        .eq('user_id', userId)
+        .maybeSingle();
+
+      if (!existingRole) {
+        const mirrorClientId = await findOrCreateClientId();
+        const { error: roleErr } = await adminClient.from('user_roles').insert({
+          user_id: userId,
+          role: 'CLIENT',
+          client_id: mirrorClientId,
+        });
+        if (roleErr) {
+          return new Response(
+            JSON.stringify({ error: `Failed to assign role: ${roleErr.message}` }),
+            { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+          );
+        }
+      } else if (existingRole.role !== 'CLIENT') {
+        // Don't add ADMIN/OPS users into client accounts via this path
+        return new Response(
+          JSON.stringify({ error: 'Cannot link an internal (ADMIN/OPS) user to a client account from the portal' }),
+          { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+    } else {
+      // New user — invite via Supabase Auth
+      isNewUser = true;
+      const { data: inviteData, error: inviteError } = await adminClient.auth.admin.inviteUserByEmail(normalizedEmail, {
+        data: { name: normalizedEmail.split('@')[0] },
+        redirectTo,
+      });
+
+      if (inviteError || !inviteData.user) {
+        console.error('[owner-invite-user] invite failed:', inviteError?.message);
+        return new Response(
+          JSON.stringify({ error: `Failed to invite user: ${inviteError?.message || 'Unknown error'}` }),
+          { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+
+      userId = inviteData.user.id;
+
+      const mirrorClientId = await findOrCreateClientId();
+      const { error: roleInsertError } = await adminClient.from('user_roles').insert({
+        user_id: userId,
+        role: 'CLIENT',
+        client_id: mirrorClientId,
+      });
+
+      if (roleInsertError) {
+        console.error('[owner-invite-user] role insert failed:', roleInsertError.message);
+        await adminClient.auth.admin.deleteUser(userId);
+        return new Response(
+          JSON.stringify({ error: `Failed to assign role: ${roleInsertError.message}` }),
+          { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+
+      await adminClient.from('profiles').insert({
+        user_id: userId,
+        email: normalizedEmail,
+        name: normalizedEmail.split('@')[0],
+        is_active: true,
+      });
+    }
+
+    // ---- Create account_users record (is_owner ALWAYS false here) ----
+    const { data: accountUser, error: auError } = await adminClient
+      .from('account_users')
+      .insert({
+        user_id: userId,
+        account_id,
+        is_owner: false,
+        can_place_orders: effectiveCanPlaceOrders,
+        can_book_roaster: effectiveCanBookRoaster,
+        can_manage_locations: !!can_manage_locations,
+        can_invite_users: !!can_invite_users,
+        location_access,
+      })
+      .select('id')
+      .single();
+
+    if (auError) {
+      console.error('[owner-invite-user] account_users insert failed:', auError.message);
+      return new Response(
+        JSON.stringify({ error: `Failed to add user to account: ${auError.message}` }),
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    if (location_access === 'ASSIGNED' && assigned_locations.length > 0 && accountUser) {
+      const { error: locError } = await adminClient
+        .from('account_user_locations')
+        .insert(assigned_locations.map((lid) => ({
+          account_user_id: accountUser.id,
+          location_id: lid,
+        })));
+
+      if (locError) {
+        console.error('[owner-invite-user] location assignment failed:', locError.message);
+      }
+    }
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        user_id: userId,
+        account_user_id: accountUser?.id,
+        message: isNewUser
+          ? `Invitation sent to ${normalizedEmail}`
+          : `User added to ${account.account_name}`,
+      }),
+      { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  } catch (error) {
+    console.error('[owner-invite-user] unexpected error:', error);
+    const message = error instanceof Error ? error.message : 'An unexpected error occurred';
+    return new Response(
+      JSON.stringify({ error: message }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+});

--- a/supabase/migrations/20260509212831_9d0b53f4-e04a-43c7-9736-c49cb3279ec0.sql
+++ b/supabase/migrations/20260509212831_9d0b53f4-e04a-43c7-9736-c49cb3279ec0.sql
@@ -1,0 +1,396 @@
+-- Account Owner Self-Service Management
+-- Enables CLIENT users with is_owner=true (or specific permission flags) to manage
+-- their account info, team members, and locations from the client/member portals.
+--
+-- All writes go through SECURITY DEFINER RPCs that enforce:
+--   * Caller is an active owner of the EXACT target account
+--   * Cannot deactivate self
+--   * Cannot remove last active owner
+--   * Allowed fields only on account update
+--   * Program-aware permission grants
+
+-- =============================================================================
+-- 1. RLS SELECT policies (allow account members to read their own data)
+-- =============================================================================
+
+-- Allow any active account member to read their own account row.
+-- Fixes a current bug where Account.tsx queries accounts directly but gets
+-- nothing back because the only existing policy is ADMIN/OPS.
+DROP POLICY IF EXISTS "Account members can read their own account" ON public.accounts;
+CREATE POLICY "Account members can read their own account"
+  ON public.accounts FOR SELECT TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM public.account_users au
+    WHERE au.account_id = accounts.id
+      AND au.user_id = auth.uid()
+      AND au.is_active = true
+  ));
+
+-- Allow account members to read all account_users rows in their account.
+-- The existing "Users can read their own account_users row" policy only exposes
+-- the caller's own row; this broader policy is needed for the team list.
+DROP POLICY IF EXISTS "Account members can read their account team" ON public.account_users;
+CREATE POLICY "Account members can read their account team"
+  ON public.account_users FOR SELECT TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM public.account_users self_au
+    WHERE self_au.account_id = account_users.account_id
+      AND self_au.user_id = auth.uid()
+      AND self_au.is_active = true
+  ));
+
+-- Allow account members to read profiles for everyone in their account
+-- (needed to render team list with names + emails).
+DROP POLICY IF EXISTS "Account members can read teammate profiles" ON public.profiles;
+CREATE POLICY "Account members can read teammate profiles"
+  ON public.profiles FOR SELECT TO authenticated
+  USING (EXISTS (
+    SELECT 1
+    FROM public.account_users teammate
+    JOIN public.account_users self_au
+      ON self_au.account_id = teammate.account_id
+    WHERE teammate.user_id = profiles.user_id
+      AND self_au.user_id = auth.uid()
+      AND self_au.is_active = true
+  ));
+
+-- Allow account members to read account_user_locations for their team.
+DROP POLICY IF EXISTS "Account members can read team account_user_locations" ON public.account_user_locations;
+CREATE POLICY "Account members can read team account_user_locations"
+  ON public.account_user_locations FOR SELECT TO authenticated
+  USING (EXISTS (
+    SELECT 1
+    FROM public.account_users target_au
+    JOIN public.account_users self_au
+      ON self_au.account_id = target_au.account_id
+    WHERE target_au.id = account_user_locations.account_user_id
+      AND self_au.user_id = auth.uid()
+      AND self_au.is_active = true
+  ));
+
+-- =============================================================================
+-- 2. Owner assertion helper
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public._assert_account_owner(_account_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.account_users au
+    WHERE au.account_id = _account_id
+      AND au.user_id = auth.uid()
+      AND au.is_active = true
+      AND au.is_owner = true
+  ) THEN
+    RAISE EXCEPTION 'Not an owner of this account';
+  END IF;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public._assert_account_owner(uuid) FROM PUBLIC, anon;
+
+-- =============================================================================
+-- 3. RPC: owner_update_account
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.owner_update_account(
+  p_account_id uuid,
+  p_account_name text,
+  p_billing_contact_name text DEFAULT NULL,
+  p_billing_email text DEFAULT NULL,
+  p_billing_phone text DEFAULT NULL,
+  p_billing_address text DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_clean_email text;
+BEGIN
+  PERFORM public._assert_account_owner(p_account_id);
+
+  IF p_account_name IS NULL OR TRIM(p_account_name) = '' THEN
+    RAISE EXCEPTION 'Account name is required';
+  END IF;
+
+  v_clean_email := NULLIF(LOWER(TRIM(COALESCE(p_billing_email, ''))), '');
+
+  UPDATE public.accounts
+  SET
+    account_name         = TRIM(p_account_name),
+    billing_contact_name = NULLIF(TRIM(COALESCE(p_billing_contact_name, '')), ''),
+    billing_email        = v_clean_email,
+    billing_phone        = NULLIF(TRIM(COALESCE(p_billing_phone, '')), ''),
+    billing_address      = NULLIF(TRIM(COALESCE(p_billing_address, '')), ''),
+    updated_at           = now()
+  WHERE id = p_account_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.owner_update_account(uuid, text, text, text, text, text) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.owner_update_account(uuid, text, text, text, text, text) TO authenticated;
+
+-- =============================================================================
+-- 4. RPC: owner_update_user_permissions
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.owner_update_user_permissions(
+  p_account_id uuid,
+  p_account_user_id uuid,
+  p_is_owner boolean,
+  p_can_place_orders boolean,
+  p_can_book_roaster boolean,
+  p_can_manage_locations boolean,
+  p_can_invite_users boolean,
+  p_location_access text,
+  p_assigned_location_ids uuid[] DEFAULT '{}'::uuid[]
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_target_user_id uuid;
+  v_target_was_owner boolean;
+  v_active_owner_count int;
+  v_programs text[];
+  v_orphan_location uuid;
+BEGIN
+  PERFORM public._assert_account_owner(p_account_id);
+
+  -- Verify target row belongs to this account; capture current owner status.
+  SELECT user_id, is_owner
+    INTO v_target_user_id, v_target_was_owner
+    FROM public.account_users
+   WHERE id = p_account_user_id
+     AND account_id = p_account_id;
+
+  IF v_target_user_id IS NULL THEN
+    RAISE EXCEPTION 'User not found in this account';
+  END IF;
+
+  -- If revoking owner, ensure at least one other active owner remains.
+  IF v_target_was_owner AND NOT p_is_owner THEN
+    SELECT COUNT(*) INTO v_active_owner_count
+      FROM public.account_users
+     WHERE account_id = p_account_id
+       AND is_owner = true
+       AND is_active = true
+       AND id <> p_account_user_id;
+
+    IF v_active_owner_count < 1 THEN
+      RAISE EXCEPTION 'Cannot remove the last owner from the account';
+    END IF;
+  END IF;
+
+  -- Program-aware permission guardrails.
+  SELECT programs INTO v_programs
+    FROM public.accounts WHERE id = p_account_id;
+
+  IF p_can_place_orders AND NOT ('MANUFACTURING' = ANY(COALESCE(v_programs, ARRAY[]::text[]))) THEN
+    RAISE EXCEPTION 'Cannot grant can_place_orders: account does not have MANUFACTURING program';
+  END IF;
+
+  IF p_can_book_roaster AND NOT ('COROASTING' = ANY(COALESCE(v_programs, ARRAY[]::text[]))) THEN
+    RAISE EXCEPTION 'Cannot grant can_book_roaster: account does not have COROASTING program';
+  END IF;
+
+  IF p_location_access NOT IN ('ALL', 'ASSIGNED') THEN
+    RAISE EXCEPTION 'Invalid location_access value (must be ALL or ASSIGNED)';
+  END IF;
+
+  -- Validate assigned location IDs all belong to this account before any writes.
+  IF p_location_access = 'ASSIGNED' AND COALESCE(array_length(p_assigned_location_ids, 1), 0) > 0 THEN
+    SELECT lid INTO v_orphan_location
+      FROM UNNEST(p_assigned_location_ids) lid
+     WHERE NOT EXISTS (
+       SELECT 1 FROM public.account_locations al
+        WHERE al.id = lid AND al.account_id = p_account_id
+     )
+     LIMIT 1;
+
+    IF v_orphan_location IS NOT NULL THEN
+      RAISE EXCEPTION 'Location % does not belong to this account', v_orphan_location;
+    END IF;
+  END IF;
+
+  UPDATE public.account_users
+  SET
+    is_owner             = p_is_owner,
+    can_place_orders     = p_can_place_orders,
+    can_book_roaster     = p_can_book_roaster,
+    can_manage_locations = p_can_manage_locations,
+    can_invite_users     = p_can_invite_users,
+    location_access      = p_location_access,
+    updated_at           = now()
+  WHERE id = p_account_user_id
+    AND account_id = p_account_id;
+
+  -- Replace location assignments.
+  DELETE FROM public.account_user_locations
+   WHERE account_user_id = p_account_user_id;
+
+  IF p_location_access = 'ASSIGNED' AND COALESCE(array_length(p_assigned_location_ids, 1), 0) > 0 THEN
+    INSERT INTO public.account_user_locations (account_user_id, location_id)
+    SELECT p_account_user_id, lid FROM UNNEST(p_assigned_location_ids) lid;
+  END IF;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.owner_update_user_permissions(uuid, uuid, boolean, boolean, boolean, boolean, boolean, text, uuid[]) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.owner_update_user_permissions(uuid, uuid, boolean, boolean, boolean, boolean, boolean, text, uuid[]) TO authenticated;
+
+-- =============================================================================
+-- 5. RPC: owner_deactivate_user
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.owner_deactivate_user(
+  p_account_id uuid,
+  p_account_user_id uuid
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_target_user_id uuid;
+  v_target_is_owner boolean;
+  v_target_is_active boolean;
+  v_active_owner_count int;
+BEGIN
+  PERFORM public._assert_account_owner(p_account_id);
+
+  SELECT user_id, is_owner, is_active
+    INTO v_target_user_id, v_target_is_owner, v_target_is_active
+    FROM public.account_users
+   WHERE id = p_account_user_id
+     AND account_id = p_account_id;
+
+  IF v_target_user_id IS NULL THEN
+    RAISE EXCEPTION 'User not found in this account';
+  END IF;
+
+  IF v_target_user_id = auth.uid() THEN
+    RAISE EXCEPTION 'Cannot deactivate your own account';
+  END IF;
+
+  -- If target is an active owner, ensure at least one other active owner remains.
+  IF v_target_is_owner AND v_target_is_active THEN
+    SELECT COUNT(*) INTO v_active_owner_count
+      FROM public.account_users
+     WHERE account_id = p_account_id
+       AND is_owner = true
+       AND is_active = true
+       AND id <> p_account_user_id;
+
+    IF v_active_owner_count < 1 THEN
+      RAISE EXCEPTION 'Cannot deactivate the last active owner';
+    END IF;
+  END IF;
+
+  UPDATE public.account_users
+  SET is_active = false,
+      updated_at = now()
+  WHERE id = p_account_user_id
+    AND account_id = p_account_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.owner_deactivate_user(uuid, uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.owner_deactivate_user(uuid, uuid) TO authenticated;
+
+-- =============================================================================
+-- 6. RPC: owner_create_location (manufacturing accounts only)
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.owner_create_location(
+  p_account_id uuid,
+  p_location_name text,
+  p_location_code text,
+  p_address text DEFAULT NULL,
+  p_qbo_billing_entity text DEFAULT NULL
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_new_id uuid;
+  v_caller_can_manage boolean;
+  v_clean_code text;
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  -- Allow either owner OR member with can_manage_locations.
+  SELECT (is_owner OR can_manage_locations) INTO v_caller_can_manage
+    FROM public.account_users
+   WHERE account_id = p_account_id
+     AND user_id = auth.uid()
+     AND is_active = true;
+
+  IF NOT COALESCE(v_caller_can_manage, false) THEN
+    RAISE EXCEPTION 'Not authorized to manage locations for this account';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.accounts
+     WHERE id = p_account_id
+       AND 'MANUFACTURING' = ANY(COALESCE(programs, ARRAY[]::text[]))
+  ) THEN
+    RAISE EXCEPTION 'Location management is only available for accounts with the MANUFACTURING program';
+  END IF;
+
+  IF p_location_name IS NULL OR TRIM(p_location_name) = '' THEN
+    RAISE EXCEPTION 'Location name is required';
+  END IF;
+
+  IF p_location_code IS NULL OR TRIM(p_location_code) = '' THEN
+    RAISE EXCEPTION 'Location code is required';
+  END IF;
+
+  v_clean_code := UPPER(TRIM(p_location_code));
+
+  -- Reject duplicate location_code within the same account.
+  IF EXISTS (
+    SELECT 1 FROM public.account_locations
+     WHERE account_id = p_account_id
+       AND UPPER(location_code) = v_clean_code
+  ) THEN
+    RAISE EXCEPTION 'A location with code % already exists for this account', v_clean_code;
+  END IF;
+
+  INSERT INTO public.account_locations (
+    account_id, location_name, location_code, address, qbo_billing_entity, is_active
+  )
+  VALUES (
+    p_account_id,
+    TRIM(p_location_name),
+    v_clean_code,
+    NULLIF(TRIM(COALESCE(p_address, '')), ''),
+    NULLIF(TRIM(COALESCE(p_qbo_billing_entity, '')), ''),
+    true
+  )
+  RETURNING id INTO v_new_id;
+
+  RETURN v_new_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.owner_create_location(uuid, text, text, text, text) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.owner_create_location(uuid, text, text, text, text) TO authenticated;


### PR DESCRIPTION
## Summary

- Account owners (`is_owner=true` in `account_users`) can now manage their account directly from the client portal (`/portal/account`) and member portal (`/member-portal/account`) — no admin required
- All writes are server-enforced via SECURITY DEFINER RPCs; UI gates are layered on top
- Fixes an existing bug where `Account.tsx` always showed "No company information available" because `accounts` had no CLIENT SELECT RLS policy

## What changed

### Database (migration `20260509212831`)
- **4 RLS SELECT policies**: accounts (own row), account_users (full team), profiles (teammates), account_user_locations (team assignments)
- **`_assert_account_owner(uuid)`**: shared SECURITY DEFINER helper, called by all write RPCs
- **`owner_update_account`**: update 5 billing fields only — no other columns reachable
- **`owner_update_user_permissions`**: edit team member permissions; last-owner guard; program-aware filtering (`can_place_orders` requires MANUFACTURING, `can_book_roaster` requires COROASTING); replaces location assignments atomically
- **`owner_deactivate_user`**: soft-delete with self-deactivate and last-active-owner guards
- **`owner_create_location`**: MANUFACTURING accounts only; owner or `can_manage_locations`; duplicate code check

### Edge function (`supabase/functions/owner-invite-user/`)
- Caller must be active owner OR have `can_invite_users=true` on the target account
- `is_owner` always hardcoded `false` — promotion via `owner_update_user_permissions` after user exists
- Rejects ADMIN/OPS users being added to client accounts via portal path
- Program-aware permission filtering; validates assigned location IDs belong to account

### Frontend
- **`AuthContext`**: now fetches and exposes `authUser.programs: string[]` for CLIENT users (one extra query after `account_users` fetch)
- **`useAccountTeam`**: fetch all `account_users` + profiles + `account_user_locations` for an account
- **`useAccountLocations`**: fetch `account_locations` for an account
- **`src/components/account-management/`** (5 new components + 1 rpc helper):
  - `AccountInfoForm` — 5-field edit form, owner-gated Edit button
  - `TeamMemberList` — member rows with permission badges, invite/edit/deactivate actions
  - `EditUserPermissionsDialog` — owner toggle (locked when last owner), program-filtered checkboxes, location picker
  - `InviteUserDialog` — email + permissions; no `is_owner` exposed; calls `owner-invite-user` edge function
  - `LocationManagementSection` — list + add location with "Bill separately?" toggle (requires QBO billing name + shows admin callout when on)
  - `ownerRpc.ts` — typed wrapper for new RPCs until `supabase gen types` is re-run
- **`Account.tsx`** (manufacturing portal): fully rewritten with tabs — Account Info / Team / Locations (Locations tab only shown for MANUFACTURING accounts)
- **`MemberAccount.tsx`** (member portal): keeps coroast metadata card; adds Account Info / Team tabs; all mutations disabled in preview mode

## Guardrails

| Rule | Enforcement |
|------|-------------|
| Owner-only writes | `_assert_account_owner` in every write RPC |
| Account scope | RPCs verify `account_id` param matches caller's membership |
| Allowed fields only | `owner_update_account` touches exactly 5 columns |
| No self-deactivate | `owner_deactivate_user` checks `target.user_id != auth.uid()` |
| Last-owner protection | Active owner count check in deactivate + revoke paths |
| No owner grant via invite | Edge function hardcodes `is_owner=false` |
| Program-aware grants | Both RPC and edge function filter against `accounts.programs` |
| Preview mode read-only | `MemberAccount` passes `readOnly={isPreviewMode}` to all components |

## Post-merge steps

1. Apply migration via Supabase dashboard or `supabase db push`
2. Deploy edge function: `supabase functions deploy owner-invite-user`
3. Regenerate types: `supabase gen types typescript --project-id cgdzjkryygwlyygeznrb > src/integrations/supabase/types.ts` — then delete `ownerRpc.ts` and switch to direct `supabase.rpc()` calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)