### PR TITLE
feat: admin preview of client portal for manufacturing accounts

### DIFF
--- a/src/components/layout/ClientLayout.tsx
+++ b/src/components/layout/ClientLayout.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { NavLink, useNavigate } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
+import { usePreview } from '@/contexts/PreviewContext';
 import { Button } from '@/components/ui/button';
 import { AccountSheet } from '@/components/account/AccountSheet';
 import {
@@ -11,7 +12,8 @@ import {
   LogOut,
   Menu,
   X,
-  ShoppingBag
+  ShoppingBag,
+  Eye,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import hiIcon from '@/assets/home-island-icon.png';
@@ -32,6 +34,7 @@ const navItems = [
 export function ClientLayout({ children }: ClientLayoutProps) {
   const { authUser, signOut } = useAuth();
   const navigate = useNavigate();
+  const { isPreviewMode, previewAccountName, previewAccountId, exitPreview } = usePreview();
   const [sidebarOpen, setSidebarOpen] = React.useState(false);
   const [accountSheetOpen, setAccountSheetOpen] = React.useState(false);
 
@@ -134,6 +137,28 @@ export function ClientLayout({ children }: ClientLayoutProps) {
             </div>
           </div>
         </header>
+
+        {/* Preview banner */}
+        {isPreviewMode && (
+          <div className="sticky top-0 z-[60] flex items-center justify-between gap-4 bg-amber-400 px-4 py-2 text-amber-950">
+            <div className="flex items-center gap-2 text-sm font-medium">
+              <Eye className="h-4 w-4" />
+              Previewing as {previewAccountName}
+            </div>
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-7 border-amber-600 bg-amber-300 text-amber-950 hover:bg-amber-200"
+              onClick={() => {
+                const id = previewAccountId;
+                exitPreview();
+                navigate(`/accounts/${id}`);
+              }}
+            >
+              Exit Preview
+            </Button>
+          </div>
+        )}
 
         {/* Page content - uses same page-container styling */}
         <main className="flex-1 overflow-y-auto">

--- a/src/pages/client/Account.tsx
+++ b/src/pages/client/Account.tsx
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useAuth } from '@/contexts/AuthContext';
+import { usePreview } from '@/contexts/PreviewContext';
 import { supabase } from '@/integrations/supabase/client';
 import { AccountInfoForm } from '@/components/account-management/AccountInfoForm';
 import { TeamMemberList } from '@/components/account-management/TeamMemberList';
@@ -9,7 +10,8 @@ import { LocationManagementSection } from '@/components/account-management/Locat
 
 export default function Account() {
   const { authUser } = useAuth();
-  const accountId = authUser?.accountId ?? null;
+  const { previewAccountId } = usePreview();
+  const accountId = previewAccountId ?? authUser?.accountId ?? null;
 
   const { data: account, isLoading } = useQuery({
     queryKey: ['client-account', accountId],

--- a/src/pages/client/NewOrder.tsx
+++ b/src/pages/client/NewOrder.tsx
@@ -12,8 +12,9 @@ import { Separator } from '@/components/ui/separator';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
+import { usePreview } from '@/contexts/PreviewContext';
 import { toast } from 'sonner';
-import { Plus, Minus, Trash2, Package } from 'lucide-react';
+import { Plus, Minus, Trash2, Package, Eye } from 'lucide-react';
 import { GramPackagingBadge, formatGramsLabel } from '@/components/GramPackagingBadge';
 import { UnusualOrderModal, type FlaggedItem } from '@/components/client/UnusualOrderModal';
 import { LocationSelect } from '@/components/orders/LocationSelect';
@@ -57,6 +58,7 @@ function buildDisplayName(productName: string, packagingTypeName: string | null,
 
 export default function NewOrder() {
   const { authUser } = useAuth();
+  const { isPreviewMode } = usePreview();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
@@ -670,6 +672,13 @@ export default function NewOrder() {
         <h1 className="page-title">New Order</h1>
       </div>
 
+      {isPreviewMode && (
+        <Alert className="mb-4 border-amber-400 bg-amber-50 text-amber-900">
+          <Eye className="h-4 w-4" />
+          <AlertDescription>Preview mode — order submission is disabled.</AlertDescription>
+        </Alert>
+      )}
+
       <div className="grid gap-6 lg:grid-cols-[1fr,400px]">
         {/* Left: Product List */}
         <Card>
@@ -899,7 +908,7 @@ export default function NewOrder() {
               <Button
                 className="w-full"
                 onClick={handleSubmitClick}
-                disabled={submitting || lineItems.length === 0}
+                disabled={isPreviewMode || submitting || lineItems.length === 0}
               >
                 {submitting ? 'Submitting…' : 'Submit Order'}
               </Button>

--- a/src/pages/client/OrderHistory.tsx
+++ b/src/pages/client/OrderHistory.tsx
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { supabase } from '@/integrations/supabase/client';
+import { usePreview } from '@/contexts/PreviewContext';
 import { format } from 'date-fns';
 import { ArrowLeft } from 'lucide-react';
 import { toast } from 'sonner';
@@ -29,15 +30,17 @@ interface LineItemSummary {
 
 export default function OrderHistory() {
   const queryClient = useQueryClient();
+  const { previewAccountId } = usePreview();
   const [selectedOrderId, setSelectedOrderId] = useState<string | null>(null);
 
   const { data: orders, isLoading, error } = useQuery({
-    queryKey: ['client-orders'],
+    queryKey: ['client-orders', previewAccountId],
     queryFn: async () => {
-      const { data, error } = await supabase
+      let q = supabase
         .from('orders')
-        .select('id, order_number, status, requested_ship_date, work_deadline_at, delivery_method, client_po, client_notes, created_at, location_id')
-        .order('created_at', { ascending: false });
+        .select('id, order_number, status, requested_ship_date, work_deadline_at, delivery_method, client_po, client_notes, created_at, location_id');
+      if (previewAccountId) q = q.eq('account_id', previewAccountId);
+      const { data, error } = await q.order('created_at', { ascending: false });
 
       if (error) throw error;
       return (data ?? []) as Order[];

--- a/src/pages/client/Portal.tsx
+++ b/src/pages/client/Portal.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Button } from '@/components/ui/button';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
+import { usePreview } from '@/contexts/PreviewContext';
 import { format } from 'date-fns';
 import { PlusCircle, Package, Truck, Clock, CheckCircle2 } from 'lucide-react';
 import { LocationCodeDisplay } from '@/components/orders/LocationSelect';
@@ -24,14 +25,16 @@ interface Order {
 export default function Portal() {
   const navigate = useNavigate();
   const { authUser } = useAuth();
+  const { previewAccountId } = usePreview();
 
   const { data: orders, isLoading } = useQuery({
-    queryKey: ['client-portal-orders'],
+    queryKey: ['client-portal-orders', previewAccountId],
     queryFn: async () => {
-      const { data, error } = await supabase
+      let q = supabase
         .from('orders')
-        .select('id, order_number, status, requested_ship_date, delivery_method, created_at, location_id, shipped_or_ready, invoiced')
-        .order('created_at', { ascending: false });
+        .select('id, order_number, status, requested_ship_date, delivery_method, created_at, location_id, shipped_or_ready, invoiced');
+      if (previewAccountId) q = q.eq('account_id', previewAccountId);
+      const { data, error } = await q.order('created_at', { ascending: false });
 
       if (error) throw error;
       return (data ?? []) as Order[];

--- a/src/pages/client/Products.tsx
+++ b/src/pages/client/Products.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
+import { usePreview } from '@/contexts/PreviewContext';
 import { Package } from 'lucide-react';
 
 interface AllowedProduct {
@@ -19,6 +20,8 @@ interface AllowedProduct {
 
 export default function Products() {
   const { authUser } = useAuth();
+  const { previewAccountId } = usePreview();
+  const effectiveAccountId = previewAccountId ?? authUser?.accountId;
 
   // TODO: Wire this query once RLS is confirmed for client_allowed_products reads by account_id.
   // Fetches all products this account is allowed to order.
@@ -28,18 +31,18 @@ export default function Products() {
   //     .select('product_id, products(id, product_name, sku, bag_size_g, format, packaging_variant)')
   //     .eq('account_id', authUser?.accountId)
   const { data: allowedProducts, isLoading: productsLoading } = useQuery({
-    queryKey: ['client-allowed-products', authUser?.accountId],
+    queryKey: ['client-allowed-products', effectiveAccountId],
     queryFn: async () => {
       // account_id column was added via migration after types were generated,
       // so cast to any to avoid stale type error.
       const { data, error } = await (supabase as any)
         .from('client_allowed_products')
         .select('product_id, products(id, product_name, sku, bag_size_g, format, packaging_variant)')
-        .eq('account_id', authUser!.accountId!);
+        .eq('account_id', effectiveAccountId!);
       if (error) throw error;
       return (data ?? []) as AllowedProduct[];
     },
-    enabled: !!authUser?.accountId,
+    enabled: !!effectiveAccountId,
   });
 
   // TODO: Wire price lookup. Fetches latest price per product from price_list.

--- a/src/pages/internal/AccountDetail.tsx
+++ b/src/pages/internal/AccountDetail.tsx
@@ -1518,19 +1518,35 @@ export default function AccountDetail() {
           {hasCoroasting && <Badge variant="outline" className="border-amber-500 text-amber-600">Co-Roasting</Badge>}
           {!account.is_active && <Badge variant="destructive">Inactive</Badge>}
         </div>
-        {hasCoroasting && authUser?.role === 'ADMIN' && (
-          <Button
-            variant="outline"
-            size="sm"
-            className="ml-auto"
-            onClick={() => {
-              enterPreview(account.id, account.account_name);
-              navigate('/member-portal');
-            }}
-          >
-            <Eye className="h-4 w-4 mr-1.5" />
-            Preview Portal
-          </Button>
+        {authUser?.role === 'ADMIN' && (hasManufacturing || hasCoroasting) && (
+          <div className="ml-auto flex items-center gap-2">
+            {hasManufacturing && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  enterPreview(account.id, account.account_name);
+                  navigate('/portal');
+                }}
+              >
+                <Eye className="h-4 w-4 mr-1.5" />
+                Preview Client Portal
+              </Button>
+            )}
+            {hasCoroasting && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  enterPreview(account.id, account.account_name);
+                  navigate('/member-portal');
+                }}
+              >
+                <Eye className="h-4 w-4 mr-1.5" />
+                Preview Member Portal
+              </Button>
+            )}
+          </div>
         )}
       </div>
 


### PR DESCRIPTION
## Summary

Extends the existing admin "Preview Member Portal" pattern (co-roasting) to manufacturing clients. From an account detail page an admin can now click **Preview Client Portal** to view `/portal/*` as that account would see it, with an amber banner and Exit button.

- **AccountDetail.tsx**: single co-roasting preview button replaced with two side-by-side buttons — `Preview Client Portal` (MANUFACTURING) and `Preview Member Portal` (COROASTING). Existing co-roasting behavior unchanged.
- **ClientLayout.tsx**: amber `Previewing as {name}` banner + Exit button (returns to `/accounts/{id}`), mirroring `MemberPortalLayout`.
- **Portal.tsx / OrderHistory.tsx**: orders query explicitly filters by `account_id` in preview mode. Required because client pages rely on RLS for scoping, and the ADMIN role bypasses RLS.
- **Products.tsx / Account.tsx**: use `previewAccountId ?? authUser?.accountId`.
- **NewOrder.tsx**: amber alert + Submit button disabled in preview to block accidental order creation.

Reuses existing `PreviewContext` (sessionStorage-backed) and `ProtectedRoute`'s `isPreviewMode` bypass for ADMIN through CLIENT routes — no changes needed there.

## What does NOT change

- `MemberPortalLayout` and `/member-portal/*` pages untouched.
- `PreviewContext` untouched.
- Existing co-roasting preview button preserved, just joined by a sibling.

## Test plan

- [ ] As ADMIN, open `/accounts/{id}` for a MANUFACTURING-only account → only `Preview Client Portal` button shows.
- [ ] As ADMIN, open `/accounts/{id}` for a COROASTING-only account → only `Preview Member Portal` button shows (existing behavior).
- [ ] Open an account with both programs → both buttons shown side-by-side.
- [ ] Click `Preview Client Portal`:
  - [ ] Amber banner appears at top of `/portal` with account name.
  - [ ] Home page shows only that account's orders (not all orders).
  - [ ] Order history shows only that account's orders.
  - [ ] Products page shows the previewed account's allowed products.
  - [ ] Account page shows the previewed account's profile.
  - [ ] New Order page shows preview alert and Submit Order is disabled.
- [ ] Click Exit Preview → returns to `/accounts/{id}` and banner clears.
- [ ] Existing `Preview Member Portal` flow still works exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)