### PR TITLE
feat: co-roasting prospect invitation landing page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,6 +63,7 @@ import MemberBilling from "@/pages/member/MemberBilling";
 import MemberAccount from "@/pages/member/MemberAccount";
 import MyNumbers from "@/pages/member/MyNumbers";
 import NotFound from "@/pages/NotFound";
+import ExplorePage from "@/pages/public/ExplorePage";
 
 const queryClient = new QueryClient();
 
@@ -75,10 +76,11 @@ const App = () => (
         <PreviewProvider>
         <AuthProvider>
           <Routes>
-            {/* Public auth routes */}
+            {/* Public routes — no auth required */}
             <Route path="/auth" element={<Auth />} />
             <Route path="/auth/callback" element={<AuthCallback />} />
             <Route path="/auth/set-password" element={<SetPassword />} />
+            <Route path="/explore/:token" element={<ExplorePage />} />
             <Route path="/" element={<Navigate to="/auth" replace />} />
 
             {/* Internal (Admin/Ops) */}

--- a/src/components/dashboard/CoRoastingTab.tsx
+++ b/src/components/dashboard/CoRoastingTab.tsx
@@ -30,6 +30,28 @@ export function CoRoastingTab({ enabled }: { enabled: boolean }) {
     },
   });
 
+  // Section A2 — Pending expressions of interest
+  const { data: pendingSubmissions, isLoading: loadingSubmissions } = useQuery({
+    queryKey: ['dashboard-coroast-submissions'],
+    enabled,
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('coroast_prospect_submissions' as any)
+        .select('id, selected_tier, submitted_at, prospect_id, prospects(business_name)')
+        .eq('status', 'PENDING')
+        .order('submitted_at', { ascending: false })
+        .limit(20);
+      if (error) throw error;
+      return (data ?? []) as Array<{
+        id: string;
+        selected_tier: string | null;
+        submitted_at: string;
+        prospect_id: string;
+        prospects: { business_name: string } | null;
+      }>;
+    },
+  });
+
   // Section B — Members with incomplete certification
   const { data: incompleteChecklist, isLoading: loadingChecklist } = useQuery({
     queryKey: ['dashboard-coroast-checklist'],
@@ -162,6 +184,39 @@ export function CoRoastingTab({ enabled }: { enabled: boolean }) {
           )}
         </CardContent>
       </Card>
+
+      {/* Section A2 — Expressions of Interest */}
+      {(!!pendingSubmissions?.length || loadingSubmissions) && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Pending Expressions of Interest</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {loadingSubmissions ? (
+              <p className="text-sm text-muted-foreground">Loading…</p>
+            ) : (
+              <div className="space-y-2">
+                {pendingSubmissions!.map((s) => (
+                  <div key={s.id} className="flex items-center justify-between text-sm border-b last:border-0 pb-2 last:pb-0">
+                    <div className="flex items-center gap-3">
+                      <span className="font-medium">{s.prospects?.business_name || 'Unknown'}</span>
+                      <span className="text-muted-foreground">{s.selected_tier}</span>
+                    </div>
+                    <div className="flex items-center gap-3">
+                      <span className="text-xs text-muted-foreground">
+                        {format(new Date(s.submitted_at), 'MMM d')}
+                      </span>
+                      <Link to={`/prospects/${s.prospect_id}`} className="text-primary hover:underline text-xs">
+                        View prospect
+                      </Link>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      )}
 
       {/* Section B */}
       <Card>

--- a/src/components/layout/ExploreLayout.tsx
+++ b/src/components/layout/ExploreLayout.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import hiLogo from '@/assets/home-island-logo.png';
+
+export function ExploreLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen bg-hi-cream font-brand flex flex-col">
+      <header className="bg-hi-navy py-4 px-6 flex items-center gap-3">
+        <img src={hiLogo} alt="Home Island Coffee Partners" className="h-10" />
+        <div className="text-hi-sand">
+          <p className="font-bold tracking-wide text-sm leading-tight">Home Island</p>
+          <p className="text-[10px] uppercase tracking-[0.18em] opacity-70 leading-tight">Coffee Partners</p>
+        </div>
+      </header>
+      <main className="flex-1">{children}</main>
+      <footer className="bg-hi-navy text-hi-sand/50 text-xs py-6 text-center">
+        © {new Date().getFullYear()} Home Island Coffee Partners · homeislandcoffee.com
+      </footer>
+    </div>
+  );
+}

--- a/src/pages/internal/ProspectDetail.tsx
+++ b/src/pages/internal/ProspectDetail.tsx
@@ -13,9 +13,36 @@ import { Badge } from '@/components/ui/badge';
 import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
-import { ArrowLeft, Copy, Check, FileText, Plus, CheckCircle2, ExternalLink } from 'lucide-react';
+import { ArrowLeft, Copy, Check, FileText, Plus, CheckCircle2, ExternalLink, Send, RotateCcw, Ban, Eye } from 'lucide-react';
 import type { Database } from '@/integrations/supabase/types';
 import { PronounsField } from '@/components/contacts/PronounsField';
+
+interface InvitationRow {
+  id: string;
+  token: string;
+  invited_at: string;
+  expires_at: string;
+  resent_at: string | null;
+  retired_at: string | null;
+}
+
+interface SubmissionRow {
+  id: string;
+  selected_tier: string | null;
+  company_name: string | null;
+  contact_name: string | null;
+  contact_email: string | null;
+  contact_phone: string | null;
+  billing_address_line1: string | null;
+  billing_address_line2: string | null;
+  billing_city: string | null;
+  billing_province: string | null;
+  billing_postal_code: string | null;
+  estimated_monthly_kg: number | null;
+  notes: string | null;
+  submitted_at: string;
+  status: string;
+}
 
 type ProspectStream = Database['public']['Enums']['prospect_stream'];
 type ProspectStage = Database['public']['Enums']['prospect_stage'];
@@ -66,9 +93,20 @@ export default function ProspectDetail() {
   const [noteText, setNoteText] = useState('');
   const [followUpBy, setFollowUpBy] = useState('');
 
+  // Email
+  const [formProspectEmail, setFormProspectEmail] = useState('');
+
   // Brief Me
   const [briefOpen, setBriefOpen] = useState(false);
   const [briefCopied, setBriefCopied] = useState(false);
+
+  // Invitation
+  const [inviteLoading, setInviteLoading] = useState(false);
+  const [retireConfirmOpen, setRetireConfirmOpen] = useState(false);
+
+  // Submission viewer
+  const [submissionOpen, setSubmissionOpen] = useState(false);
+  const [selectedSubmission, setSelectedSubmission] = useState<SubmissionRow | null>(null);
 
   // Convert modal
   const [convertOpen, setConvertOpen] = useState(false);
@@ -174,12 +212,39 @@ export default function ProspectDetail() {
     },
   });
 
+  const { data: invitation, refetch: refetchInvitation } = useQuery({
+    queryKey: ['prospect-invitation', id],
+    enabled: !!id,
+    queryFn: async () => {
+      const { data } = await supabase
+        .from('coroast_prospect_invitations' as any)
+        .select('id, token, invited_at, expires_at, resent_at, retired_at')
+        .eq('prospect_id', id!)
+        .maybeSingle();
+      return (data ?? null) as InvitationRow | null;
+    },
+  });
+
+  const { data: submissions = [], refetch: refetchSubmissions } = useQuery({
+    queryKey: ['prospect-submissions', id],
+    enabled: !!id,
+    queryFn: async () => {
+      const { data } = await supabase
+        .from('coroast_prospect_submissions' as any)
+        .select('id, selected_tier, company_name, contact_name, contact_email, contact_phone, billing_address_line1, billing_address_line2, billing_city, billing_province, billing_postal_code, estimated_monthly_kg, notes, submitted_at, status')
+        .eq('prospect_id', id!)
+        .order('submitted_at', { ascending: false });
+      return (data ?? []) as SubmissionRow[];
+    },
+  });
+
   // Initialize form when prospect loads
   useEffect(() => {
     if (prospect && !formDirty) {
       setFormBusinessName(prospect.business_name);
       setFormContactName(prospect.contact_name || '');
       setFormContactInfo(prospect.contact_info || '');
+      setFormProspectEmail((prospect as any).prospect_email || '');
       setFormPronouns((prospect as any).pronouns ?? null);
       setFormStream(prospect.stream as ProspectStream);
       setFormStage(prospect.stage as ProspectStage);
@@ -194,6 +259,7 @@ export default function ProspectDetail() {
           business_name: formBusinessName.trim(),
           contact_name: formContactName.trim() || null,
           contact_info: formContactInfo.trim() || null,
+          prospect_email: formProspectEmail.trim() || null,
           pronouns: formPronouns ? formPronouns.trim() || null : null,
           stream: formStream,
           stage: formStage,
@@ -240,6 +306,34 @@ export default function ProspectDetail() {
     setConvertOpen(true);
   };
 
+  const handleSendInvitation = async () => {
+    setInviteLoading(true);
+    try {
+      const { data, error } = await supabase.functions.invoke('send-prospect-invitation', {
+        body: { prospect_id: id },
+      });
+      const errMsg = (error?.message || (data as any)?.error) as string | undefined;
+      if (errMsg) throw new Error(errMsg === 'no_email' ? 'Add an email address before sending.' : errMsg);
+      toast.success(invitation ? 'Invitation resent' : 'Invitation sent');
+      refetchInvitation();
+    } catch (err: any) {
+      toast.error(err.message || 'Failed to send invitation');
+    } finally {
+      setInviteLoading(false);
+    }
+  };
+
+  const handleRetireInvitation = async () => {
+    if (!invitation) return;
+    await supabase
+      .from('coroast_prospect_invitations' as any)
+      .update({ retired_at: new Date().toISOString() })
+      .eq('id', invitation.id);
+    refetchInvitation();
+    setRetireConfirmOpen(false);
+    toast.success('Invitation retired');
+  };
+
   const handleConvertToAccount = async () => {
     if (!prospect || (!convertMfg && !convertCoroast)) return;
     setConvertLoading(true);
@@ -270,6 +364,21 @@ export default function ProspectDetail() {
         .from('prospects')
         .update({ converted: true, converted_to_account_id: account.id } as any)
         .eq('id', id!);
+
+      // Retire invitation and mark submission converted if they exist
+      if (invitation) {
+        await supabase
+          .from('coroast_prospect_invitations' as any)
+          .update({ retired_at: new Date().toISOString() })
+          .eq('id', invitation.id);
+      }
+      const latestPending = submissions.find(s => s.status === 'PENDING');
+      if (latestPending) {
+        await supabase
+          .from('coroast_prospect_submissions' as any)
+          .update({ status: 'CONVERTED' })
+          .eq('id', latestPending.id);
+      }
 
       toast.success('Converted to Account');
       navigate(`/accounts/${account.id}`);
@@ -384,11 +493,20 @@ export default function ProspectDetail() {
               onChange={(next) => { setFormPronouns(next); setFormDirty(true); }}
             />
             <div>
-              <Label>Email / Phone</Label>
+              <Label>Email</Label>
+              <Input
+                type="email"
+                value={formProspectEmail}
+                onChange={(e) => { setFormProspectEmail(e.target.value); setFormDirty(true); }}
+                placeholder="hello@example.com"
+              />
+            </div>
+            <div>
+              <Label>Phone / Other Contact</Label>
               <Input
                 value={formContactInfo}
                 onChange={(e) => { setFormContactInfo(e.target.value); setFormDirty(true); }}
-                placeholder="email@example.com | 604-555-1234"
+                placeholder="604-555-1234"
               />
             </div>
             <div>
@@ -548,7 +666,130 @@ export default function ProspectDetail() {
         </CardContent>
       </Card>
 
-      {/* Section 4: Convert */}
+      {/* Section 4: Explore Invitation (co-roast prospects only) */}
+      {(prospect.stream === 'CO_ROAST' || prospect.stream === 'BOTH') && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Explore Invitation</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {/* No invitation yet */}
+            {!invitation && (
+              <div className="space-y-2">
+                <p className="text-sm text-muted-foreground">
+                  Send a private link so this prospect can explore co-roasting tiers, run their numbers, and express interest.
+                </p>
+                {!((prospect as any).prospect_email) && (
+                  <p className="text-xs text-amber-600">Add an email address above before sending.</p>
+                )}
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="gap-1.5"
+                  disabled={inviteLoading || !((prospect as any).prospect_email)}
+                  onClick={handleSendInvitation}
+                >
+                  <Send className="h-3.5 w-3.5" />
+                  {inviteLoading ? 'Sending…' : 'Send Invitation'}
+                </Button>
+              </div>
+            )}
+
+            {/* Active invitation */}
+            {invitation && invitation.retired_at === null && new Date(invitation.expires_at) > new Date() && (
+              <div className="space-y-3">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <Badge className="bg-green-600 text-white">Active</Badge>
+                  <span className="text-xs text-muted-foreground">
+                    {invitation.resent_at
+                      ? `Last sent ${format(new Date(invitation.resent_at), 'MMM d, yyyy')}`
+                      : `Sent ${format(new Date(invitation.invited_at), 'MMM d, yyyy')}`}
+                    {' · '}expires {format(new Date(invitation.expires_at), 'MMM d, yyyy')}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <code className="text-xs bg-muted px-2 py-1 rounded truncate max-w-xs">
+                    {`${window.location.origin}/explore/${invitation.token}`}
+                  </code>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => {
+                      navigator.clipboard.writeText(`${window.location.origin}/explore/${invitation.token}`);
+                      toast.success('Link copied');
+                    }}
+                  >
+                    <Copy className="h-3.5 w-3.5" />
+                  </Button>
+                </div>
+                <div className="flex gap-2">
+                  <Button variant="outline" size="sm" className="gap-1.5" disabled={inviteLoading} onClick={handleSendInvitation}>
+                    <RotateCcw className="h-3.5 w-3.5" />
+                    {inviteLoading ? 'Sending…' : 'Resend'}
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="gap-1.5 text-muted-foreground"
+                    onClick={() => setRetireConfirmOpen(true)}
+                  >
+                    <Ban className="h-3.5 w-3.5" />
+                    Retire
+                  </Button>
+                </div>
+              </div>
+            )}
+
+            {/* Expired invitation */}
+            {invitation && invitation.retired_at === null && new Date(invitation.expires_at) <= new Date() && (
+              <div className="space-y-2">
+                <Badge variant="secondary">Expired</Badge>
+                <Button variant="outline" size="sm" className="gap-1.5" disabled={inviteLoading} onClick={handleSendInvitation}>
+                  <Send className="h-3.5 w-3.5" />
+                  {inviteLoading ? 'Sending…' : 'Resend Invitation'}
+                </Button>
+              </div>
+            )}
+
+            {/* Retired invitation */}
+            {invitation && invitation.retired_at !== null && (
+              <div className="space-y-2">
+                <Badge variant="outline">Retired</Badge>
+                <p className="text-xs text-muted-foreground">Invitation retired — prospect converted to account.</p>
+              </div>
+            )}
+
+            {/* Submissions */}
+            {submissions.length > 0 && (
+              <div className="border-t pt-3 space-y-2">
+                <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                  Expressions of Interest ({submissions.length})
+                </p>
+                {submissions.map((sub) => (
+                  <div key={sub.id} className="flex items-center justify-between text-sm border rounded-md px-3 py-2">
+                    <div>
+                      <span className="font-medium">{sub.selected_tier ?? '—'}</span>
+                      <span className="text-muted-foreground ml-2 text-xs">
+                        {format(new Date(sub.submitted_at), 'MMM d, yyyy')}
+                      </span>
+                      <Badge variant="outline" className="ml-2 text-xs">{sub.status}</Badge>
+                    </div>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => { setSelectedSubmission(sub); setSubmissionOpen(true); }}
+                    >
+                      <Eye className="h-3.5 w-3.5" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Section 5: Convert */}
       {(showConvert || prospect.converted) && (
         <Card>
           <CardHeader>
@@ -613,6 +854,61 @@ export default function ProspectDetail() {
               </Button>
             </div>
           </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Retire Confirmation */}
+      <Dialog open={retireConfirmOpen} onOpenChange={setRetireConfirmOpen}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Retire invitation?</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">The link will stop working immediately.</p>
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="ghost" onClick={() => setRetireConfirmOpen(false)}>Cancel</Button>
+            <Button variant="destructive" onClick={handleRetireInvitation}>Retire</Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Submission Detail Modal */}
+      <Dialog open={submissionOpen} onOpenChange={setSubmissionOpen}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Expression of Interest</DialogTitle>
+          </DialogHeader>
+          {selectedSubmission && (
+            <div className="space-y-2 text-sm">
+              <div><span className="font-medium">Tier interest: </span>{selectedSubmission.selected_tier ?? '—'}</div>
+              <div><span className="font-medium">Company: </span>{selectedSubmission.company_name ?? '—'}</div>
+              <div><span className="font-medium">Contact: </span>{selectedSubmission.contact_name ?? '—'}</div>
+              <div><span className="font-medium">Email: </span>{selectedSubmission.contact_email ?? '—'}</div>
+              <div><span className="font-medium">Phone: </span>{selectedSubmission.contact_phone ?? '—'}</div>
+              <div><span className="font-medium">Monthly volume: </span>{selectedSubmission.estimated_monthly_kg ? `${selectedSubmission.estimated_monthly_kg} kg/month` : '—'}</div>
+              {(selectedSubmission.billing_address_line1 || selectedSubmission.billing_city) && (
+                <div>
+                  <span className="font-medium">Address: </span>
+                  {[
+                    selectedSubmission.billing_address_line1,
+                    selectedSubmission.billing_address_line2,
+                    selectedSubmission.billing_city,
+                    selectedSubmission.billing_province,
+                    selectedSubmission.billing_postal_code,
+                  ].filter(Boolean).join(', ')}
+                </div>
+              )}
+              {selectedSubmission.notes && (
+                <div>
+                  <p className="font-medium mb-1">Notes:</p>
+                  <p className="bg-muted/40 rounded p-2 whitespace-pre-wrap">{selectedSubmission.notes}</p>
+                </div>
+              )}
+              <p className="text-xs text-muted-foreground pt-1">
+                Submitted {format(new Date(selectedSubmission.submitted_at), 'MMM d, yyyy h:mm a')}
+                {' · '}Status: {selectedSubmission.status}
+              </p>
+            </div>
+          )}
         </DialogContent>
       </Dialog>
 

--- a/src/pages/public/ExplorePage.tsx
+++ b/src/pages/public/ExplorePage.tsx
@@ -1,0 +1,463 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import { useParams } from 'react-router-dom';
+import { supabase } from '@/integrations/supabase/client';
+import { ExploreLayout } from '@/components/layout/ExploreLayout';
+import { TIER_RATES } from '@/components/bookings/bookingUtils';
+import { ROASTER_THROUGHPUT_KG_PER_HR } from '@/lib/unitEconomics';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { toast } from 'sonner';
+
+type Tier = 'MEMBER' | 'GROWTH' | 'PRODUCTION';
+type LoadState = 'loading' | 'not_found' | 'expired' | 'retired' | 'ready';
+
+interface InvitationData {
+  invitation_id: string;
+  prospect_id: string;
+  expires_at: string;
+  retired_at: string | null;
+  business_name: string;
+  contact_name: string | null;
+  has_submission: boolean;
+}
+
+const TIER_ORDER: Tier[] = ['MEMBER', 'GROWTH', 'PRODUCTION'];
+
+const TIER_EXTRA: Record<Tier, { storage: string; horizon: string }> = {
+  MEMBER: { storage: 'No storage', horizon: 'Standard booking' },
+  GROWTH: { storage: '1 pallet storage', horizon: 'Priority — up to 2 weeks ahead' },
+  PRODUCTION: { storage: '2 pallets storage', horizon: 'First-access booking' },
+};
+
+const CANADIAN_PROVINCES = [
+  'Alberta', 'British Columbia', 'Manitoba', 'New Brunswick',
+  'Newfoundland and Labrador', 'Northwest Territories', 'Nova Scotia',
+  'Nunavut', 'Ontario', 'Prince Edward Island', 'Quebec',
+  'Saskatchewan', 'Yukon',
+];
+
+// Per-tier cost calculation — matches unitEconomics.ts logic
+function calcTier(
+  tier: Tier,
+  monthlyKg: number,
+  greenCostPerKg: number,
+  packagingPerBag: number,
+  bagsPerKg: number,
+  wholesalePricePerBag: number,
+  retailPricePerBag: number,
+) {
+  const t = TIER_RATES[tier];
+  const roastHoursPerMonth = monthlyKg / ROASTER_THROUGHPUT_KG_PER_HR;
+  const overageHours = Math.max(0, roastHoursPerMonth - t.includedHours);
+  const facilityCostPerMonth = t.base + overageHours * t.overageRate;
+  const facilityCostPerKg = monthlyKg > 0 ? facilityCostPerMonth / monthlyKg : 0;
+  const kgPerBag = bagsPerKg > 0 ? 1 / bagsPerKg : 0;
+  // 15% roast yield loss: need 1/0.85 green kg per roasted kg
+  const greenPerBag = kgPerBag * (1 / 0.85) * greenCostPerKg;
+  const facilityPerBag = facilityCostPerKg * kgPerBag;
+  const cogPerBag = greenPerBag + packagingPerBag + facilityPerBag;
+  const wholesaleMargin = wholesalePricePerBag > 0
+    ? ((wholesalePricePerBag - cogPerBag) / wholesalePricePerBag) * 100
+    : null;
+  const retailMargin = retailPricePerBag > 0
+    ? ((retailPricePerBag - cogPerBag) / retailPricePerBag) * 100
+    : null;
+  const monthlyBags = monthlyKg * bagsPerKg;
+  const breakEvenKg = cogPerBag > 0 && wholesalePricePerBag > cogPerBag
+    ? facilityCostPerMonth / ((wholesalePricePerBag - cogPerBag) * bagsPerKg)
+    : null;
+  return {
+    tier,
+    label: t.label,
+    facilityCostPerMonth,
+    facilityCostPerKg,
+    cogPerBag,
+    wholesaleMargin,
+    retailMargin,
+    monthlyBags,
+    breakEvenKg,
+  };
+}
+
+function fmt(n: number | null, prefix = '$', decimals = 2): string {
+  if (n === null || !isFinite(n)) return '—';
+  return `${prefix}${n.toFixed(decimals)}`;
+}
+
+function fmtPct(n: number | null): string {
+  if (n === null || !isFinite(n)) return '—';
+  return `${n.toFixed(1)}%`;
+}
+
+export default function ExplorePage() {
+  const { token } = useParams<{ token: string }>();
+
+  const [loadState, setLoadState] = useState<LoadState>('loading');
+  const [invitation, setInvitation] = useState<InvitationData | null>(null);
+
+  // Calculator inputs
+  const [monthlyKg, setMonthlyKg] = useState('');
+  const [greenCostPerKg, setGreenCostPerKg] = useState('');
+  const [packagingPerBag, setPackagingPerBag] = useState('');
+  const [bagsPerKg, setBagsPerKg] = useState('7');
+  const [wholesalePrice, setWholesalePrice] = useState('');
+  const [retailPrice, setRetailPrice] = useState('');
+
+  // EOI form
+  const [eoiTier, setEoiTier] = useState<Tier | ''>('');
+  const [eoiCompany, setEoiCompany] = useState('');
+  const [eoiName, setEoiName] = useState('');
+  const [eoiEmail, setEoiEmail] = useState('');
+  const [eoiPhone, setEoiPhone] = useState('');
+  const [eoiAddr1, setEoiAddr1] = useState('');
+  const [eoiAddr2, setEoiAddr2] = useState('');
+  const [eoiCity, setEoiCity] = useState('');
+  const [eoiProvince, setEoiProvince] = useState('');
+  const [eoiPostal, setEoiPostal] = useState('');
+  const [eoiNotes, setEoiNotes] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  useEffect(() => {
+    if (!token) { setLoadState('not_found'); return; }
+    supabase.rpc('get_invitation_by_token' as any, { p_token: token }).then(({ data, error }) => {
+      if (error || !data) { setLoadState('not_found'); return; }
+      const inv = data as InvitationData;
+      if (inv.retired_at) { setLoadState('retired'); return; }
+      if (new Date(inv.expires_at) < new Date()) { setLoadState('expired'); return; }
+      setInvitation(inv);
+      setEoiCompany(inv.business_name);
+      setEoiName(inv.contact_name ?? '');
+      setLoadState('ready');
+    });
+  }, [token]);
+
+  const calcResults = useMemo(() => {
+    const kg = parseFloat(monthlyKg);
+    const green = parseFloat(greenCostPerKg);
+    const pkg = parseFloat(packagingPerBag);
+    const bpk = parseFloat(bagsPerKg);
+    if (!kg || !green || !pkg || !bpk) return null;
+    const ws = parseFloat(wholesalePrice) || 0;
+    const rt = parseFloat(retailPrice) || 0;
+    return TIER_ORDER.map(t => calcTier(t, kg, green, pkg, bpk, ws, rt));
+  }, [monthlyKg, greenCostPerKg, packagingPerBag, bagsPerKg, wholesalePrice, retailPrice]);
+
+  const handleTierCardClick = (tier: Tier) => {
+    setEoiTier(tier);
+    document.getElementById('eoi-section')?.scrollIntoView({ behavior: 'smooth' });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!token || !eoiTier) return;
+    setSubmitting(true);
+    try {
+      const { data, error } = await supabase.rpc('submit_prospect_interest' as any, {
+        p_token: token,
+        p_selected_tier: eoiTier,
+        p_company_name: eoiCompany.trim() || null,
+        p_contact_name: eoiName.trim() || null,
+        p_contact_email: eoiEmail.trim() || null,
+        p_contact_phone: eoiPhone.trim() || null,
+        p_billing_address_line1: eoiAddr1.trim() || null,
+        p_billing_address_line2: eoiAddr2.trim() || null,
+        p_billing_city: eoiCity.trim() || null,
+        p_billing_province: eoiProvince || null,
+        p_billing_postal_code: eoiPostal.trim() || null,
+        p_estimated_monthly_kg: parseFloat(monthlyKg) || null,
+        p_notes: eoiNotes.trim() || null,
+      });
+
+      const res = data as { ok: boolean; error?: string; submission_id?: string } | null;
+      if (error || !res?.ok) throw new Error(res?.error || 'Submission failed');
+
+      // Notify team — fire and forget
+      if (res.submission_id) {
+        supabase.functions.invoke('notify-prospect-submission', {
+          body: { submission_id: res.submission_id },
+        }).catch(() => {});
+      }
+
+      setSubmitted(true);
+    } catch (err: any) {
+      toast.error(err.message || 'Something went wrong. Please try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const firstName = invitation?.contact_name?.split(' ')[0] || invitation?.business_name || '';
+
+  if (loadState === 'loading') {
+    return (
+      <ExploreLayout>
+        <div className="max-w-3xl mx-auto px-4 py-16 text-center text-muted-foreground">
+          Loading…
+        </div>
+      </ExploreLayout>
+    );
+  }
+
+  if (loadState !== 'ready') {
+    const messages: Record<Exclude<LoadState, 'loading' | 'ready'>, string> = {
+      not_found: 'This link is not valid.',
+      expired: 'This link has expired. Please reach out to us and we\'ll send a fresh one.',
+      retired: 'This link is no longer active.',
+    };
+    return (
+      <ExploreLayout>
+        <div className="max-w-xl mx-auto px-4 py-24 text-center space-y-4">
+          <p className="text-lg text-hi-navy font-medium">{messages[loadState]}</p>
+          <p className="text-muted-foreground text-sm">
+            Questions? Get in touch at{' '}
+            <a href="mailto:hello@homeislandcoffee.com" className="text-hi-steel-blue underline">
+              hello@homeislandcoffee.com
+            </a>
+          </p>
+        </div>
+      </ExploreLayout>
+    );
+  }
+
+  return (
+    <ExploreLayout>
+      <div className="max-w-3xl mx-auto px-4 py-10 space-y-14">
+
+        {/* Section 1 — Welcome */}
+        <section className="bg-hi-navy text-hi-sand rounded-2xl p-8 space-y-3">
+          <h1 className="text-2xl font-bold">
+            {firstName ? `Hi ${firstName},` : 'Welcome.'}
+          </h1>
+          <p className="text-hi-sand/80 leading-relaxed">
+            We're glad you're here. This is your space to explore the co-roasting programme and see how the numbers might work for your business. Take your time — there's no deadline and no obligation.
+          </p>
+        </section>
+
+        {/* Section 2 — Tiers */}
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold text-hi-navy">The tiers</h2>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {TIER_ORDER.map((tier) => {
+              const t = TIER_RATES[tier];
+              const extra = TIER_EXTRA[tier];
+              return (
+                <button
+                  key={tier}
+                  onClick={() => handleTierCardClick(tier)}
+                  className="text-left border-2 rounded-xl p-5 space-y-3 hover:border-hi-steel-blue hover:shadow-md transition-all focus:outline-none focus:ring-2 focus:ring-hi-steel-blue bg-white"
+                >
+                  <div>
+                    <p className="font-bold text-hi-navy text-lg">{t.label}</p>
+                    <p className="text-2xl font-bold text-hi-steel-blue">${t.base}<span className="text-sm font-normal text-muted-foreground">/month</span></p>
+                  </div>
+                  <ul className="text-sm space-y-1 text-muted-foreground">
+                    <li>{t.includedHours} hrs included</li>
+                    <li>${t.overageRate}/hr overage</li>
+                    <li>{extra.storage}</li>
+                    <li>{extra.horizon}</li>
+                  </ul>
+                  <p className="text-xs text-hi-steel-blue font-medium">Click to express interest →</p>
+                </button>
+              );
+            })}
+          </div>
+        </section>
+
+        {/* Section 3 — Calculator */}
+        <section className="space-y-4">
+          <div>
+            <h2 className="text-xl font-semibold text-hi-navy">Run your numbers</h2>
+            <p className="text-sm text-muted-foreground mt-1">Enter your estimates and see how the costs compare across each tier.</p>
+          </div>
+          <div className="bg-white rounded-xl border p-6 space-y-4">
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+              <div>
+                <Label className="text-xs">Monthly roast volume (kg)</Label>
+                <Input type="number" min="0" value={monthlyKg} onChange={e => setMonthlyKg(e.target.value)} placeholder="e.g. 80" />
+              </div>
+              <div>
+                <Label className="text-xs">Green coffee cost ($/kg)</Label>
+                <Input type="number" min="0" value={greenCostPerKg} onChange={e => setGreenCostPerKg(e.target.value)} placeholder="e.g. 9.50" />
+              </div>
+              <div>
+                <Label className="text-xs">Packaging cost ($/bag)</Label>
+                <Input type="number" min="0" value={packagingPerBag} onChange={e => setPackagingPerBag(e.target.value)} placeholder="e.g. 1.20" />
+              </div>
+              <div>
+                <Label className="text-xs">Bags per kg</Label>
+                <Input type="number" min="1" value={bagsPerKg} onChange={e => setBagsPerKg(e.target.value)} />
+              </div>
+              <div>
+                <Label className="text-xs">Wholesale price ($/bag)</Label>
+                <Input type="number" min="0" value={wholesalePrice} onChange={e => setWholesalePrice(e.target.value)} placeholder="optional" />
+              </div>
+              <div>
+                <Label className="text-xs">Retail price ($/bag) <span className="text-muted-foreground">optional</span></Label>
+                <Input type="number" min="0" value={retailPrice} onChange={e => setRetailPrice(e.target.value)} placeholder="optional" />
+              </div>
+            </div>
+
+            {calcResults && (
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm mt-2">
+                  <thead>
+                    <tr className="text-left border-b">
+                      <th className="py-2 pr-4 text-muted-foreground font-medium w-48"></th>
+                      {calcResults.map(r => (
+                        <th key={r.tier} className="py-2 pr-4 font-semibold text-hi-navy">{r.label}</th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y">
+                    <tr>
+                      <td className="py-2 pr-4 text-muted-foreground">Monthly facility cost</td>
+                      {calcResults.map(r => <td key={r.tier} className="py-2 pr-4 font-medium">{fmt(r.facilityCostPerMonth)}</td>)}
+                    </tr>
+                    <tr>
+                      <td className="py-2 pr-4 text-muted-foreground">Facility cost / kg</td>
+                      {calcResults.map(r => <td key={r.tier} className="py-2 pr-4">{fmt(r.facilityCostPerKg)}</td>)}
+                    </tr>
+                    <tr>
+                      <td className="py-2 pr-4 text-muted-foreground">Est. COGS / bag</td>
+                      {calcResults.map(r => <td key={r.tier} className="py-2 pr-4">{fmt(r.cogPerBag)}</td>)}
+                    </tr>
+                    {wholesalePrice && (
+                      <tr>
+                        <td className="py-2 pr-4 text-muted-foreground">Gross margin (wholesale)</td>
+                        {calcResults.map(r => <td key={r.tier} className="py-2 pr-4">{fmtPct(r.wholesaleMargin)}</td>)}
+                      </tr>
+                    )}
+                    {retailPrice && (
+                      <tr>
+                        <td className="py-2 pr-4 text-muted-foreground">Gross margin (retail)</td>
+                        {calcResults.map(r => <td key={r.tier} className="py-2 pr-4">{fmtPct(r.retailMargin)}</td>)}
+                      </tr>
+                    )}
+                    {wholesalePrice && (
+                      <tr>
+                        <td className="py-2 pr-4 text-muted-foreground">Break-even (kg/month)</td>
+                        {calcResults.map(r => <td key={r.tier} className="py-2 pr-4">{r.breakEvenKg ? r.breakEvenKg.toFixed(0) : '—'}</td>)}
+                      </tr>
+                    )}
+                  </tbody>
+                </table>
+                <p className="text-xs text-muted-foreground mt-3">Assumes 15% roast yield loss and 40 kg/hr throughput.</p>
+              </div>
+            )}
+          </div>
+        </section>
+
+        {/* Section 4 — Express Interest */}
+        <section id="eoi-section" className="space-y-4">
+          <div>
+            <h2 className="text-xl font-semibold text-hi-navy">Tell us which tier feels like a fit</h2>
+            <p className="text-sm text-muted-foreground mt-1">No commitment — just let us know where you're leaning and we'll be in touch to talk through next steps.</p>
+          </div>
+
+          {submitted ? (
+            <div className="bg-white rounded-xl border p-8 text-center space-y-2">
+              <p className="text-lg font-semibold text-hi-navy">Thanks{firstName ? `, ${firstName}` : ''}.</p>
+              <p className="text-muted-foreground">We'll be in touch soon to talk through next steps.</p>
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="bg-white rounded-xl border p-6 space-y-6">
+              {/* Tier selector */}
+              <div>
+                <Label className="text-sm font-medium mb-2 block">Which tier are you curious about?</Label>
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+                  {TIER_ORDER.map((tier) => {
+                    const t = TIER_RATES[tier];
+                    const selected = eoiTier === tier;
+                    return (
+                      <button
+                        key={tier}
+                        type="button"
+                        onClick={() => setEoiTier(tier)}
+                        className={`text-left border-2 rounded-lg p-4 transition-all focus:outline-none ${
+                          selected
+                            ? 'border-hi-steel-blue bg-hi-steel-blue/5'
+                            : 'border-border hover:border-hi-steel-blue/50'
+                        }`}
+                      >
+                        <p className="font-semibold text-hi-navy">{t.label}</p>
+                        <p className="text-sm text-muted-foreground">${t.base}/month</p>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              {/* Contact fields */}
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <Label className="text-xs">Company name *</Label>
+                  <Input required value={eoiCompany} onChange={e => setEoiCompany(e.target.value)} />
+                </div>
+                <div>
+                  <Label className="text-xs">Your name *</Label>
+                  <Input required value={eoiName} onChange={e => setEoiName(e.target.value)} />
+                </div>
+                <div>
+                  <Label className="text-xs">Email *</Label>
+                  <Input type="email" required value={eoiEmail} onChange={e => setEoiEmail(e.target.value)} />
+                </div>
+                <div>
+                  <Label className="text-xs">Phone <span className="text-muted-foreground">(optional)</span></Label>
+                  <Input type="tel" value={eoiPhone} onChange={e => setEoiPhone(e.target.value)} />
+                </div>
+              </div>
+
+              {/* Billing address */}
+              <div className="space-y-3">
+                <p className="text-sm font-medium text-muted-foreground">Billing address <span className="font-normal">(optional — for when you're ready)</span></p>
+                <Input placeholder="Address line 1" value={eoiAddr1} onChange={e => setEoiAddr1(e.target.value)} />
+                <Input placeholder="Address line 2" value={eoiAddr2} onChange={e => setEoiAddr2(e.target.value)} />
+                <div className="grid grid-cols-2 gap-3">
+                  <Input placeholder="City" value={eoiCity} onChange={e => setEoiCity(e.target.value)} />
+                  <Select value={eoiProvince} onValueChange={setEoiProvince}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Province" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {CANADIAN_PROVINCES.map(p => (
+                        <SelectItem key={p} value={p}>{p}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <Input placeholder="Postal code" value={eoiPostal} onChange={e => setEoiPostal(e.target.value)} className="max-w-xs" />
+              </div>
+
+              {/* Notes */}
+              <div>
+                <Label className="text-xs">Anything else you'd like us to know? <span className="text-muted-foreground">(optional)</span></Label>
+                <Textarea
+                  value={eoiNotes}
+                  onChange={e => setEoiNotes(e.target.value)}
+                  maxLength={500}
+                  rows={3}
+                  className="resize-none"
+                  placeholder="Questions, context, timing — whatever feels relevant."
+                />
+                <p className="text-xs text-muted-foreground text-right mt-1">{eoiNotes.length}/500</p>
+              </div>
+
+              <Button
+                type="submit"
+                disabled={!eoiTier || !eoiName.trim() || !eoiEmail.trim() || submitting}
+                className="bg-hi-navy text-hi-sand hover:bg-hi-steel-blue w-full md:w-auto"
+              >
+                {submitting ? 'Sending…' : 'Let us know you\'re interested'}
+              </Button>
+            </form>
+          )}
+        </section>
+
+      </div>
+    </ExploreLayout>
+  );
+}

--- a/supabase/functions/notify-prospect-submission/index.ts
+++ b/supabase/functions/notify-prospect-submission/index.ts
@@ -1,0 +1,130 @@
+import { createClient } from 'npm:@supabase/supabase-js@2'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+const SITE_URL = Deno.env.get('SITE_URL') || 'https://homeislandcoffeepartners.lovable.app'
+const SITE_NAME = 'Home Island Coffee Partners'
+const FROM_ADDRESS = `${SITE_NAME} <noreply@notify.homeislandcoffee.com>`
+const SENDER_DOMAIN = 'notify.homeislandcoffee.com'
+const NOTIFY_RECIPIENTS = ['ted@homeislandcoffee.com', 'aaron@homeislandcoffee.com']
+
+const TIER_LABELS: Record<string, string> = {
+  MEMBER: 'Member',
+  GROWTH: 'Growth',
+  PRODUCTION: 'Production',
+}
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  })
+}
+
+function buildEmailHtml(sub: Record<string, any>, businessName: string, prospectUrl: string): string {
+  const tier = TIER_LABELS[sub.selected_tier] ?? sub.selected_tier ?? '—'
+  const rows = [
+    ['Company', sub.company_name || businessName],
+    ['Contact', sub.contact_name || '—'],
+    ['Email', sub.contact_email || '—'],
+    ['Phone', sub.contact_phone || '—'],
+    ['Tier interest', tier],
+    ['Monthly volume', sub.estimated_monthly_kg ? `${sub.estimated_monthly_kg} kg/month` : '—'],
+    ['Address', [sub.billing_address_line1, sub.billing_address_line2, sub.billing_city, sub.billing_province, sub.billing_postal_code].filter(Boolean).join(', ') || '—'],
+    ['Notes', sub.notes || '—'],
+    ['Submitted', new Date(sub.submitted_at).toLocaleString('en-CA', { timeZone: 'America/Vancouver' })],
+  ]
+    .map(([k, v]) => `<tr><td style="padding:4px 12px 4px 0;font-weight:600;vertical-align:top;white-space:nowrap">${k}</td><td style="padding:4px 0">${v}</td></tr>`)
+    .join('')
+
+  return `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="font-family:sans-serif;color:#1a1a1a;max-width:560px;margin:0 auto;padding:24px">
+  <h2 style="color:#0B3E5E;margin:0 0 16px">New Expression of Interest</h2>
+  <p><strong>${sub.company_name || businessName}</strong> has expressed interest in the <strong>${tier}</strong> tier.</p>
+  <table style="border-collapse:collapse;width:100%;margin:16px 0">${rows}</table>
+  <p><a href="${prospectUrl}" style="color:#0B3E5E">View prospect in JIM →</a></p>
+</body>
+</html>`
+}
+
+function buildEmailText(sub: Record<string, any>, businessName: string, prospectUrl: string): string {
+  const tier = TIER_LABELS[sub.selected_tier] ?? sub.selected_tier ?? '—'
+  return `New Expression of Interest
+
+${sub.company_name || businessName} has expressed interest in the ${tier} tier.
+
+Contact: ${sub.contact_name || '—'}
+Email: ${sub.contact_email || '—'}
+Phone: ${sub.contact_phone || '—'}
+Monthly volume: ${sub.estimated_monthly_kg ? `${sub.estimated_monthly_kg} kg/month` : '—'}
+Address: ${[sub.billing_address_line1, sub.billing_address_line2, sub.billing_city, sub.billing_province, sub.billing_postal_code].filter(Boolean).join(', ') || '—'}
+Notes: ${sub.notes || '—'}
+Submitted: ${new Date(sub.submitted_at).toLocaleString('en-CA', { timeZone: 'America/Vancouver' })}
+
+View prospect: ${prospectUrl}`
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders })
+
+  try {
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!
+    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+    const adminClient = createClient(supabaseUrl, supabaseServiceKey, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    })
+
+    const { submission_id } = await req.json()
+    if (!submission_id) return json({ ok: false, error: 'submission_id required' }, 422)
+
+    const { data: sub, error: subErr } = await adminClient
+      .from('coroast_prospect_submissions')
+      .select('*, prospects(business_name)')
+      .eq('id', submission_id)
+      .single()
+    if (subErr || !sub) return json({ ok: false, error: 'Submission not found' }, 404)
+
+    const businessName = (sub as any).prospects?.business_name ?? 'Unknown'
+    const prospectUrl = `${SITE_URL}/prospects/${sub.prospect_id}`
+    const subject = `${sub.company_name || businessName} expressed interest in the ${TIER_LABELS[sub.selected_tier] ?? sub.selected_tier} tier`
+    const html = buildEmailHtml(sub, businessName, prospectUrl)
+    const text = buildEmailText(sub, businessName, prospectUrl)
+    const now = new Date().toISOString()
+
+    for (const recipient of NOTIFY_RECIPIENTS) {
+      const messageId = crypto.randomUUID()
+      await adminClient.from('email_send_log').insert({
+        message_id: messageId,
+        template_name: 'prospect_submission_notify',
+        recipient_email: recipient,
+        status: 'pending',
+      })
+      await adminClient.rpc('enqueue_email', {
+        queue_name: 'transactional_emails',
+        payload: {
+          message_id: messageId,
+          to: recipient,
+          from: FROM_ADDRESS,
+          sender_domain: SENDER_DOMAIN,
+          subject,
+          html,
+          text,
+          purpose: 'transactional',
+          label: 'prospect_submission_notify',
+          queued_at: now,
+        },
+      })
+    }
+
+    console.log('[notify-prospect-submission] Notified team for submission', submission_id)
+    return json({ ok: true })
+  } catch (err) {
+    console.error('[notify-prospect-submission] Unexpected:', err)
+    return json({ ok: false, error: String(err) }, 500)
+  }
+})

--- a/supabase/functions/send-prospect-invitation/index.ts
+++ b/supabase/functions/send-prospect-invitation/index.ts
@@ -1,0 +1,177 @@
+import { createClient } from 'npm:@supabase/supabase-js@2'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+const SITE_URL = Deno.env.get('SITE_URL') || 'https://homeislandcoffeepartners.lovable.app'
+const SITE_NAME = 'Home Island Coffee Partners'
+const FROM_ADDRESS = `${SITE_NAME} <noreply@notify.homeislandcoffee.com>`
+const SENDER_DOMAIN = 'notify.homeislandcoffee.com'
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  })
+}
+
+function buildEmailHtml(firstName: string, exploreUrl: string): string {
+  return `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+<body style="font-family:sans-serif;color:#1a1a1a;max-width:560px;margin:0 auto;padding:24px">
+  <p style="margin:0 0 8px"><img src="https://homeislandcoffee.com/icon.png" alt="" width="36" height="36"></p>
+  <h2 style="color:#0B3E5E;margin:0 0 16px">Home Island Coffee Partners</h2>
+  <p>Hi ${firstName},</p>
+  <p>We'd love for you to explore what co-roasting with Home Island Coffee Partners looks like for your business. We've put together a private page just for you where you can look through our membership options, run some numbers, and let us know if any of it feels like a fit — no pressure, no commitment.</p>
+  <p style="margin:24px 0">
+    <a href="${exploreUrl}" style="background:#0B3E5E;color:#D2AC58;text-decoration:none;padding:12px 24px;border-radius:6px;display:inline-block;font-weight:600">
+      Explore the programme →
+    </a>
+  </p>
+  <p>This link is personal to you and will be active for 90 days. If you have any questions before then, just reply to this email and it'll reach us directly.</p>
+  <p>Ted &amp; Aaron<br><em>Home Island Coffee Partners</em></p>
+</body>
+</html>`
+}
+
+function buildEmailText(firstName: string, exploreUrl: string): string {
+  return `Hi ${firstName},
+
+We'd love for you to explore what co-roasting with Home Island Coffee Partners looks like for your business. We've put together a private page just for you where you can look through our membership options, run some numbers, and let us know if any of it feels like a fit — no pressure, no commitment.
+
+Your personal link (active for 90 days):
+${exploreUrl}
+
+If you have any questions, just reply to this email and it'll reach us directly.
+
+Ted & Aaron
+Home Island Coffee Partners`
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders })
+
+  try {
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!
+    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+    const adminClient = createClient(supabaseUrl, supabaseServiceKey, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    })
+
+    // Auth — require ADMIN or OPS
+    const authHeader = req.headers.get('Authorization')
+    if (!authHeader) return json({ ok: false, error: 'Unauthorized' }, 401)
+
+    const token = authHeader.replace('Bearer ', '').trim()
+    const { data: { user }, error: authError } = await adminClient.auth.getUser(token)
+    if (authError || !user) return json({ ok: false, error: 'Invalid token' }, 401)
+
+    const { data: roleRow } = await adminClient
+      .from('user_roles')
+      .select('role')
+      .eq('user_id', user.id)
+      .single()
+    if (!roleRow || !['ADMIN', 'OPS'].includes(roleRow.role)) {
+      return json({ ok: false, error: 'Forbidden' }, 403)
+    }
+
+    const { prospect_id } = await req.json()
+    if (!prospect_id) return json({ ok: false, error: 'prospect_id required' }, 422)
+
+    // Fetch prospect
+    const { data: prospect, error: pErr } = await adminClient
+      .from('prospects')
+      .select('id, business_name, contact_name, prospect_email, stream')
+      .eq('id', prospect_id)
+      .single()
+    if (pErr || !prospect) return json({ ok: false, error: 'Prospect not found' }, 404)
+    if (!prospect.prospect_email) {
+      return json({ ok: false, error: 'no_email' }, 422)
+    }
+    if (!['CO_ROAST', 'BOTH'].includes(prospect.stream ?? '')) {
+      return json({ ok: false, error: 'Prospect stream is not CO_ROAST or BOTH' }, 422)
+    }
+
+    // Upsert invitation — INSERT first time, UPDATE on resend
+    const expiresAt = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString()
+    const now = new Date().toISOString()
+
+    const { data: existing } = await adminClient
+      .from('coroast_prospect_invitations')
+      .select('id, token')
+      .eq('prospect_id', prospect_id)
+      .maybeSingle()
+
+    let invitation: { id: string; token: string }
+
+    if (existing) {
+      const { data: updated, error: updErr } = await adminClient
+        .from('coroast_prospect_invitations')
+        .update({
+          expires_at: expiresAt,
+          resent_at: now,
+          retired_at: null,
+          invited_by: user.id,
+        })
+        .eq('id', existing.id)
+        .select('id, token')
+        .single()
+      if (updErr || !updated) return json({ ok: false, error: 'Failed to update invitation' }, 500)
+      invitation = updated
+    } else {
+      const { data: inserted, error: insErr } = await adminClient
+        .from('coroast_prospect_invitations')
+        .insert({ prospect_id, expires_at: expiresAt, invited_by: user.id })
+        .select('id, token')
+        .single()
+      if (insErr || !inserted) return json({ ok: false, error: 'Failed to create invitation' }, 500)
+      invitation = inserted
+    }
+
+    const exploreUrl = `${SITE_URL}/explore/${invitation.token}`
+    const firstName = prospect.contact_name?.split(' ')[0] || prospect.business_name
+
+    const subject = `You're invited to explore co-roasting with Home Island Coffee Partners`
+    const html = buildEmailHtml(firstName, exploreUrl)
+    const text = buildEmailText(firstName, exploreUrl)
+    const messageId = crypto.randomUUID()
+
+    // Log pending
+    await adminClient.from('email_send_log').insert({
+      message_id: messageId,
+      template_name: 'prospect_invitation',
+      recipient_email: prospect.prospect_email,
+      status: 'pending',
+    })
+
+    const { error: enqueueErr } = await adminClient.rpc('enqueue_email', {
+      queue_name: 'transactional_emails',
+      payload: {
+        message_id: messageId,
+        to: prospect.prospect_email,
+        from: FROM_ADDRESS,
+        sender_domain: SENDER_DOMAIN,
+        subject,
+        html,
+        text,
+        purpose: 'transactional',
+        label: 'prospect_invitation',
+        queued_at: now,
+      },
+    })
+
+    if (enqueueErr) {
+      console.error('[send-prospect-invitation] Enqueue failed:', enqueueErr.message)
+      return json({ ok: false, error: 'Failed to enqueue email' }, 500)
+    }
+
+    console.log('[send-prospect-invitation] Sent to', prospect.prospect_email, 'url', exploreUrl)
+    return json({ ok: true, invitation_id: invitation.id, explore_url: exploreUrl })
+  } catch (err) {
+    console.error('[send-prospect-invitation] Unexpected:', err)
+    return json({ ok: false, error: String(err) }, 500)
+  }
+})

--- a/supabase/migrations/20260510200000_prospect_invite_landing.sql
+++ b/supabase/migrations/20260510200000_prospect_invite_landing.sql
@@ -1,0 +1,155 @@
+-- Add dedicated email column to prospects
+ALTER TABLE public.prospects ADD COLUMN prospect_email text;
+
+-- Invitation table (one row per prospect, upsert on resend)
+CREATE TABLE public.coroast_prospect_invitations (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  prospect_id  uuid NOT NULL REFERENCES public.prospects(id) ON DELETE CASCADE,
+  token        text NOT NULL UNIQUE DEFAULT encode(gen_random_bytes(24), 'hex'),
+  invited_by   uuid REFERENCES auth.users(id),
+  invited_at   timestamptz NOT NULL DEFAULT now(),
+  expires_at   timestamptz NOT NULL DEFAULT (now() + interval '90 days'),
+  resent_at    timestamptz,
+  retired_at   timestamptz,
+  CONSTRAINT one_invite_per_prospect UNIQUE (prospect_id)
+);
+
+CREATE INDEX idx_prospect_invitations_token ON public.coroast_prospect_invitations(token);
+
+ALTER TABLE public.coroast_prospect_invitations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.coroast_prospect_invitations FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY "Deny anon prospect invitations"
+  ON public.coroast_prospect_invitations FOR ALL TO anon
+  USING (false) WITH CHECK (false);
+
+CREATE POLICY "Admin/Ops manage prospect invitations"
+  ON public.coroast_prospect_invitations FOR ALL TO authenticated
+  USING (has_role(auth.uid(), 'ADMIN'::app_role) OR has_role(auth.uid(), 'OPS'::app_role))
+  WITH CHECK (has_role(auth.uid(), 'ADMIN'::app_role) OR has_role(auth.uid(), 'OPS'::app_role));
+
+-- Submission table
+CREATE TABLE public.coroast_prospect_submissions (
+  id                    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  invitation_id         uuid NOT NULL REFERENCES public.coroast_prospect_invitations(id),
+  prospect_id           uuid NOT NULL REFERENCES public.prospects(id),
+  submitted_at          timestamptz NOT NULL DEFAULT now(),
+  selected_tier         text CHECK (selected_tier IN ('MEMBER', 'GROWTH', 'PRODUCTION')),
+  company_name          text,
+  contact_name          text,
+  contact_email         text,
+  contact_phone         text,
+  billing_address_line1 text,
+  billing_address_line2 text,
+  billing_city          text,
+  billing_province      text,
+  billing_postal_code   text,
+  estimated_monthly_kg  numeric,
+  notes                 text,
+  status                text NOT NULL DEFAULT 'PENDING' CHECK (status IN ('PENDING', 'REVIEWED', 'CONVERTED')),
+  reviewed_by           uuid REFERENCES auth.users(id),
+  reviewed_at           timestamptz
+);
+
+CREATE INDEX idx_prospect_submissions_prospect ON public.coroast_prospect_submissions(prospect_id);
+CREATE INDEX idx_prospect_submissions_status   ON public.coroast_prospect_submissions(status);
+
+ALTER TABLE public.coroast_prospect_submissions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.coroast_prospect_submissions FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY "Deny anon prospect submissions"
+  ON public.coroast_prospect_submissions FOR ALL TO anon
+  USING (false) WITH CHECK (false);
+
+CREATE POLICY "Admin/Ops manage prospect submissions"
+  ON public.coroast_prospect_submissions FOR ALL TO authenticated
+  USING (has_role(auth.uid(), 'ADMIN'::app_role) OR has_role(auth.uid(), 'OPS'::app_role))
+  WITH CHECK (has_role(auth.uid(), 'ADMIN'::app_role) OR has_role(auth.uid(), 'OPS'::app_role));
+
+-- RPC: validate token + return invitation context (anon-accessible)
+CREATE OR REPLACE FUNCTION public.get_invitation_by_token(p_token text)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE v_result jsonb;
+BEGIN
+  SELECT jsonb_build_object(
+    'invitation_id',  i.id,
+    'prospect_id',    i.prospect_id,
+    'expires_at',     i.expires_at,
+    'retired_at',     i.retired_at,
+    'business_name',  p.business_name,
+    'contact_name',   p.contact_name,
+    'has_submission', EXISTS (
+      SELECT 1 FROM public.coroast_prospect_submissions s WHERE s.invitation_id = i.id
+    )
+  ) INTO v_result
+  FROM public.coroast_prospect_invitations i
+  JOIN public.prospects p ON p.id = i.prospect_id
+  WHERE i.token = p_token;
+  RETURN v_result;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_invitation_by_token(text) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_invitation_by_token(text) TO anon, authenticated;
+
+-- RPC: submit expression of interest (anon-accessible, validates token)
+CREATE OR REPLACE FUNCTION public.submit_prospect_interest(
+  p_token                 text,
+  p_selected_tier         text,
+  p_company_name          text DEFAULT NULL,
+  p_contact_name          text DEFAULT NULL,
+  p_contact_email         text DEFAULT NULL,
+  p_contact_phone         text DEFAULT NULL,
+  p_billing_address_line1 text DEFAULT NULL,
+  p_billing_address_line2 text DEFAULT NULL,
+  p_billing_city          text DEFAULT NULL,
+  p_billing_province      text DEFAULT NULL,
+  p_billing_postal_code   text DEFAULT NULL,
+  p_estimated_monthly_kg  numeric DEFAULT NULL,
+  p_notes                 text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_inv coroast_prospect_invitations;
+  v_id  uuid;
+BEGIN
+  SELECT * INTO v_inv
+  FROM public.coroast_prospect_invitations WHERE token = p_token;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'invalid_token');
+  END IF;
+  IF v_inv.retired_at IS NOT NULL THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'invitation_retired');
+  END IF;
+  IF v_inv.expires_at < now() THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'invitation_expired');
+  END IF;
+  IF p_selected_tier NOT IN ('MEMBER', 'GROWTH', 'PRODUCTION') THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'invalid_tier');
+  END IF;
+
+  INSERT INTO public.coroast_prospect_submissions (
+    invitation_id, prospect_id, selected_tier,
+    company_name, contact_name, contact_email, contact_phone,
+    billing_address_line1, billing_address_line2, billing_city,
+    billing_province, billing_postal_code, estimated_monthly_kg, notes
+  ) VALUES (
+    v_inv.id, v_inv.prospect_id, p_selected_tier,
+    p_company_name, p_contact_name, p_contact_email, p_contact_phone,
+    p_billing_address_line1, p_billing_address_line2, p_billing_city,
+    p_billing_province, p_billing_postal_code, p_estimated_monthly_kg, p_notes
+  ) RETURNING id INTO v_id;
+
+  RETURN jsonb_build_object('ok', true, 'submission_id', v_id);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.submit_prospect_interest(text,text,text,text,text,text,text,text,text,text,text,numeric,text) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.submit_prospect_interest(text,text,text,text,text,text,text,text,text,text,text,numeric,text) TO anon, authenticated;


### PR DESCRIPTION
## Summary

Adds a private, invitation-only landing page at `/explore/:token` where co-roasting prospects can explore the three membership tiers, run a cost calculator, and submit an expression of interest — all without authentication. Admins trigger the flow from the Prospect Detail page; the prospect receives a branded email with a personal 90-day link.

## What changed

**Database** (`supabase/migrations/20260510200000_prospect_invite_landing.sql`)
- New tables: `coroast_prospect_invitations` (one row per prospect, upsert on resend) and `coroast_prospect_submissions`
- New SECURITY DEFINER RPCs callable by anon: `get_invitation_by_token`, `submit_prospect_interest`
- Adds `prospect_email` column to `prospects`

**Edge functions**
- `send-prospect-invitation` — ADMIN/OPS-only, upserts invitation row, enqueues branded email via the existing `transactional_emails` queue
- `notify-prospect-submission` — sends notification to ted@ and aaron@ on new submission

**Admin UI**
- `ProspectDetail.tsx` — dedicated email input, new "Explore Invitation" card (send / resend / retire / expired states), submission detail dialog. Conversion retires the invitation and marks pending submissions `CONVERTED`.
- `CoRoastingTab.tsx` — "Pending Expressions of Interest" card on the dashboard

**Public landing page**
- New `ExploreLayout` (logo header, no sidebar)
- New `ExplorePage` with welcome, tier cards, calculator (reuses `TIER_RATES` + `unitEconomics.ts` math), and EOI form
- `App.tsx` — `/explore/:token` route registered before auth routes, no `ProtectedRoute` wrapper

## Reviewer notes

- Migration must be applied and types regenerated (`supabase gen types ...`) before the `as any` casts on `coroast_prospect_invitations` / `coroast_prospect_submissions` can be removed.
- Calculator assumes 15% roast yield loss and 40 kg/hr throughput — surfaced in a footnote.
- `notify-prospect-submission` is intentionally unauthenticated (called from anon page); it validates `submission_id` exists via service role before sending.
- Hardcoded tier display in the public page (storage / booking horizon copy) — `TIER_RATES` only stores rate fields.
- Recipient addresses (`ted@homeislandcoffee.com`, `aaron@homeislandcoffee.com`) are hardcoded in `notify-prospect-submission`. Confirm these before deploying.

## Test plan

- [ ] Apply migration, regenerate types
- [ ] Open a CO_ROAST or BOTH prospect → add email → click "Send Invitation" → verify row in `coroast_prospect_invitations` and pending entry in `email_send_log`
- [ ] Visit `/explore/<token>` in incognito → page loads with personalized greeting
- [ ] Try expired / retired / invalid tokens → correct error messages
- [ ] Fill calculator with sample numbers → comparison table renders for all three tiers
- [ ] Submit EOI → row in `coroast_prospect_submissions`, notification emails enqueued
- [ ] Dashboard Co-Roasting tab shows "Pending Expressions of Interest"
- [ ] Convert prospect to account → invitation `retired_at` set, submission `status = CONVERTED`

🤖 Generated with [Claude Code](https://claude.com/claude-code)