### PR TITLE
Rewrite Dev/Test Reset RPCs against current schema

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -4391,7 +4391,7 @@ export type Database = {
       }
       dev_reset_master_data: { Args: never; Returns: Json }
       dev_reset_test_day: { Args: never; Returns: Json }
-      dev_test_reset: { Args: never; Returns: undefined }
+      dev_test_reset: { Args: never; Returns: Json }
       dev_test_seed_minimal: { Args: never; Returns: undefined }
       enqueue_email: {
         Args: { payload: Json; queue_name: string }

--- a/src/pages/internal/AdminTools.tsx
+++ b/src/pages/internal/AdminTools.tsx
@@ -142,10 +142,12 @@ export default function AdminTools() {
     
     setIsResetting(true);
     try {
-      const { error } = await supabase.rpc('dev_test_reset');
+      const { data, error } = await supabase.rpc('dev_test_reset');
       if (error) throw error;
-      
-      toast.success('Test data reset complete');
+
+      const counts = (data ?? {}) as Record<string, number>;
+      const totalCleared = Object.values(counts).reduce((sum, n) => sum + (n ?? 0), 0);
+      toast.success(`Test data reset complete. Cleared ${totalCleared} rows across ${Object.keys(counts).length} tables.`);
       setShowResetModal(false);
       setResetConfirmText('');
       setResetUnderstood(false);
@@ -186,14 +188,14 @@ export default function AdminTools() {
       const { data, error } = await supabase.rpc('dev_reset_test_day');
       if (error) throw error;
       
-      const counts = data as Record<string, number>;
-      const totalCleared = Object.values(counts).reduce((sum, count) => sum + count, 0);
-      
+      const counts = (data ?? {}) as Record<string, number>;
+      const totalCleared = Object.values(counts).reduce((sum, n) => sum + (n ?? 0), 0);
+
       toast.success(
         `Test day reset complete. Cleared ${totalCleared} rows: ` +
-        `${counts.orders} orders, ${counts.order_line_items} line items, ` +
-        `${counts.roasted_batches} batches, ${counts.packing_runs} packing runs, ` +
-        `${counts.inventory_transactions} inventory txns`
+        `${counts.orders ?? 0} orders, ${counts.order_line_items ?? 0} line items, ` +
+        `${counts.roasted_batches ?? 0} batches, ${counts.packing_runs ?? 0} packing runs, ` +
+        `${counts.inventory_transactions ?? 0} inventory txns`
       );
       
       setShowResetTestDayModal(false);
@@ -442,7 +444,7 @@ export default function AdminTools() {
             <CardTitle className="text-lg">Dev / Test Reset</CardTitle>
           </div>
           <CardDescription>
-            Clears all orders and production state while preserving products, clients, and configuration.
+            Clears ALL orders and all transactional data. Preserves master data (clients, products, roast groups, green coffee, pricing, packaging, accounts, co-roasting).
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -450,20 +452,25 @@ export default function AdminTools() {
             <div className="text-sm text-muted-foreground">
               <p className="font-medium mb-2">This will delete:</p>
               <ul className="list-disc list-inside space-y-1 ml-2">
-                <li>All orders and line items</li>
-                <li>All roasted batches and packing runs</li>
+                <li>All orders, line items, ship picks, inventory transactions, order notifications, audit log</li>
+                <li>All roasted batches, packing runs, exceptions, andon picks, external demand</li>
                 <li>All production checkmarks and plan items</li>
-                <li>All andon picks and external demand</li>
-                <li>All WIP and FG inventory records</li>
+                <li>All WIP ledger / adjustments and FG inventory log (FG and roast group inventory zeroed)</li>
+                <li>All quotes, offer workspace sessions, standing offer sessions</li>
+                <li>All prospects, prospect notes, client notes</li>
+                <li>All email send log/state, unsubscribe tokens, suppressed emails, feedback submissions</li>
+                <li>All locked prices</li>
               </ul>
             </div>
             <div className="text-sm text-muted-foreground">
               <p className="font-medium mb-2">This will NOT delete:</p>
               <ul className="list-disc list-inside space-y-1 ml-2">
-                <li>Clients, products, roast groups</li>
-                <li>Board configuration</li>
-                <li>Price lists</li>
-                <li>Users and roles</li>
+                <li>Accounts, account users, clients, products, roast groups</li>
+                <li>Green coffee (vendors, samples, lots, contracts, purchases, releases)</li>
+                <li>Pricing rules/tiers/profiles, packaging costs/types, price list</li>
+                <li>Board config, sourcing sequences (PO/lot counters)</li>
+                <li>Co-roasting data (use the Clear All Co-Roasting Data button)</li>
+                <li>Users, roles, profiles, app settings</li>
               </ul>
             </div>
             <Button 
@@ -529,7 +536,7 @@ export default function AdminTools() {
                 <CardTitle className="text-lg">Reset Test Day (DEV ONLY)</CardTitle>
               </div>
               <CardDescription>
-                Complete reset of all transactional data. Returns inventory to zero state. Hidden in production.
+                Same as Dev / Test Reset above. Returns row counts for inspection. Hidden in production.
               </CardDescription>
             </CardHeader>
             <CardContent>
@@ -537,19 +544,21 @@ export default function AdminTools() {
                 <div className="text-sm text-muted-foreground">
                   <p className="font-medium mb-2">This will delete (in FK-safe order):</p>
                   <ul className="list-disc list-inside space-y-1 ml-2">
-                    <li>All inventory_transactions (the ledger)</li>
-                    <li>All ship_picks, packing_runs, roasted_batches</li>
-                    <li>All order_line_items and orders (admin-created)</li>
-                    <li>All production checkmarks and plan items</li>
-                    <li>All andon picks and external demand</li>
+                    <li>ALL orders, line items, ship_picks, inventory_transactions, order_notifications, audit log</li>
+                    <li>All roasted_batches, packing_runs, exceptions, andon_picks, external_demand</li>
+                    <li>All production checkmarks and plan items, WIP ledger/adjustments, FG inventory log</li>
+                    <li>All quotes, offer_workspace_*, standing_offer_*</li>
+                    <li>All prospects, prospect_notes, client_notes</li>
+                    <li>All email_send_log/state, unsubscribe tokens, suppressed_emails, feedback_submissions, locked_prices</li>
                   </ul>
                 </div>
                 <div className="text-sm text-muted-foreground">
                   <p className="font-medium mb-2">Preserves:</p>
                   <ul className="list-disc list-inside space-y-1 ml-2">
-                    <li>Clients, products, roast groups</li>
-                    <li>Board configuration (source_board_products)</li>
-                    <li>Price lists, users, roles</li>
+                    <li>Accounts, clients, products, roast groups, green coffee</li>
+                    <li>Pricing/packaging config, price list, board config, sourcing sequences</li>
+                    <li>Co-roasting data (separate button)</li>
+                    <li>Users, roles, profiles, app settings</li>
                   </ul>
                 </div>
                 <Button 
@@ -575,7 +584,7 @@ export default function AdminTools() {
                 <CardTitle className="text-lg">Reset Master Data (DEV ONLY)</CardTitle>
               </div>
               <CardDescription>
-                <span className="font-bold text-red-600">NUCLEAR OPTION:</span> Clears ALL clients, products, roast groups, and their dependencies. Use to start fresh with real-world data entry.
+                <span className="font-bold text-red-600">NUCLEAR OPTION:</span> Runs Dev / Test Reset, then deletes ALL master data (accounts, clients, products, roast groups, green coffee, pricing, packaging, co-roasting). Use to start completely fresh.
               </CardDescription>
             </CardHeader>
             <CardContent>
@@ -583,19 +592,21 @@ export default function AdminTools() {
                 <div className="text-sm text-muted-foreground">
                   <p className="font-medium mb-2">This will DELETE:</p>
                   <ul className="list-disc list-inside space-y-1 ml-2">
-                    <li>All clients and client locations</li>
-                    <li>All products and price lists</li>
-                    <li>All roast groups and inventory levels</li>
-                    <li>All orders, batches, packing runs</li>
-                    <li>All board configurations</li>
-                    <li>All green coffee lots</li>
+                    <li>Everything in Dev / Test Reset (orders, production, inventory, quotes/offers, CRM, comms)</li>
+                    <li>All accounts, account_users, account_locations, clients, client_locations</li>
+                    <li>All products, roast_groups, roast_group_components/notes/inventory_levels, fg_inventory rows</li>
+                    <li>All green coffee (vendors, samples, lots, contracts, purchases, releases, notes, snapshots)</li>
+                    <li>All pricing (rules, tiers, profiles, price_list), packaging (costs, types)</li>
+                    <li>All board configuration (source_board_products, client_allowed_products)</li>
+                    <li>All co-roasting (members, bookings, billing periods, hour ledger, invoices, storage, waivers, blocks, prospects)</li>
                   </ul>
                 </div>
                 <div className="text-sm text-muted-foreground">
                   <p className="font-medium mb-2">Preserves:</p>
                   <ul className="list-disc list-inside space-y-1 ml-2">
-                    <li>Schema, enums, constraints</li>
-                    <li>Auth users and roles</li>
+                    <li>Schema, enums, constraints, RLS policies</li>
+                    <li>Auth users, profiles, user_roles</li>
+                    <li>app_settings, sourcing_sequences (PO/lot counter monotonicity)</li>
                   </ul>
                 </div>
                 <Button 
@@ -652,7 +663,7 @@ export default function AdminTools() {
                 onCheckedChange={(checked) => setResetUnderstood(checked === true)}
               />
               <Label htmlFor="reset-understood" className="text-sm leading-relaxed cursor-pointer">
-                I understand this deletes all test orders and production data
+                I understand this deletes ALL orders, production, inventory, quotes/offers, prospects, CRM notes, comms, and locked prices
               </Label>
             </div>
           </div>

--- a/supabase/migrations/20260511195950_dev_reset_rewrite.sql
+++ b/supabase/migrations/20260511195950_dev_reset_rewrite.sql
@@ -1,0 +1,374 @@
+-- Rewrite of dev_test_reset, dev_reset_test_day, dev_reset_master_data
+-- against the current schema (May 2026).
+--
+-- - dev_test_reset: full transactional rollback. Deletes ALL orders +
+--   transactional data (orders/production/inventory/quotes/offers/
+--   prospects/CRM transactional/comms/locked prices). Preserves master
+--   data (clients/products/roast_groups/green coffee/pricing/packaging/
+--   accounts/coroast/etc).
+-- - dev_reset_test_day: thin wrapper that calls dev_test_reset for UI
+--   compatibility.
+-- - dev_reset_master_data: nuclear. dev_test_reset + master data
+--   (clients/products/roast_groups/green/pricing/packaging/coroast/
+--   accounts). Preserves: auth users, profiles, user_roles, app_settings,
+--   sourcing_sequences (PO/lot counter monotonicity), schema/enums.
+--
+-- All three are SECURITY DEFINER, gated on ADMIN role, single plpgsql
+-- function = single implicit transaction = all-or-nothing.
+
+-- Return type of dev_test_reset changes from void -> jsonb, so drop first.
+DROP FUNCTION IF EXISTS public.dev_test_reset();
+DROP FUNCTION IF EXISTS public.dev_reset_test_day();
+DROP FUNCTION IF EXISTS public.dev_reset_master_data();
+
+-- ============================================================
+-- RPC 1: dev_test_reset  (transactional rollback)
+-- ============================================================
+CREATE FUNCTION public.dev_test_reset()
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_counts jsonb := '{}'::jsonb;
+  v_rows   integer;
+BEGIN
+  IF NOT public.has_role(auth.uid(), 'ADMIN'::app_role) THEN
+    RAISE EXCEPTION 'Access denied: ADMIN role required';
+  END IF;
+
+  -- ========== ORDER GRAPH (children first) ==========
+  DELETE FROM public.ship_picks;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('ship_picks', v_rows);
+
+  DELETE FROM public.inventory_transactions;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('inventory_transactions', v_rows);
+
+  DELETE FROM public.order_notifications;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('order_notifications', v_rows);
+
+  DELETE FROM public.order_date_audit_log;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('order_date_audit_log', v_rows);
+
+  DELETE FROM public.external_demand;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('external_demand', v_rows);
+
+  DELETE FROM public.order_line_items;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('order_line_items', v_rows);
+
+  DELETE FROM public.orders;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('orders', v_rows);
+
+  -- ========== PRODUCTION GRAPH ==========
+  DELETE FROM public.andon_picks;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('andon_picks', v_rows);
+
+  DELETE FROM public.roast_exception_events;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('roast_exception_events', v_rows);
+
+  DELETE FROM public.production_checkmarks;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('production_checkmarks', v_rows);
+
+  DELETE FROM public.production_plan_items;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('production_plan_items', v_rows);
+
+  DELETE FROM public.packing_runs;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('packing_runs', v_rows);
+
+  DELETE FROM public.wip_ledger;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('wip_ledger', v_rows);
+
+  DELETE FROM public.wip_adjustments;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('wip_adjustments', v_rows);
+
+  DELETE FROM public.fg_inventory_log;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('fg_inventory_log', v_rows);
+
+  DELETE FROM public.roasted_batches;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('roasted_batches', v_rows);
+
+  -- ========== INVENTORY ZERO-OUT (preserve rows) ==========
+  UPDATE public.fg_inventory SET units_on_hand = 0, updated_at = now() WHERE units_on_hand <> 0;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('fg_inventory_zeroed', v_rows);
+
+  UPDATE public.roast_group_inventory_levels
+    SET wip_kg = 0, fg_kg = 0, updated_at = now()
+    WHERE wip_kg <> 0 OR fg_kg <> 0;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('roast_group_inventory_levels_zeroed', v_rows);
+
+  -- ========== QUOTES / OFFERS / STANDING OFFERS ==========
+  DELETE FROM public.quote_line_items;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('quote_line_items', v_rows);
+
+  DELETE FROM public.quotes;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('quotes', v_rows);
+
+  DELETE FROM public.offer_workspace_lines;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('offer_workspace_lines', v_rows);
+
+  DELETE FROM public.offer_workspace_sessions;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('offer_workspace_sessions', v_rows);
+
+  DELETE FROM public.standing_offer_lines;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('standing_offer_lines', v_rows);
+
+  DELETE FROM public.standing_offer_sessions;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('standing_offer_sessions', v_rows);
+
+  -- ========== PROSPECTS + CRM TRANSACTIONAL ==========
+  DELETE FROM public.prospect_notes;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('prospect_notes', v_rows);
+
+  DELETE FROM public.prospects;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('prospects', v_rows);
+
+  DELETE FROM public.client_notes;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('client_notes', v_rows);
+
+  -- ========== COMMS / EMAIL INFRA ==========
+  DELETE FROM public.email_send_log;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('email_send_log', v_rows);
+
+  DELETE FROM public.email_send_state;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('email_send_state', v_rows);
+
+  DELETE FROM public.email_unsubscribe_tokens;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('email_unsubscribe_tokens', v_rows);
+
+  DELETE FROM public.suppressed_emails;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('suppressed_emails', v_rows);
+
+  DELETE FROM public.feedback_submissions;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('feedback_submissions', v_rows);
+
+  -- ========== LOCKED PRICES (tied to orders) ==========
+  DELETE FROM public.locked_prices;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('locked_prices', v_rows);
+
+  RETURN v_counts;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.dev_test_reset() FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.dev_test_reset() TO authenticated;
+
+-- ============================================================
+-- RPC 2: dev_reset_test_day  (alias of dev_test_reset)
+-- ============================================================
+CREATE FUNCTION public.dev_reset_test_day()
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  -- ADMIN check is also performed inside dev_test_reset, but verifying
+  -- here gives a clearer error and avoids the inner call when unauthorized.
+  IF NOT public.has_role(auth.uid(), 'ADMIN'::app_role) THEN
+    RAISE EXCEPTION 'Access denied: ADMIN role required';
+  END IF;
+
+  RETURN public.dev_test_reset();
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.dev_reset_test_day() FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.dev_reset_test_day() TO authenticated;
+
+-- ============================================================
+-- RPC 3: dev_reset_master_data  (nuclear)
+-- ============================================================
+CREATE FUNCTION public.dev_reset_master_data()
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_counts jsonb;
+  v_rows   integer;
+BEGIN
+  IF NOT public.has_role(auth.uid(), 'ADMIN'::app_role) THEN
+    RAISE EXCEPTION 'Access denied: ADMIN role required';
+  END IF;
+
+  -- Phase 1: clear all transactional data via dev_test_reset.
+  v_counts := public.dev_test_reset();
+
+  -- Phase 2: clear master data graph.
+
+  -- Pricing config (depends on products/clients)
+  DELETE FROM public.price_list;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('price_list', v_rows);
+
+  DELETE FROM public.pricing_rules;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('pricing_rules', v_rows);
+
+  DELETE FROM public.pricing_rule_profiles;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('pricing_rule_profiles', v_rows);
+
+  DELETE FROM public.pricing_tiers;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('pricing_tiers', v_rows);
+
+  DELETE FROM public.packaging_costs;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('packaging_costs', v_rows);
+
+  DELETE FROM public.packaging_types;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('packaging_types', v_rows);
+
+  -- Board / allowed products
+  DELETE FROM public.source_board_products;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('source_board_products', v_rows);
+
+  DELETE FROM public.client_allowed_products;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('client_allowed_products', v_rows);
+
+  -- Coroast (full wipe at nuclear tier)
+  DELETE FROM public.coroast_storage_allocations;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('coroast_storage_allocations', v_rows);
+
+  DELETE FROM public.coroast_waiver_log;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('coroast_waiver_log', v_rows);
+
+  DELETE FROM public.coroast_hour_ledger;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('coroast_hour_ledger', v_rows);
+
+  DELETE FROM public.coroast_billing_extras;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('coroast_billing_extras', v_rows);
+
+  DELETE FROM public.coroast_bookings;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('coroast_bookings', v_rows);
+
+  DELETE FROM public.coroast_billing_periods;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('coroast_billing_periods', v_rows);
+
+  DELETE FROM public.coroast_recurring_blocks;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('coroast_recurring_blocks', v_rows);
+
+  DELETE FROM public.coroast_member_notes;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('coroast_member_notes', v_rows);
+
+  DELETE FROM public.coroast_member_checklist;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('coroast_member_checklist', v_rows);
+
+  DELETE FROM public.coroast_invoices;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('coroast_invoices', v_rows);
+
+  DELETE FROM public.coroast_unit_economics_scenarios;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('coroast_unit_economics_scenarios', v_rows);
+
+  DELETE FROM public.coroast_availability_windows;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('coroast_availability_windows', v_rows);
+
+  DELETE FROM public.coroast_loring_blocks;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('coroast_loring_blocks', v_rows);
+
+  DELETE FROM public.coroast_prospect_submissions;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('coroast_prospect_submissions', v_rows);
+
+  DELETE FROM public.coroast_prospect_invitations;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('coroast_prospect_invitations', v_rows);
+
+  DELETE FROM public.coroast_members;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('coroast_members', v_rows);
+
+  -- Green coffee graph
+  DELETE FROM public.green_lot_consumption_log;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('green_lot_consumption_log', v_rows);
+
+  DELETE FROM public.green_lot_roast_group_links;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('green_lot_roast_group_links', v_rows);
+
+  DELETE FROM public.green_lot_notes;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('green_lot_notes', v_rows);
+
+  DELETE FROM public.green_sample_roast_profile_links;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('green_sample_roast_profile_links', v_rows);
+
+  DELETE FROM public.green_sample_notes;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('green_sample_notes', v_rows);
+
+  DELETE FROM public.green_inventory_snapshots;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('green_inventory_snapshots', v_rows);
+
+  DELETE FROM public.green_release_lines;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('green_release_lines', v_rows);
+
+  DELETE FROM public.green_releases;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('green_releases', v_rows);
+
+  DELETE FROM public.green_purchase_lines;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('green_purchase_lines', v_rows);
+
+  DELETE FROM public.green_purchases;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('green_purchases', v_rows);
+
+  DELETE FROM public.green_contract_notes;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('green_contract_notes', v_rows);
+
+  DELETE FROM public.green_contracts;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('green_contracts', v_rows);
+
+  DELETE FROM public.green_lots;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('green_lots', v_rows);
+
+  DELETE FROM public.green_coffee_lots;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('green_coffee_lots', v_rows);
+
+  DELETE FROM public.green_samples;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('green_samples', v_rows);
+
+  DELETE FROM public.green_vendor_notes;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('green_vendor_notes', v_rows);
+
+  DELETE FROM public.green_vendors;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('green_vendors', v_rows);
+
+  -- Product graph
+  DELETE FROM public.roast_group_notes;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('roast_group_notes', v_rows);
+
+  DELETE FROM public.roast_group_components;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('roast_group_components', v_rows);
+
+  DELETE FROM public.roast_group_inventory_levels;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('roast_group_inventory_levels', v_rows);
+
+  DELETE FROM public.fg_inventory;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('fg_inventory', v_rows);
+
+  DELETE FROM public.products;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('products', v_rows);
+
+  DELETE FROM public.roast_groups;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('roast_groups', v_rows);
+
+  -- Client/account graph
+  DELETE FROM public.client_locations;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('client_locations', v_rows);
+
+  DELETE FROM public.clients;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('clients', v_rows);
+
+  DELETE FROM public.account_user_locations;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('account_user_locations', v_rows);
+
+  DELETE FROM public.account_users;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('account_users', v_rows);
+
+  DELETE FROM public.account_locations;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('account_locations', v_rows);
+
+  DELETE FROM public.accounts;
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_counts := v_counts || jsonb_build_object('accounts', v_rows);
+
+  -- sourcing_sequences intentionally preserved (PO/lot counter monotonicity).
+  -- app_settings, profiles, user_roles, auth.users preserved.
+
+  RETURN v_counts || jsonb_build_object('status', 'success');
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.dev_reset_master_data() FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.dev_reset_master_data() TO authenticated;


### PR DESCRIPTION
## Summary

- Rewrites the three reset RPCs on `/admin-tools` (`dev_test_reset`, `dev_reset_test_day`, `dev_reset_master_data`) against the current schema. The previous versions were last touched in Jan 2026 and had drifted as ~25 new tables were added (quotes, offer_workspace_*, standing_offer_*, prospects, client_notes, full coroast suite, order_notifications, feedback_submissions, green_releases/_lines, pricing_tiers, packaging_costs, locked_prices, etc).
- Fixes FK integrity holes: `ship_picks`, `inventory_transactions`, `order_notifications`, `order_date_audit_log` all reference `orders` but were not cleared by the old `dev_test_reset`. With CASCADE-less FKs (e.g. `inventory_transactions.order_id`), deleting orders could fail or leave dangling rows.
- Fixes inventory desync: old code zeroed `fg_inventory.units_on_hand` but never touched `roast_group_inventory_levels.wip_kg/fg_kg`. New code zeroes both.

## What each RPC now does

- **`dev_test_reset`** (return type changed `void` -> `jsonb`): deletes ALL orders + every transactional graph (orders, production, inventory ledger, quotes/offers, standing offers, prospects, CRM notes, email infra, feedback submissions, locked prices). Preserves master data (accounts, clients, products, roast groups, green coffee, pricing config, packaging config, coroast). Returns per-table row counts.
- **`dev_reset_test_day`**: thin wrapper that calls `dev_test_reset`. Kept so the existing UI button keeps working without behavior change.
- **`dev_reset_master_data`**: runs `dev_test_reset` then deletes master data (pricing rules/tiers/profiles, packaging, board config, full coroast suite incl. members/blocks/availability/economics scenarios, full green coffee graph, products, roast_groups, clients, account graph). Preserves auth users, `profiles`, `user_roles`, `app_settings`, `sourcing_sequences` so PO/lot counters stay monotonic across a relaunch.

All three remain `SECURITY DEFINER`, ADMIN-gated via `has_role()`, single plpgsql function = single implicit transaction = all-or-nothing. `EXECUTE` revoked from `PUBLIC`/`anon`, granted to `authenticated`.

## Scope decisions (per audit)

- Order deletion: **ALL orders**, not `created_by_admin = true` only. The flag is unreliable (only set in admin UI; client-portal orders default `false`; any code path that omits the column silently writes `false`). For a launch reset, clean decks is the right call.
- Coroast transactional data: left to the separate "Clear All Co-Roasting Data" button at the day-to-day reset tier. `dev_reset_master_data` does wipe coroast at the nuclear tier.
- Date-scoped windows removed: old code only deleted production rows from the last 14 days, leaving older test rows behind.

## UI changes

- `src/pages/internal/AdminTools.tsx`: all three reset card descriptions and bullet lists rewritten to match new scope. Toast in `handleReset` now reads row counts (return type changed). `handleResetTestDay` defensively `?? 0`s each count.
- `src/integrations/supabase/types.ts`: `dev_test_reset` Returns flipped `undefined` -> `Json`. Full `supabase gen types` regen recommended after migration applies to staging.

## Test plan

- [ ] Apply `supabase/migrations/20260511195950_dev_reset_rewrite.sql` to a staging Supabase project
- [ ] Seed via `dev_test_seed_minimal`, then call `dev_test_reset()`. Confirm: `SELECT count(*) FROM orders` = 0; ditto every table listed in RPC 1; clients/products/roast_groups/accounts/green_* counts unchanged
- [ ] Re-seed, call `dev_reset_master_data()`. Confirm: every non-preserved table = 0; `sourcing_sequences` rows intact; `auth.users` intact
- [ ] From `/admin-tools` click each of the three reset buttons against staging; confirm toast row counts match seeded volumes
- [ ] Log in as OPS or CLIENT and call each RPC directly; confirm `Access denied: ADMIN role required`
- [ ] `supabase gen types typescript --project-id cgdzjkryygwlyygeznrb > src/integrations/supabase/types.ts` and `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)