### PR TITLE
feat: require origin on roast groups, fix product-create error UX

### DIFF
--- a/src/components/bulk-edit/cells/EditableCell.tsx
+++ b/src/components/bulk-edit/cells/EditableCell.tsx
@@ -2,7 +2,16 @@ import React, { useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 import { Input } from '@/components/ui/input';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { Checkbox } from '@/components/ui/checkbox';
 import type { ColumnDef, SaveResult } from '../types';
 
@@ -18,11 +27,13 @@ export function EditableCell<TRow>({ row, column, isHighlighted, onSave }: Props
   const [value, setValue] = useState<unknown>(initial);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const [forceCustom, setForceCustom] = useState(false);
   const lastSavedRef = useRef<unknown>(initial);
 
   useEffect(() => {
     setValue(initial);
     lastSavedRef.current = initial;
+    setForceCustom(false);
   }, [initial]);
 
   const formatted = column.format ? column.format(value, row) : (value ?? '');
@@ -100,25 +111,78 @@ export function EditableCell<TRow>({ row, column, isHighlighted, onSave }: Props
           disabled={saving}
         />
       )}
-      {column.type === 'select' && (
-        <Select
-          value={value === null || value === undefined ? '__none__' : String(value)}
-          onValueChange={(v) => {
-            const next = v === '__none__' ? null : v;
-            setValue(next);
-            commit(next);
-          }}
-          disabled={saving}
-        >
-          <SelectTrigger className="h-7 text-xs"><SelectValue /></SelectTrigger>
-          <SelectContent>
-            {column.allowEmpty && <SelectItem value="__none__">—</SelectItem>}
-            {(column.options ?? []).map((opt) => (
-              <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      )}
+      {column.type === 'select' && (() => {
+        const CUSTOM = '__custom__';
+        const strValue = value === null || value === undefined ? '' : String(value);
+        const knownValues = new Set<string>([
+          ...(column.options ?? []).map((o) => o.value),
+          ...(column.groups ?? []).flatMap((g) => g.options.map((o) => o.value)),
+        ]);
+        const isUnknownExisting = column.allowCustom && strValue !== '' && !knownValues.has(strValue);
+        const inCustomMode = column.allowCustom && (forceCustom || isUnknownExisting);
+        const selectValue = inCustomMode ? CUSTOM : strValue === '' ? '__none__' : strValue;
+
+        if (inCustomMode) {
+          return (
+            <div className="flex items-center gap-1">
+              <Input
+                className="h-7 text-xs flex-1"
+                value={(value as string) ?? ''}
+                onChange={(e) => setValue(e.target.value)}
+                onBlur={() => commit(value)}
+                disabled={saving}
+              />
+              <button
+                type="button"
+                className="text-[10px] text-muted-foreground underline px-1"
+                onClick={() => { setForceCustom(false); setValue(null); commit(null); }}
+                disabled={saving}
+              >
+                clear
+              </button>
+            </div>
+          );
+        }
+
+        return (
+          <Select
+            value={selectValue}
+            onValueChange={(v) => {
+              if (v === '__none__') { setForceCustom(false); setValue(null); commit(null); return; }
+              if (v === CUSTOM) { setForceCustom(true); setValue(''); return; }
+              setForceCustom(false);
+              setValue(v);
+              commit(v);
+            }}
+            disabled={saving}
+          >
+            <SelectTrigger className="h-7 text-xs"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              {column.allowEmpty && <SelectItem value="__none__">—</SelectItem>}
+              {(column.options ?? []).map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
+              ))}
+              {(column.groups ?? []).map((group, idx) => (
+                <React.Fragment key={group.label ?? `g-${idx}`}>
+                  <SelectSeparator />
+                  <SelectGroup>
+                    {group.label && <SelectLabel>{group.label}</SelectLabel>}
+                    {group.options.map((opt) => (
+                      <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
+                    ))}
+                  </SelectGroup>
+                </React.Fragment>
+              ))}
+              {column.allowCustom && (
+                <>
+                  <SelectSeparator />
+                  <SelectItem value={CUSTOM}>Other…</SelectItem>
+                </>
+              )}
+            </SelectContent>
+          </Select>
+        );
+      })()}
       {column.type === 'boolean' && (
         <div className="flex items-center justify-center h-7">
           <Checkbox

--- a/src/components/bulk-edit/configs/roastGroups.tsx
+++ b/src/components/bulk-edit/configs/roastGroups.tsx
@@ -3,6 +3,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { format as formatDate } from 'date-fns';
 import type { ColumnDef, SaveResult } from '../types';
+import { ORIGIN_TOP, ORIGIN_SECONDARY } from '@/lib/originOptions';
 
 interface RoastGroupRow {
   roast_group: string;
@@ -12,6 +13,7 @@ interface RoastGroupRow {
   is_active: boolean;
   is_blend: boolean;
   blend_type: string | null;
+  origin: string | null;
   notes: string | null;
   created_at: string;
 }
@@ -36,7 +38,7 @@ export function useRoastGroupsBulkEdit(enabled = true) {
     queryFn: async () => {
       const { data, error } = await supabase
         .from('roast_groups')
-        .select('roast_group, roast_group_code, display_name, default_roaster, is_active, is_blend, blend_type, notes, created_at')
+        .select('roast_group, roast_group_code, display_name, default_roaster, is_active, is_blend, blend_type, origin, notes, created_at')
         .order('display_name');
       if (error) throw error;
       return (data ?? []) as unknown as RoastGroupRow[];
@@ -51,6 +53,15 @@ export function useRoastGroupsBulkEdit(enabled = true) {
     {
       key: 'display_name', header: 'Name', type: 'text', width: '220px',
       getValue: (r) => r.display_name,
+    },
+    {
+      key: 'origin', header: 'Origin', type: 'select', width: '160px',
+      allowEmpty: true, allowCustom: true,
+      groups: [
+        { label: 'Common', options: ORIGIN_TOP.map((o) => ({ value: o, label: o })) },
+        { label: 'Other origins', options: ORIGIN_SECONDARY.map((o) => ({ value: o, label: o })) },
+      ],
+      getValue: (r) => r.origin ?? '',
     },
     {
       key: 'default_roaster', header: 'Default Roaster', type: 'select', width: '140px',

--- a/src/components/bulk-edit/types.ts
+++ b/src/components/bulk-edit/types.ts
@@ -5,6 +5,11 @@ export interface SelectOption {
   label: string;
 }
 
+export interface SelectOptionGroup {
+  label?: string;
+  options: SelectOption[];
+}
+
 export interface ColumnDef<TRow = any> {
   key: string;
   header: string;
@@ -12,6 +17,8 @@ export interface ColumnDef<TRow = any> {
   readOnly?: boolean;
   width?: string;
   options?: SelectOption[];
+  groups?: SelectOptionGroup[];
+  allowCustom?: boolean;
   getValue: (row: TRow) => unknown;
   format?: (value: unknown, row: TRow) => string;
   allowEmpty?: boolean;

--- a/src/components/products/NewSingleOriginProductModal.tsx
+++ b/src/components/products/NewSingleOriginProductModal.tsx
@@ -8,7 +8,9 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
-import { Loader2 } from 'lucide-react';
+import { Loader2, AlertCircle } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { COMMON_ORIGINS } from '@/lib/skuGenerator';
 import { createOrReuseRoastGroup } from '@/lib/roastGroupCreation';
 import { RoastGroupPreview } from './RoastGroupPreview';
@@ -157,6 +159,11 @@ export function NewSingleOriginProductModal({ open, onOpenChange, initialLifecyc
   // Derive isBlend from selected roast group
   const selectedRoastGroupRecord = roastGroups?.find(g => g.roast_group === selectedRoastGroup);
   const isBlendSelected = selectedRoastGroupRecord?.is_blend === true;
+  const selectedRgMissingOrigin =
+    roastGroupMode === 'existing' &&
+    !!selectedRoastGroupRecord &&
+    !selectedRoastGroupRecord.is_blend &&
+    !(selectedRoastGroupRecord.origin?.trim());
   
   // Derived values
   const selectedClient = useMemo(() => 
@@ -240,6 +247,7 @@ export function NewSingleOriginProductModal({ open, onOpenChange, initialLifecyc
     if (!clientId) return false;
     if (!selectedClient?.account_code) return false;
     if (roastGroupMode === 'existing' && !selectedRoastGroup) return false;
+    if (selectedRgMissingOrigin) return false;
     if (roastGroupMode === 'new') {
       if (!origin) return false;
       if (origin === '__custom__' && !customOrigin.trim()) return false;
@@ -248,7 +256,7 @@ export function NewSingleOriginProductModal({ open, onOpenChange, initialLifecyc
     if (validVariants.length === 0) return false;
     if (!lifecycle) return false;
     return true;
-  }, [clientId, selectedClient, roastGroupMode, selectedRoastGroup, origin, customOrigin, finishedGoodName, validVariants, lifecycle]);
+  }, [clientId, selectedClient, roastGroupMode, selectedRoastGroup, selectedRgMissingOrigin, origin, customOrigin, finishedGoodName, validVariants, lifecycle]);
   
   // Reset form
   const resetForm = () => {
@@ -309,6 +317,10 @@ export function NewSingleOriginProductModal({ open, onOpenChange, initialLifecyc
         skuOrigin = selectedRg?.origin ?? '';
       }
       
+      if (roastGroupMode === 'existing' && !skuOrigin) {
+        throw new Error('Selected roast group is missing an origin. Open the roast group detail page and set the origin before creating products.');
+      }
+
       // Get resolved SKUs with collision handling
       // Use the user-entered suffix (finishedGoodName) for the FG name code
       let resolvedSkus;
@@ -506,17 +518,35 @@ export function NewSingleOriginProductModal({ open, onOpenChange, initialLifecyc
             </RadioGroup>
 
             {roastGroupMode === 'existing' && (
-              <Select value={selectedRoastGroup || 'NONE'} onValueChange={(v) => setSelectedRoastGroup(v === 'NONE' ? '' : v)}>
-                <SelectTrigger><SelectValue placeholder="Select roast group" /></SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="NONE">Select roast group...</SelectItem>
-                  {singleOriginRoastGroups.map(g => (
-                    <SelectItem key={g.roast_group} value={g.roast_group}>
-                      {g.display_name?.trim() || g.roast_group.replace(/_/g, ' ')} ({g.roast_group_code})
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <>
+                <Select value={selectedRoastGroup || 'NONE'} onValueChange={(v) => setSelectedRoastGroup(v === 'NONE' ? '' : v)}>
+                  <SelectTrigger><SelectValue placeholder="Select roast group" /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="NONE">Select roast group...</SelectItem>
+                    {singleOriginRoastGroups.map(g => (
+                      <SelectItem key={g.roast_group} value={g.roast_group}>
+                        {g.display_name?.trim() || g.roast_group.replace(/_/g, ' ')} ({g.roast_group_code})
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {selectedRgMissingOrigin && (
+                  <Alert variant="destructive">
+                    <AlertCircle className="h-4 w-4" />
+                    <AlertTitle>Origin missing on this roast group</AlertTitle>
+                    <AlertDescription>
+                      Products can't be created until this roast group has an origin set.{' '}
+                      <Link
+                        to={`/roast-groups/${encodeURIComponent(selectedRoastGroup)}`}
+                        className="underline font-medium"
+                        onClick={() => onOpenChange(false)}
+                      >
+                        Open roast group to fix
+                      </Link>
+                    </AlertDescription>
+                  </Alert>
+                )}
+              </>
             )}
 
             {roastGroupMode === 'new' && (

--- a/src/components/products/OriginSelect.tsx
+++ b/src/components/products/OriginSelect.tsx
@@ -1,0 +1,102 @@
+import React, { useEffect } from 'react';
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Input } from '@/components/ui/input';
+import {
+  ORIGIN_GROUPS,
+  ORIGIN_CUSTOM_SENTINEL,
+  isKnownOrigin,
+} from '@/lib/originOptions';
+
+const NONE_VALUE = '__none__';
+
+export interface OriginSelectValue {
+  value: string;
+  customValue: string;
+}
+
+interface Props {
+  value: string;
+  customValue: string;
+  onChange: (next: OriginSelectValue) => void;
+  placeholder?: string;
+  id?: string;
+  disabled?: boolean;
+}
+
+/**
+ * Grouped origin picker. `value` is either '' (none), a known origin,
+ * or ORIGIN_CUSTOM_SENTINEL. When sentinel, `customValue` holds the
+ * free-text entry. Legacy values not in the known set auto-promote to
+ * custom mode.
+ */
+export function OriginSelect({
+  value,
+  customValue,
+  onChange,
+  placeholder = 'Select origin…',
+  id,
+  disabled,
+}: Props) {
+  // Auto-promote legacy free-text origin to custom mode
+  useEffect(() => {
+    if (value && value !== ORIGIN_CUSTOM_SENTINEL && !isKnownOrigin(value)) {
+      onChange({ value: ORIGIN_CUSTOM_SENTINEL, customValue: value });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const selectValue = value === '' ? NONE_VALUE : value;
+
+  return (
+    <div className="space-y-2">
+      <Select
+        value={selectValue}
+        onValueChange={(v) => {
+          if (v === NONE_VALUE) onChange({ value: '', customValue: '' });
+          else if (v === ORIGIN_CUSTOM_SENTINEL) onChange({ value: ORIGIN_CUSTOM_SENTINEL, customValue });
+          else onChange({ value: v, customValue: '' });
+        }}
+        disabled={disabled}
+      >
+        <SelectTrigger id={id}>
+          <SelectValue placeholder={placeholder} />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={NONE_VALUE}>{placeholder}</SelectItem>
+          {ORIGIN_GROUPS.map((group, idx) => (
+            <React.Fragment key={group.label}>
+              <SelectSeparator />
+              <SelectGroup>
+                {group.label && <SelectLabel>{group.label}</SelectLabel>}
+                {group.options.map((o) => (
+                  <SelectItem key={o} value={o}>
+                    {o}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+              {idx === ORIGIN_GROUPS.length - 1 && <SelectSeparator />}
+            </React.Fragment>
+          ))}
+          <SelectItem value={ORIGIN_CUSTOM_SENTINEL}>Other…</SelectItem>
+        </SelectContent>
+      </Select>
+      {value === ORIGIN_CUSTOM_SENTINEL && (
+        <Input
+          placeholder="Enter origin"
+          value={customValue}
+          onChange={(e) => onChange({ value: ORIGIN_CUSTOM_SENTINEL, customValue: e.target.value })}
+          disabled={disabled}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/roast-groups/NewRoastGroupModal.tsx
+++ b/src/components/roast-groups/NewRoastGroupModal.tsx
@@ -13,6 +13,8 @@ import { toast } from 'sonner';
 import { Loader2 } from 'lucide-react';
 import { createOrReuseRoastGroup } from '@/lib/roastGroupCreation';
 import { RoastGroupPreview } from '@/components/products/RoastGroupPreview';
+import { OriginSelect } from '@/components/products/OriginSelect';
+import { ORIGIN_CUSTOM_SENTINEL } from '@/lib/originOptions';
 
 interface Props {
   open: boolean;
@@ -27,6 +29,7 @@ export function NewRoastGroupModal({ open, onOpenChange }: Props) {
   const [isBlend, setIsBlend] = useState(false);
   const [blendType, setBlendType] = useState<string | null>(null);
   const [origin, setOrigin] = useState('');
+  const [originCustom, setOriginCustom] = useState('');
   const [isSeasonal, setIsSeasonal] = useState(false);
   const [defaultRoaster, setDefaultRoaster] = useState<string>('EITHER');
   const [batchKg, setBatchKg] = useState(20);
@@ -58,6 +61,7 @@ export function NewRoastGroupModal({ open, onOpenChange }: Props) {
     setIsBlend(false);
     setBlendType(null);
     setOrigin('');
+    setOriginCustom('');
     setIsSeasonal(false);
     setDefaultRoaster('EITHER');
     setBatchKg(20);
@@ -66,16 +70,22 @@ export function NewRoastGroupModal({ open, onOpenChange }: Props) {
     setNotes('');
   };
 
+  const effectiveOrigin = origin === ORIGIN_CUSTOM_SENTINEL ? originCustom.trim() : origin;
+
   const handleSave = async () => {
     const trimmed = displayName.trim();
     if (!trimmed) { toast.error('Display name is required'); return; }
+    if (!isBlend && !effectiveOrigin) {
+      toast.error('Origin is required for single-origin roast groups');
+      return;
+    }
 
     setSaving(true);
     try {
       const result = await createOrReuseRoastGroup({
         displayName: trimmed,
         isBlend,
-        origin: isBlend ? null : origin || null,
+        origin: isBlend ? null : effectiveOrigin || null,
         cropsterProfileRef: cropsterRef || null,
         notes: notes || null,
       });
@@ -176,8 +186,15 @@ export function NewRoastGroupModal({ open, onOpenChange }: Props) {
           {/* Origin (single origin only) */}
           {!isBlend && (
             <div>
-              <Label>Origin Country</Label>
-              <Input value={origin} onChange={e => setOrigin(e.target.value)} placeholder="e.g. Guatemala" />
+              <Label>Origin Country *</Label>
+              <OriginSelect
+                value={origin}
+                customValue={originCustom}
+                onChange={({ value, customValue }) => {
+                  setOrigin(value);
+                  setOriginCustom(customValue);
+                }}
+              />
             </div>
           )}
 
@@ -239,7 +256,7 @@ export function NewRoastGroupModal({ open, onOpenChange }: Props) {
 
           <div className="flex justify-end gap-2 pt-2">
             <Button variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>Cancel</Button>
-            <Button onClick={handleSave} disabled={saving || !displayName.trim()}>
+            <Button onClick={handleSave} disabled={saving || !displayName.trim() || (!isBlend && !effectiveOrigin)}>
               {saving && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
               Create
             </Button>

--- a/src/lib/originOptions.ts
+++ b/src/lib/originOptions.ts
@@ -1,0 +1,39 @@
+export const ORIGIN_TOP = [
+  'Brazil',
+  'Colombia',
+  'Ethiopia',
+  'Guatemala',
+  'Honduras',
+  'Kenya',
+  'Peru',
+  'Rwanda',
+] as const;
+
+export const ORIGIN_SECONDARY = [
+  'Bolivia',
+  'China',
+  'Costa Rica',
+  'El Salvador',
+  'India',
+  'Indonesia',
+  'Mexico',
+  'Nicaragua',
+  'Panama',
+  'Papua New Guinea',
+  'Tanzania',
+  'Uganda',
+] as const;
+
+export const ORIGIN_GROUPS: ReadonlyArray<{ label: string; options: readonly string[] }> = [
+  { label: 'Common', options: ORIGIN_TOP },
+  { label: 'Other origins', options: ORIGIN_SECONDARY },
+];
+
+export const ORIGIN_CUSTOM_SENTINEL = '__custom__';
+
+export const ALL_KNOWN_ORIGINS = new Set<string>([...ORIGIN_TOP, ...ORIGIN_SECONDARY]);
+
+export function isKnownOrigin(value: string | null | undefined): boolean {
+  if (!value) return false;
+  return ALL_KNOWN_ORIGINS.has(value);
+}


### PR DESCRIPTION
## Summary

Three coordinated fixes to make the missing-roast-group-origin failure obvious and self-serve, instead of a cryptic "Could not generate SKU" toast.

- **Require origin when creating a roast group.** `NewRoastGroupModal` now uses a grouped `OriginSelect` dropdown (top 8 common + 12 secondary, alphabetized, with an "Other…" free-text fallback) and blocks Save until an origin is set for single-origin groups.
- **Block product create on existing roast groups missing origin.** `NewSingleOriginProductModal` shows a destructive `Alert` with a link directly to the roast group detail page when the selected roast group is single-origin but has no `origin`, disables Save, and replaces the catch-all SKU-generation toast with an actionable message.
- **Bulk-edit Origin column.** The roast groups bulk-edit tab gains an editable Origin column using the same grouped dropdown, so admins can spot and fix missing origins from the list view. `ColumnDef` was extended with `groups` and `allowCustom`; `EditableCell` renders grouped options + separators and switches to inline text mode for "Other…" or legacy free-text values.

## Why

When `roast_groups.origin` was empty, downstream SKU generation in `NewSingleOriginProductModal` failed silently with `Could not generate SKU` and no hint that the fix lived on the roast group detail page. Root cause: the create modal accepted origin as un-validated free text. This PR closes that gap end-to-end without DB schema changes.

## Notes for reviewer

- "Blend" is intentionally **not** in the origin dropdown — the existing Single/Blend radio drives type; the dropdown only renders for Single Origin.
- The existing "Create new roast group" flow inside `NewSingleOriginProductModal` (a separate inline picker using flat `COMMON_ORIGINS`) is intentionally left alone for this PR — migrating it to the shared component is a follow-up.
- No migrations: `roast_groups.origin` stays nullable (blends legitimately have null origin). Existing rows missing origin can be fixed via the new bulk-edit column.

## Test plan

- [ ] Bulk-edit roast groups tab: Origin column appears, dropdown shows two groups with separator and "Other…", saving commits to Supabase, an existing free-text origin renders as inline text.
- [ ] New Roast Group modal: Single Origin → dropdown visible; Save disabled until origin chosen; "Other…" prompts a free-text input that saves correctly. Blend type → dropdown hidden, Save works.
- [ ] In bulk-edit, clear origin on a single-origin roast group. Open New Single-Origin Product modal, pick that roast group → red Alert appears with link, Save disabled. Click link → lands on roast group detail page. Set origin, return, retry → product creates successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)