### PR TITLE
feat: variant column on order detail line items

### DIFF
--- a/src/pages/internal/OrderDetail.tsx
+++ b/src/pages/internal/OrderDetail.tsx
@@ -776,10 +776,10 @@ export default function OrderDetail() {
                 <thead>
                   <tr className="border-b text-left">
                     <th className="pb-2">Product</th>
+                    <th className="pb-2">Variant</th>
                     <th className="pb-2">Demanded</th>
                     <th className="pb-2">Packed</th>
                     <th className="pb-2">Status</th>
-                    <th className="pb-2">Grind</th>
                     <th className="pb-2">Unit Price</th>
                     <th className="pb-2 text-right">Subtotal</th>
                   </tr>
@@ -787,11 +787,9 @@ export default function OrderDetail() {
                 <tbody>
                   {lineItemsWithPackedStatus.map((li) => (
                     <tr key={li.id} className="border-b last:border-0">
+                      <td className="py-2">{li.product?.product_name ?? 'Unknown'}</td>
                       <td className="py-2">
-                        <div className="flex flex-col gap-1">
-                          <span>{li.product?.product_name ?? 'Unknown'}</span>
-                          <PackagingBadge variant={(li.product as { packaging_variant?: PackagingVariant | null } | null)?.packaging_variant ?? null} />
-                        </div>
+                        <PackagingBadge variant={(li.product as { packaging_variant?: PackagingVariant | null } | null)?.packaging_variant ?? null} />
                       </td>
                       <td className="py-2">{li.quantity_units}</td>
                       <td className="py-2">{li.packedUnits}</td>
@@ -807,7 +805,6 @@ export default function OrderDetail() {
                           </Badge>
                         )}
                       </td>
-                      <td className="py-2">{li.grind ?? '—'}</td>
                       <td className="py-2">${li.unit_price_locked.toFixed(2)}</td>
                       <td className="py-2 text-right">${(li.quantity_units * li.unit_price_locked).toFixed(2)}</td>
                     </tr>


### PR DESCRIPTION
## Summary
- Adds a **Variant** column between Product and Demanded on the order detail Line Items table, surfacing each line's `packaging_variant` (e.g. `RETAIL_250G`) at a glance.
- Removes the **Grind** column. Grind isn't part of the order workflow yet, so it always rendered `WHOLE_BEAN` and added noise. Will revisit post-MVP.
- Product cell now shows the product name only (the variant badge previously stacked underneath is gone — it lives in its own column now).

## Why
Reviewers/ops looking at an order couldn't tell which variant was ordered in what quantity without inspecting the small badge tucked under each product name. Promoting variant to a proper column matches how the rest of the table is scanned (one fact per column).

## Scope
- Single file: `src/pages/internal/OrderDetail.tsx` (Line Items table only).
- No schema change — the query already joins `packaging_variant` from `products`.
- Column count unchanged at 7; footer `colSpan={6}` left as-is.

## Test plan
- [ ] `npm run dev` → open an order with multiple line items; confirm Variant column shows the `PackagingBadge`, Grind column is gone, Product cell shows name only.
- [ ] Total row still right-aligns correctly under Subtotal.
- [ ] `npm run lint` passes.
- [ ] `npm run test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)