### PR TITLE
Session A: location validation on order create + pronouns on create forms

### DIFF
--- a/src/components/production/ShipTab.tsx
+++ b/src/components/production/ShipTab.tsx
@@ -82,6 +82,7 @@ interface ShippableOrder {
   missingUnitsTotal: number;
   ship_display_order: number | null;
   manually_deprioritized?: boolean;
+  location_name: string | null;
 }
 
 // ShortListItem type now comes from useAuthoritativeShortList hook
@@ -184,6 +185,7 @@ export function ShipTab({ dateFilterConfig, today }: ShipTabProps) {
           manually_deprioritized,
           client:clients(name),
           account:accounts(account_name),
+          location:client_locations(name, location_code),
           line_items:order_line_items(
             id,
             product_id,
@@ -338,6 +340,7 @@ export function ShipTab({ dateFilterConfig, today }: ShipTabProps) {
         missingUnitsTotal,
         ship_display_order: order.ship_display_order ?? null,
         manually_deprioritized: order.manually_deprioritized ?? false,
+        location_name: (order as any).location?.name ?? null,
       });
     }
 

--- a/src/components/production/SortableShipCard.tsx
+++ b/src/components/production/SortableShipCard.tsx
@@ -12,7 +12,7 @@ import { OverdueBadge, isOrderOverdue } from './OverdueBadge';
 import { format, parseISO } from 'date-fns';
 import { toZonedTime } from 'date-fns-tz';
 import { TIMEZONE } from '@/lib/productionScheduling';
-import { Truck, Clock, ChevronDown, ChevronRight, MessageSquare, AlertTriangle, ExternalLink, Layers, CheckCircle2, GripVertical } from 'lucide-react';
+import { Truck, Clock, ChevronDown, ChevronRight, MessageSquare, AlertTriangle, ExternalLink, Layers, CheckCircle2, GripVertical, MapPin } from 'lucide-react';
 import { PackagingBadge, type PackagingVariant } from '@/components/PackagingBadge';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
@@ -50,6 +50,7 @@ interface ShippableOrder {
   missingUnitsTotal: number;
   ship_display_order: number | null;
   manually_deprioritized?: boolean;
+  location_name: string | null;
 }
 
 interface ShipPick {
@@ -297,6 +298,15 @@ export function SortableShipCard({
             </span>
             <span>•</span>
             <span>{order.delivery_method}</span>
+            {order.location_name && (
+              <>
+                <span>•</span>
+                <span className="flex items-center gap-1">
+                  <MapPin className="h-3 w-3" />
+                  {order.location_name}
+                </span>
+              </>
+            )}
             <span>•</span>
             <span className="flex items-center gap-1">
               <Layers className="h-3 w-3" />

--- a/src/pages/internal/Accounts.tsx
+++ b/src/pages/internal/Accounts.tsx
@@ -17,6 +17,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
 import { Plus, Search, Info, CalendarIcon, Building2, CheckCircle2, Trash2 } from 'lucide-react';
+import { PronounsField } from '@/components/contacts/PronounsField';
 import { cn } from '@/lib/utils';
 import { format } from 'date-fns';
 
@@ -67,6 +68,7 @@ export default function Accounts() {
   // Form state
   const [formName, setFormName] = useState('');
   const [formContact, setFormContact] = useState('');
+  const [formPronouns, setFormPronouns] = useState<string | null>(null);
   const [formEmail, setFormEmail] = useState('');
   const [formPhone, setFormPhone] = useState('');
   const [formAddress, setFormAddress] = useState('');
@@ -116,6 +118,7 @@ export default function Accounts() {
       const payload: Record<string, unknown> = {
         account_name: formName.trim(),
         billing_contact_name: formContact || null,
+        pronouns: formPronouns ? formPronouns.trim() || null : null,
         billing_email: formEmail || null,
         billing_phone: formPhone || null,
         billing_address: formAddress || null,
@@ -157,6 +160,7 @@ export default function Accounts() {
   const resetForm = () => {
     setFormName('');
     setFormContact('');
+    setFormPronouns(null);
     setFormEmail('');
     setFormPhone('');
     setFormAddress('');
@@ -304,6 +308,9 @@ export default function Accounts() {
                   <Label htmlFor="acct-contact">Billing contact</Label>
                   <Input id="acct-contact" value={formContact} onChange={e => setFormContact(e.target.value)} />
                 </div>
+                <PronounsField value={formPronouns} onChange={setFormPronouns} />
+              </div>
+              <div className="grid grid-cols-2 gap-3">
                 <div>
                   <Label htmlFor="acct-email">Billing email</Label>
                   <Input id="acct-email" type="email" value={formEmail} onChange={e => setFormEmail(e.target.value)} />

--- a/src/pages/internal/CreateOrderForClient.tsx
+++ b/src/pages/internal/CreateOrderForClient.tsx
@@ -120,6 +120,22 @@ export default function CreateOrderForClient() {
     },
   });
 
+  // Fetch client locations (shared cache key with LocationSelect component)
+  const { data: clientLocations } = useQuery({
+    queryKey: ['client-locations', selectedClientId],
+    queryFn: async () => {
+      if (!selectedClientId) return [];
+      const { data, error } = await supabase
+        .from('client_locations')
+        .select('id')
+        .eq('client_id', selectedClientId)
+        .eq('is_active', true);
+      if (error) throw error;
+      return data ?? [];
+    },
+    enabled: !!selectedClientId,
+  });
+
   // Fetch products for selected client with packaging type join
   const { data: products, isLoading: productsLoading } = useQuery({
     queryKey: ['client-products-admin', selectedClientId],
@@ -292,6 +308,10 @@ export default function CreateOrderForClient() {
   const submitOrder = async () => {
     if (!selectedClientId) {
       toast.error('Select a client');
+      return;
+    }
+    if (clientLocations && clientLocations.length > 0 && !selectedLocationId) {
+      toast.error('Select a delivery location for this client');
       return;
     }
     if (lineItems.length === 0) {
@@ -573,6 +593,7 @@ export default function CreateOrderForClient() {
               clientId={selectedClientId}
               value={selectedLocationId}
               onChange={setSelectedLocationId}
+              required
             />
           )}
         </CardContent>

--- a/src/pages/internal/Prospects.tsx
+++ b/src/pages/internal/Prospects.tsx
@@ -13,6 +13,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
 import { Plus, CheckCircle2, Trash2 } from 'lucide-react';
 import type { Database } from '@/integrations/supabase/types';
+import { PronounsField } from '@/components/contacts/PronounsField';
 
 type ProspectStream = Database['public']['Enums']['prospect_stream'];
 type ProspectStage = Database['public']['Enums']['prospect_stage'];
@@ -62,6 +63,7 @@ export default function Prospects() {
   // Form state
   const [formName, setFormName] = useState('');
   const [formContact, setFormContact] = useState('');
+  const [formPronouns, setFormPronouns] = useState<string | null>(null);
   const [formEmail, setFormEmail] = useState('');
   const [formPhone, setFormPhone] = useState('');
   const [formStream, setFormStream] = useState<ProspectStream>('CO_ROAST');
@@ -84,6 +86,7 @@ export default function Prospects() {
       const { error } = await supabase.from('prospects').insert({
         business_name: formName.trim(),
         contact_name: formContact.trim() || null,
+        pronouns: formPronouns ? formPronouns.trim() || null : null,
         contact_info: contactInfo,
         stream: formStream,
         created_by: authUser!.id,
@@ -102,6 +105,7 @@ export default function Prospects() {
     setShowDialog(false);
     setFormName('');
     setFormContact('');
+    setFormPronouns(null);
     setFormEmail('');
     setFormPhone('');
     setFormStream('CO_ROAST');
@@ -201,6 +205,7 @@ export default function Prospects() {
                 placeholder="Jane Smith"
               />
             </div>
+            <PronounsField value={formPronouns} onChange={setFormPronouns} />
             <div>
               <Label htmlFor="email">Email</Label>
               <Input


### PR DESCRIPTION
## Summary

Bundle of two small internal-user feedback items (Session A from the May 11 JIM Feedback Brief).

### Item 1 — Order location visibility (multi-location clients)
- `CreateOrderForClient.tsx`: query `client_locations` count for the selected client; block submit with `"Select a delivery location for this client"` when client has any locations and none is selected. `LocationSelect` marked `required` so the asterisk shows.
- `ShipTab.tsx`: orders query now joins `client_locations(name, location_code)` via the existing `orders.location_id` FK.
- `SortableShipCard.tsx`: location name displayed inline in the metrics row with a `MapPin` icon (between delivery method and SKU count). Renders only when `location_name` is set, so single-location and legacy orders are unaffected.

### Item 3 — Preferred pronouns on contact create forms
The internal admin edit flows (`AccountDetail.tsx`, `ProspectDetail.tsx`) and list displays already had pronouns wired up. The gap was the *create* dialogs — addressed here:
- `Prospects.tsx`: `PronounsField` added to the Add Prospect dialog (state, reset, and insert payload).
- `Accounts.tsx`: `PronounsField` added to the New Account modal (same wiring).

Both reuse the existing `src/components/contacts/PronounsField.tsx` component. No DB schema changes — `accounts.pronouns` and `prospects.pronouns` columns already exist.

## Out of scope (deferred)
- Item 2 (Product Dependency Map page) — context brief saved separately for a future session.
- Item 4 (Admin/OPS email notification preferences for new orders + bookings) — deferred for later scoping.

## Test plan

- [ ] Admin creates an order for a multi-location client without picking a location → submit blocked with toast.
- [ ] Admin picks a location and submits → order created, location visible on the ship-queue card.
- [ ] Single-location (or no-location) client unaffected on the create page.
- [ ] Existing orders without a `location_id` still render in `ShipTab` (no broken join, no missing badge).
- [ ] New Account modal: pronouns saved to `accounts.pronouns` and displayed on `AccountDetail` afterward.
- [ ] Add Prospect dialog: pronouns saved to `prospects.pronouns` and visible on the Prospects list (`{name} ({pronouns})`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)