### PR TITLE
Product Map: hover reorders + aligns connected columns

### DIFF
--- a/src/pages/internal/ProductMap.tsx
+++ b/src/pages/internal/ProductMap.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { Badge } from '@/components/ui/badge';
@@ -74,7 +74,12 @@ function bagLabel(g: number): string {
 export default function ProductMap() {
   const [hoveredLotId, setHoveredLotId] = useState<string | null>(null);
   const [hoveredRg, setHoveredRg] = useState<string | null>(null);
-  const [hoveredProductId, setHoveredProductId] = useState<string | null>(null);
+  const [alignTop, setAlignTop] = useState<number | null>(null);
+  const [hoverSource, setHoverSource] = useState<'lot' | 'rg' | 'product' | null>(null);
+
+  const lotColRef = useRef<HTMLDivElement>(null);
+  const rgColRef = useRef<HTMLDivElement>(null);
+  const productColRef = useRef<HTMLDivElement>(null);
 
   // ── Queries ──────────────────────────────────────────────────────────────
 
@@ -188,19 +193,92 @@ export default function ProductMap() {
       for (const p of rgToProducts.get(hoveredRg) ?? []) productIds.add(p.id);
     }
 
-    if (hoveredProductId) {
-      productIds.add(hoveredProductId);
-      const p = (products ?? []).find(p => p.id === hoveredProductId);
-      if (p?.roast_group) {
-        rgs.add(p.roast_group);
-        for (const lotId of rgToLots.get(p.roast_group) ?? []) lotIds.add(lotId);
-      }
-    }
-
     return { highlightedLotIds: lotIds, highlightedRgs: rgs, highlightedProductIds: productIds };
-  }, [hoveredLotId, hoveredRg, hoveredProductId, lotToRGs, rgToLots, rgToProducts, blendComponents, products]);
+  }, [hoveredLotId, hoveredRg, lotToRGs, rgToLots, rgToProducts, blendComponents]);
 
-  const anyHover = hoveredLotId !== null || hoveredRg !== null || hoveredProductId !== null;
+  const anyHover = hoveredLotId !== null || hoveredRg !== null;
+
+  // ── Event handlers ────────────────────────────────────────────────────────
+
+  function handleLotEnter(e: React.MouseEvent, lotId: string) {
+    setHoveredLotId(lotId);
+    setHoverSource('lot');
+    setAlignTop(e.currentTarget.getBoundingClientRect().top);
+  }
+  function handleLotLeave() {
+    setHoveredLotId(null);
+    setHoverSource(null);
+    setAlignTop(null);
+  }
+
+  function handleRgEnter(e: React.MouseEvent, rg: string) {
+    setHoveredRg(rg);
+    setHoverSource('rg');
+    setAlignTop(e.currentTarget.getBoundingClientRect().top);
+  }
+  function handleRgLeave() {
+    setHoveredRg(null);
+    setHoverSource(null);
+    setAlignTop(null);
+  }
+
+  function handleProductGroupEnter(e: React.MouseEvent, rg: string) {
+    setHoveredRg(rg);
+    setHoverSource('product');
+    setAlignTop(e.currentTarget.getBoundingClientRect().top);
+  }
+  function handleProductGroupLeave() {
+    setHoveredRg(null);
+    setHoverSource(null);
+    setAlignTop(null);
+  }
+
+  // ── Spacer helper ─────────────────────────────────────────────────────────
+
+  function getSpacerHeight(colRef: React.RefObject<HTMLDivElement>): number {
+    if (alignTop === null || !colRef.current) return 0;
+    return Math.max(0, alignTop - colRef.current.getBoundingClientRect().top);
+  }
+
+  // ── Sort helpers ──────────────────────────────────────────────────────────
+
+  function sortLots() {
+    const connected: Lot[] = [], unconnected: Lot[] = [];
+    for (const lot of lots ?? [])
+      (highlightedLotIds.has(lot.id) ? connected : unconnected).push(lot);
+    return { connected, unconnected };
+  }
+
+  function sortRgs() {
+    const connected: RoastGroup[] = [], unconnected: RoastGroup[] = [];
+    for (const rg of roastGroups ?? [])
+      (highlightedRgs.has(rg.roast_group) ? connected : unconnected).push(rg);
+    return { connected, unconnected };
+  }
+
+  function sortProductGroups() {
+    const connected: RoastGroup[] = [], unconnected: RoastGroup[] = [];
+    for (const rg of roastGroups ?? []) {
+      if ((rgToProducts.get(rg.roast_group) ?? []).length === 0) continue;
+      (highlightedRgs.has(rg.roast_group) ? connected : unconnected).push(rg);
+    }
+    return { connected, unconnected };
+  }
+
+  // ── Pre-render partitions ─────────────────────────────────────────────────
+
+  const needsLotSort = hoverSource === 'rg' || hoverSource === 'product';
+  const needsRgSort = hoverSource === 'lot' || hoverSource === 'product';
+  const needsProdSort = hoverSource === 'lot' || hoverSource === 'rg';
+
+  const { connected: connectedLots, unconnected: unconnectedLots } =
+    needsLotSort ? sortLots() : { connected: [], unconnected: [] };
+  const { connected: connectedRgs, unconnected: unconnectedRgs } =
+    needsRgSort ? sortRgs() : { connected: [], unconnected: [] };
+  const { connected: connectedProdGroups, unconnected: unconnectedProdGroups } =
+    needsProdSort ? sortProductGroups() : { connected: [], unconnected: [] };
+
+  // ── Card styles ───────────────────────────────────────────────────────────
 
   function cardClass(highlighted: boolean) {
     return cn(
@@ -229,6 +307,175 @@ export default function ProductMap() {
     );
   }
 
+  // ── Lot card renderer ─────────────────────────────────────────────────────
+
+  function LotCard({ lot }: { lot: Lot }) {
+    return (
+      <div
+        key={lot.id}
+        className={cardClass(highlightedLotIds.has(lot.id))}
+        onMouseEnter={e => handleLotEnter(e, lot.id)}
+        onMouseLeave={handleLotLeave}
+      >
+        <div className="flex items-start justify-between gap-2">
+          <span className="font-mono text-sm font-semibold">{lot.lot_number}</span>
+          {statusBadge(lot.status)}
+        </div>
+        {lot.contract && (
+          <p className="text-xs text-muted-foreground mt-0.5 leading-tight">
+            {[lot.contract.origin ?? lot.contract.origin_country, lot.contract.producer]
+              .filter(Boolean)
+              .join(' · ')}
+          </p>
+        )}
+        <p className="text-xs text-muted-foreground mt-0.5">
+          {lot.kg_on_hand.toFixed(1)} kg on hand
+        </p>
+        {lot.links.length === 0 && (
+          <p className="text-[10px] text-muted-foreground/60 mt-1 italic">
+            No roast group linked
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  // ── RG card renderer ──────────────────────────────────────────────────────
+
+  function RgCard({ rg }: { rg: RoastGroup }) {
+    const directLots = rgToLots.get(rg.roast_group) ?? [];
+    const componentRgs = blendComponents.get(rg.roast_group) ?? [];
+    const hasComponentsWithLots = componentRgs.some(c => (rgToLots.get(c) ?? []).length > 0);
+    const showNoLotsWarning = directLots.length === 0 && !hasComponentsWithLots;
+    const productsForRg = rgToProducts.get(rg.roast_group) ?? [];
+
+    return (
+      <div
+        key={rg.roast_group}
+        className={cardClass(highlightedRgs.has(rg.roast_group))}
+        onMouseEnter={e => handleRgEnter(e, rg.roast_group)}
+        onMouseLeave={handleRgLeave}
+      >
+        <div className="flex items-start justify-between gap-2">
+          <span className="text-sm font-semibold">{rg.display_name}</span>
+          {rg.is_blend ? (
+            <Badge className="bg-blue-100 text-blue-800 border-blue-200 text-[10px] px-1.5 py-0 flex-shrink-0 font-medium">
+              {rg.blend_type === 'PRE_ROAST'
+                ? 'PRE-ROAST BLEND'
+                : rg.blend_type === 'POST_ROAST'
+                ? 'POST-ROAST BLEND'
+                : 'BLEND'}
+            </Badge>
+          ) : (
+            <Badge
+              variant="outline"
+              className="text-[10px] px-1.5 py-0 text-green-700 border-green-200 flex-shrink-0"
+            >
+              SINGLE ORIGIN
+            </Badge>
+          )}
+        </div>
+
+        {!rg.is_blend && rg.origin && (
+          <p className="text-xs text-muted-foreground mt-0.5">{rg.origin}</p>
+        )}
+
+        {rg.is_blend && rg.components.length > 0 && (
+          <div className="mt-1.5 space-y-0.5">
+            {rg.components.map(c => (
+              <p key={c.component_roast_group} className="text-xs text-muted-foreground">
+                {rgNameMap.get(c.component_roast_group) ?? c.component_roast_group}
+                <span className="ml-1.5 font-medium text-foreground/70">{c.pct}%</span>
+              </p>
+            ))}
+          </div>
+        )}
+
+        {rg.is_blend && rg.blend_type === 'POST_ROAST' && (
+          <p className="text-[10px] text-muted-foreground/60 mt-1 italic">
+            Post-roast — green lots per component above
+          </p>
+        )}
+
+        <div className="mt-1.5 flex flex-wrap gap-x-3">
+          {showNoLotsWarning && (
+            <p className="text-[10px] text-amber-600 flex items-center gap-1">
+              <AlertTriangle className="h-2.5 w-2.5" />
+              No lots linked
+            </p>
+          )}
+          {productsForRg.length === 0 && (
+            <p className="text-[10px] text-muted-foreground/50 italic">No products</p>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // ── Product group card renderer ───────────────────────────────────────────
+
+  function ProductGroupCard({ rg }: { rg: RoastGroup }) {
+    const productsForRg = rgToProducts.get(rg.roast_group) ?? [];
+    if (productsForRg.length === 0) return null;
+
+    const byAccount = new Map<string, { name: string; products: Product[] }>();
+    for (const p of productsForRg) {
+      const key = p.account_id ?? '__unknown__';
+      const name = p.accounts?.account_name ?? 'Unknown Account';
+      if (!byAccount.has(key)) byAccount.set(key, { name, products: [] });
+      byAccount.get(key)!.products.push(p);
+    }
+
+    const rgHighlighted = highlightedRgs.has(rg.roast_group);
+
+    return (
+      <div
+        key={rg.roast_group}
+        className={cn(
+          'rounded-lg border transition-all duration-100 cursor-default',
+          anyHover
+            ? rgHighlighted
+              ? 'border-amber-300 ring-1 ring-amber-200'
+              : 'opacity-30 border-border'
+            : 'border-border hover:border-muted-foreground/40'
+        )}
+        onMouseEnter={e => handleProductGroupEnter(e, rg.roast_group)}
+        onMouseLeave={handleProductGroupLeave}
+      >
+        <div className="px-3 py-2 border-b bg-muted/30 rounded-t-lg">
+          <span className="text-xs font-semibold text-foreground/80">{rg.display_name}</span>
+        </div>
+        <div className="p-2 space-y-2">
+          {Array.from(byAccount.values()).map(({ name, products: acctProducts }) => (
+            <div key={name}>
+              <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground px-1 mb-0.5">
+                {name}
+              </p>
+              {acctProducts.map(p => (
+                <div
+                  key={p.id}
+                  className={cn(
+                    'flex items-center justify-between rounded px-2 py-1 cursor-default transition-all duration-100',
+                    anyHover
+                      ? highlightedProductIds.has(p.id)
+                        ? 'bg-amber-50'
+                        : 'opacity-40'
+                      : 'hover:bg-muted/50'
+                  )}
+                >
+                  <span className="text-xs">{p.product_name}</span>
+                  <span className="text-[10px] text-muted-foreground ml-2 flex-shrink-0 font-mono">
+                    {bagLabel(p.bag_size_g)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-col min-h-full">
       {/* ── Page header ──────────────────────────────────────────────────── */}
@@ -246,200 +493,99 @@ export default function ProductMap() {
       <div className="flex divide-x flex-1">
 
         {/* ── Green Lots ─────────────────────────────────────────────────── */}
-        <div className="w-72 flex-shrink-0 p-4 space-y-2">
+        <div className="w-72 flex-shrink-0 p-4">
           <h2 className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground mb-3 flex items-center gap-1.5">
             <Leaf className="h-3 w-3" />
             Green Lots
           </h2>
 
-          {(lots ?? []).length === 0 && (
-            <p className="text-sm text-muted-foreground italic">No active lots</p>
-          )}
+          <div ref={lotColRef}>
+            {(lots ?? []).length === 0 && (
+              <p className="text-sm text-muted-foreground italic">No active lots</p>
+            )}
 
-          {(lots ?? []).map(lot => (
-            <div
-              key={lot.id}
-              className={cardClass(highlightedLotIds.has(lot.id))}
-              onMouseEnter={() => setHoveredLotId(lot.id)}
-              onMouseLeave={() => setHoveredLotId(null)}
-            >
-              <div className="flex items-start justify-between gap-2">
-                <span className="font-mono text-sm font-semibold">{lot.lot_number}</span>
-                {statusBadge(lot.status)}
+            {!needsLotSort ? (
+              <div className="space-y-2">
+                {(lots ?? []).map(lot => <LotCard key={lot.id} lot={lot} />)}
               </div>
-              {lot.contract && (
-                <p className="text-xs text-muted-foreground mt-0.5 leading-tight">
-                  {[lot.contract.origin ?? lot.contract.origin_country, lot.contract.producer]
-                    .filter(Boolean)
-                    .join(' · ')}
-                </p>
-              )}
-              <p className="text-xs text-muted-foreground mt-0.5">
-                {lot.kg_on_hand.toFixed(1)} kg on hand
-              </p>
-              {lot.links.length === 0 && (
-                <p className="text-[10px] text-muted-foreground/60 mt-1 italic">
-                  No roast group linked
-                </p>
-              )}
-            </div>
-          ))}
+            ) : (
+              <>
+                <div style={{ height: getSpacerHeight(lotColRef) }} />
+                <div className="space-y-2">
+                  {connectedLots.map(lot => <LotCard key={lot.id} lot={lot} />)}
+                </div>
+                {unconnectedLots.length > 0 && (
+                  <div className="space-y-2 mt-2">
+                    {unconnectedLots.map(lot => <LotCard key={lot.id} lot={lot} />)}
+                  </div>
+                )}
+              </>
+            )}
+          </div>
         </div>
 
         {/* ── Roast Groups ─────────────────────────────────────────────────── */}
-        <div className="flex-1 p-4 space-y-2">
+        <div className="flex-1 p-4">
           <h2 className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground mb-3 flex items-center gap-1.5">
             <Network className="h-3 w-3" />
             Roast Groups
           </h2>
 
-          {(roastGroups ?? []).length === 0 && (
-            <p className="text-sm text-muted-foreground italic">No active roast groups</p>
-          )}
+          <div ref={rgColRef}>
+            {(roastGroups ?? []).length === 0 && (
+              <p className="text-sm text-muted-foreground italic">No active roast groups</p>
+            )}
 
-          {(roastGroups ?? []).map(rg => {
-            const directLots = rgToLots.get(rg.roast_group) ?? [];
-            const componentRgs = blendComponents.get(rg.roast_group) ?? [];
-            const hasComponentsWithLots = componentRgs.some(c => (rgToLots.get(c) ?? []).length > 0);
-            const showNoLotsWarning = directLots.length === 0 && !hasComponentsWithLots;
-            const productsForRg = rgToProducts.get(rg.roast_group) ?? [];
-
-            return (
-              <div
-                key={rg.roast_group}
-                className={cardClass(highlightedRgs.has(rg.roast_group))}
-                onMouseEnter={() => setHoveredRg(rg.roast_group)}
-                onMouseLeave={() => setHoveredRg(null)}
-              >
-                <div className="flex items-start justify-between gap-2">
-                  <span className="text-sm font-semibold">{rg.display_name}</span>
-                  {rg.is_blend ? (
-                    <Badge className="bg-blue-100 text-blue-800 border-blue-200 text-[10px] px-1.5 py-0 flex-shrink-0 font-medium">
-                      {rg.blend_type === 'PRE_ROAST'
-                        ? 'PRE-ROAST BLEND'
-                        : rg.blend_type === 'POST_ROAST'
-                        ? 'POST-ROAST BLEND'
-                        : 'BLEND'}
-                    </Badge>
-                  ) : (
-                    <Badge
-                      variant="outline"
-                      className="text-[10px] px-1.5 py-0 text-green-700 border-green-200 flex-shrink-0"
-                    >
-                      SINGLE ORIGIN
-                    </Badge>
-                  )}
+            {!needsRgSort ? (
+              <div className="space-y-2">
+                {(roastGroups ?? []).map(rg => <RgCard key={rg.roast_group} rg={rg} />)}
+              </div>
+            ) : (
+              <>
+                <div style={{ height: getSpacerHeight(rgColRef) }} />
+                <div className="space-y-2">
+                  {connectedRgs.map(rg => <RgCard key={rg.roast_group} rg={rg} />)}
                 </div>
-
-                {!rg.is_blend && rg.origin && (
-                  <p className="text-xs text-muted-foreground mt-0.5">{rg.origin}</p>
-                )}
-
-                {rg.is_blend && rg.components.length > 0 && (
-                  <div className="mt-1.5 space-y-0.5">
-                    {rg.components.map(c => (
-                      <p key={c.component_roast_group} className="text-xs text-muted-foreground">
-                        {rgNameMap.get(c.component_roast_group) ?? c.component_roast_group}
-                        <span className="ml-1.5 font-medium text-foreground/70">{c.pct}%</span>
-                      </p>
-                    ))}
+                {unconnectedRgs.length > 0 && (
+                  <div className="space-y-2 mt-2">
+                    {unconnectedRgs.map(rg => <RgCard key={rg.roast_group} rg={rg} />)}
                   </div>
                 )}
-
-                {rg.is_blend && rg.blend_type === 'POST_ROAST' && (
-                  <p className="text-[10px] text-muted-foreground/60 mt-1 italic">
-                    Post-roast — green lots per component above
-                  </p>
-                )}
-
-                <div className="mt-1.5 flex flex-wrap gap-x-3">
-                  {showNoLotsWarning && (
-                    <p className="text-[10px] text-amber-600 flex items-center gap-1">
-                      <AlertTriangle className="h-2.5 w-2.5" />
-                      No lots linked
-                    </p>
-                  )}
-                  {productsForRg.length === 0 && (
-                    <p className="text-[10px] text-muted-foreground/50 italic">No products</p>
-                  )}
-                </div>
-              </div>
-            );
-          })}
+              </>
+            )}
+          </div>
         </div>
 
         {/* ── Products ──────────────────────────────────────────────────────── */}
-        <div className="w-80 flex-shrink-0 p-4 space-y-2">
+        <div className="w-80 flex-shrink-0 p-4">
           <h2 className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground mb-3 flex items-center gap-1.5">
             <Package className="h-3 w-3" />
             Products
           </h2>
 
-          {(roastGroups ?? []).map(rg => {
-            const productsForRg = rgToProducts.get(rg.roast_group) ?? [];
-            if (productsForRg.length === 0) return null;
-
-            const byAccount = new Map<string, { name: string; products: Product[] }>();
-            for (const p of productsForRg) {
-              const key = p.account_id ?? '__unknown__';
-              const name = p.accounts?.account_name ?? 'Unknown Account';
-              if (!byAccount.has(key)) byAccount.set(key, { name, products: [] });
-              byAccount.get(key)!.products.push(p);
-            }
-
-            const rgHighlighted = highlightedRgs.has(rg.roast_group);
-
-            return (
-              <div
-                key={rg.roast_group}
-                className={cn(
-                  'rounded-lg border transition-all duration-100',
-                  anyHover
-                    ? rgHighlighted
-                      ? 'border-amber-300 ring-1 ring-amber-200'
-                      : 'opacity-30 border-border'
-                    : 'border-border'
-                )}
-              >
-                <div className="px-3 py-2 border-b bg-muted/30 rounded-t-lg">
-                  <span className="text-xs font-semibold text-foreground/80">{rg.display_name}</span>
-                </div>
-                <div className="p-2 space-y-2">
-                  {Array.from(byAccount.values()).map(({ name, products: acctProducts }) => (
-                    <div key={name}>
-                      <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground px-1 mb-0.5">
-                        {name}
-                      </p>
-                      {acctProducts.map(p => (
-                        <div
-                          key={p.id}
-                          className={cn(
-                            'flex items-center justify-between rounded px-2 py-1 cursor-default transition-all duration-100',
-                            anyHover
-                              ? highlightedProductIds.has(p.id)
-                                ? 'bg-amber-50'
-                                : 'opacity-40'
-                              : 'hover:bg-muted/50'
-                          )}
-                          onMouseEnter={() => setHoveredProductId(p.id)}
-                          onMouseLeave={() => setHoveredProductId(null)}
-                        >
-                          <span className="text-xs">{p.product_name}</span>
-                          <span className="text-[10px] text-muted-foreground ml-2 flex-shrink-0 font-mono">
-                            {bagLabel(p.bag_size_g)}
-                          </span>
-                        </div>
-                      ))}
-                    </div>
-                  ))}
-                </div>
+          <div ref={productColRef}>
+            {!needsProdSort ? (
+              <div className="space-y-2">
+                {(roastGroups ?? []).map(rg => <ProductGroupCard key={rg.roast_group} rg={rg} />)}
               </div>
-            );
-          })}
+            ) : (
+              <>
+                <div style={{ height: getSpacerHeight(productColRef) }} />
+                <div className="space-y-2">
+                  {connectedProdGroups.map(rg => <ProductGroupCard key={rg.roast_group} rg={rg} />)}
+                </div>
+                {unconnectedProdGroups.length > 0 && (
+                  <div className="space-y-2 mt-2">
+                    {unconnectedProdGroups.map(rg => <ProductGroupCard key={rg.roast_group} rg={rg} />)}
+                  </div>
+                )}
+              </>
+            )}
 
-          {(roastGroups ?? []).every(rg => (rgToProducts.get(rg.roast_group) ?? []).length === 0) && (
-            <p className="text-sm text-muted-foreground italic">No products linked to active roast groups</p>
-          )}
+            {(roastGroups ?? []).every(rg => (rgToProducts.get(rg.roast_group) ?? []).length === 0) && (
+              <p className="text-sm text-muted-foreground italic">No products linked to active roast groups</p>
+            )}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Hovering an item on the Product Map now reorders the two non-source columns so connected items float to the top
- A top spacer is inserted in each non-source column so the **first connected item** aligns to the hovered item's viewport Y position — makes cross-column connections readable when items are far apart vertically
- Source column (the one containing the hovered item) does not reorder itself
- Products column hover moved from individual product rows to the group card (per RG); existing per-row amber/dim styling still applies via `highlightedProductIds`

## How it works

- New state: `alignTop` (viewport Y of hovered item, captured from `e.currentTarget.getBoundingClientRect().top`) and `hoverSource` (`'lot' | 'rg' | 'product'`)
- New refs (`lotColRef`, `rgColRef`, `productColRef`) point to each column's items wrapper below its header
- `getSpacerHeight(colRef)` = `max(0, alignTop - colRef.top)` — computed at render time
- `sortLots` / `sortRgs` / `sortProductGroups` partition items by `highlightedLotIds` / `highlightedRgs`
- `hoveredProductId` state removed (individual product hover retired); product group hover sets `hoveredRg` so the existing highlight memo continues working unchanged

## Test plan

- [ ] `/internal/product-map` loads
- [ ] Hover a green lot → RG + Products columns reorder, first connected RG/product group aligns to the lot's Y position; unconnected dim below
- [ ] Hover a roast group → Lots + Products columns reorder/align
- [ ] Hover a product group card → Lots + RGs columns reorder/align
- [ ] Mouse off → all columns return to natural order, no spacer
- [ ] Lot with no roast group links → hover dims everything in the other columns, no alignment artifacts
- [ ] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)