### PR TITLE
Fix Add Batch modal misrouting batches to wrong roast group

### DIFF
--- a/src/components/production/RoastTab.tsx
+++ b/src/components/production/RoastTab.tsx
@@ -146,6 +146,18 @@ export function RoastTab({ dateFilterConfig, today }: RoastTabProps) {
   const [addBatchSaving, setAddBatchSaving] = useState(false);
   const [addBatchNewName, setAddBatchNewName] = useState('');
 
+  const resetAddBatchModal = () => {
+    setShowAddBatchModal(false);
+    setAddBatchRgKey('');
+    setAddBatchNewName('');
+    setAddBatchKg('');
+    setAddBatchRoaster('');
+    setAddBatchDate(today);
+    setAddBatchCropster('');
+    setAddBatchMode('existing');
+    setAddBatchSaving(false);
+  };
+
   // Depletion warning modal state (Add Batch flow)
   const [depletionState, setDepletionState] = useState<{
     roastGroupKey: string;
@@ -1405,17 +1417,7 @@ export function RoastTab({ dateFilterConfig, today }: RoastTabProps) {
       )}
       {/* Add Batch Modal */}
       <Dialog open={showAddBatchModal} onOpenChange={(open) => {
-        if (!open) {
-          setShowAddBatchModal(false);
-          setAddBatchRgKey('');
-          setAddBatchNewName('');
-          setAddBatchKg('');
-          setAddBatchRoaster('');
-          setAddBatchDate(today);
-          setAddBatchCropster('');
-          setAddBatchMode('existing');
-          setAddBatchSaving(false);
-        }
+        if (!open) resetAddBatchModal();
       }}>
         <DialogContent className="max-w-lg">
           <DialogHeader>
@@ -1531,7 +1533,7 @@ export function RoastTab({ dateFilterConfig, today }: RoastTabProps) {
           </div>
 
           <div className="flex justify-end gap-2 mt-4">
-            <Button variant="outline" onClick={() => setShowAddBatchModal(false)}>
+            <Button variant="outline" onClick={resetAddBatchModal}>
               Cancel
             </Button>
             <Button
@@ -1587,15 +1589,18 @@ export function RoastTab({ dateFilterConfig, today }: RoastTabProps) {
 
                     toast.success(swaps.length > 0 ? `Batch added — ${swaps.length} successor swap(s) applied` : 'Batch added');
                     queryClient.invalidateQueries({ queryKey: ['roasted-batches'] });
-                    setShowAddBatchModal(false);
-                    setAddBatchRgKey('');
-                    setAddBatchNewName('');
-                    setAddBatchKg('');
-                    setAddBatchRoaster('');
-                    setAddBatchDate(today);
-                    setAddBatchCropster('');
-                    setAddBatchMode('existing');
+                    resetAddBatchModal();
                   };
+
+                  // Guard: roastGroupKey must be a known group
+                  if (addBatchMode === 'existing') {
+                    const known = (roastGroupsConfig ?? []).some(rg => rg.roast_group === roastGroupKey);
+                    if (!known) {
+                      toast.error('Roast group selection is invalid — please re-select and try again.');
+                      setAddBatchSaving(false);
+                      return;
+                    }
+                  }
 
                   // Skip depletion check for brand-new groups (no links yet)
                   if (!isNewlyCreated) {


### PR DESCRIPTION
## Summary

- Fixes F-011: Add Batch modal could insert batches under the wrong `roast_group` when stale state leaked across modal openings.
- Cancel button now resets the full modal state (previously only hid the dialog).
- Adds a defensive guard that rejects submission if the selected roast-group key isn't present in `roastGroupsConfig`.

## Root cause

`src/components/production/RoastTab.tsx` Cancel button (was line 1534) called `setShowAddBatchModal(false)` only. In Radix controlled-Dialog mode, `onOpenChange` does not fire when `open` is externally flipped to `false`, so the existing reset block in `onOpenChange` was bypassed. Sequence that produced the bug:

1. Open modal from a roast-group row card → `addBatchRgKey` set to that group (e.g. Ethiopia – Banko Dhadato).
2. Cancel via the Cancel button → state retained.
3. Open via the global Add Batch button (which never sets `addBatchRgKey`) → modal re-mounts with the previous group still selected.
4. Submit → insert goes to the wrong `roast_group`.

The reported 8.4 kg expected on Ethiopia is exactly `10 kg × (1 − 16% yield loss)`, confirming the row was inserted with the stale key plus the user's 10 kg planned output.

## Changes

- Extract `resetAddBatchModal()` helper covering all nine pieces of modal state.
- Call it from `onOpenChange`, the Cancel button, and the post-insert success path.
- Add a submit-time guard: if `addBatchMode === 'existing'` and `addBatchRgKey` is not in `roastGroupsConfig`, toast an error and abort. Belt-and-suspenders against any future stale-state regression.

## Test plan

- [ ] Open modal from a roast-group row → Cancel (not Escape) → open via global Add Batch → combobox shows placeholder, not the previous group.
- [ ] Repeat above, select a different group, submit → verify Planned column updates on the selected group only.
- [ ] Open via global Add Batch with no prior context → select a group → submit → verify correct routing.
- [ ] Inspect Supabase `roasted_batches.roast_group` for each test row.
- [ ] Quick-add chips still work (regression check — they bypass the modal entirely).

🤖 Generated with [Claude Code](https://claude.com/claude-code)