### PR TITLE
Warn on past Requested Ship Date (F-005)

### DIFF
--- a/src/pages/client/NewOrder.tsx
+++ b/src/pages/client/NewOrder.tsx
@@ -77,6 +77,9 @@ export default function NewOrder() {
     return date.toISOString().split('T')[0];
   }, []);
 
+  const todayIsoDate = useMemo(() => new Date().toISOString().split('T')[0], []);
+  const isShipDateInPast = shipPreference === 'SPECIFIC' && !!requestedShipDate && requestedShipDate < todayIsoDate;
+
   const [showUnusualModal, setShowUnusualModal] = useState(false);
   const [flaggedItems, setFlaggedItems] = useState<FlaggedItem[]>([]);
   const [totalFlag, setTotalFlag] = useState<{
@@ -359,6 +362,11 @@ export default function NewOrder() {
         toast.error(`"${invalidItem.displayName}" quantity must be a multiple of ${constraints.caseSize} (case size).`);
         return;
       }
+    }
+
+    if (isShipDateInPast) {
+      const ok = window.confirm('Requested Ship Date is in the past. Submit order anyway?');
+      if (!ok) return;
     }
 
     const isUnusual = await checkUnusualOrderSize();
@@ -876,6 +884,11 @@ export default function NewOrder() {
                       min={minSpecificDate}
                       onChange={(e) => setRequestedShipDate(e.target.value)}
                     />
+                    {isShipDateInPast && (
+                      <p className="text-xs text-amber-600 mt-1">
+                        ⚠ That date has already passed. Confirm this is intentional.
+                      </p>
+                    )}
                   </div>
                 )}
                 

--- a/src/pages/internal/CreateOrderForClient.tsx
+++ b/src/pages/internal/CreateOrderForClient.tsx
@@ -105,6 +105,9 @@ export default function CreateOrderForClient() {
   const [internalNotes, setInternalNotes] = useState('');
   const [submitting, setSubmitting] = useState(false);
 
+  const todayIsoDate = useMemo(() => new Date().toISOString().split('T')[0], []);
+  const isShipDateInPast = !!requestedShipDate && requestedShipDate < todayIsoDate;
+
   // Fetch all accounts (replaces legacy clients query)
   const { data: clients } = useQuery({
     queryKey: ['all-accounts-for-orders'],
@@ -327,6 +330,11 @@ export default function CreateOrderForClient() {
     if (missingPrice) {
       toast.error(`"${missingPrice.displayName}" has no price set.`);
       return;
+    }
+
+    if (isShipDateInPast) {
+      const ok = window.confirm('Requested Ship Date is in the past. Create order anyway?');
+      if (!ok) return;
     }
 
     setSubmitting(true);
@@ -704,6 +712,11 @@ export default function CreateOrderForClient() {
                     value={requestedShipDate}
                     onChange={(e) => setRequestedShipDate(e.target.value)}
                   />
+                  {isShipDateInPast && (
+                    <p className="text-xs text-amber-600 mt-1">
+                      ⚠ That date has already passed. Confirm this is intentional.
+                    </p>
+                  )}
                 </div>
                 <div>
                   <Label>Work Deadline <span className="text-destructive">*</span></Label>


### PR DESCRIPTION
## Summary
- Fixes F-005: Requested Ship Date input silently accepted past dates while Work Deadline picker greyed them out — two inconsistent date mechanisms in the same form.
- Adds an inline amber warning under Requested Ship Date when the chosen date is before today.
- Gates submit behind a `window.confirm()` so back-dating an order requires explicit acknowledgement (preserves legitimate manual/historical entry).
- Applied to both the internal `CreateOrderForClient` flow (the reported bug site) and the client portal `NewOrder` flow for consistency.

## Why a soft warning rather than a hard block
Requested Ship Date is informational and ops occasionally back-date orders entered after the fact. The ticket explicitly allowed either "both reject" or "warn and confirm" — confirm preserves the manual-entry workflow while eliminating silent acceptance.

## Out of scope
- Work Deadline picker (already correct).
- Server / Zod / RLS validation — UI-only fix per ticket.
- Client portal `min={today+3}` behavior unchanged.

## Test plan
- [ ] Internal: `/internal/orders/new-for-client`, set Requested Ship Date to yesterday → amber warning appears, submit shows confirm dialog. Cancel → no insert. Confirm → order created back-dated.
- [ ] Internal: set date to today or later → no warning, no confirm.
- [ ] Client: `/client/orders/new` → manual back-date paste shows warning + confirm (browser `min` blocks most cases).
- [ ] No regression in Work Deadline picker behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)