### PR TITLE
F-010: Clarify roast plan quick-add chip +N suffix

### DIFF
--- a/src/components/production/RoastTab.tsx
+++ b/src/components/production/RoastTab.tsx
@@ -19,6 +19,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
@@ -804,6 +805,15 @@ export function RoastTab({ dateFilterConfig, today }: RoastTabProps) {
     // Calculate how many batches needed based on expected output per batch
     const expectedOutputPerBatch = standardBatch * (1 - yieldLossPct / 100);
     const batchCount = Math.ceil(remainingNeed / expectedOutputPerBatch);
+
+    const LARGE_BATCH_CONFIRM_THRESHOLD = 10;
+    if (batchCount >= LARGE_BATCH_CONFIRM_THRESHOLD) {
+      const ok = window.confirm(
+        `Add ${batchCount} planned batches for ${roastGroup}? This will create ${batchCount} rows in production planning.`
+      );
+      if (!ok) return;
+    }
+
     createSuggestedBatchesMutation.mutate({
       roastGroup,
       count: batchCount,
@@ -1084,18 +1094,35 @@ export function RoastTab({ dateFilterConfig, today }: RoastTabProps) {
                               const suggestedBatches = remainingNeed > 0 ? Math.ceil(remainingNeed / expectedOutputPerBatch) : 0;
                               
                               if (suggestedBatches === 0) return null;
-                              
+
+                              const batchWord = suggestedBatches === 1 ? 'batch' : 'batches';
+                              const ariaLabel = `Click to add ${suggestedBatches} planned ${batchWord} for ${g.roast_group}`;
+
                               return (
-                                <Button
-                                  key={g.roast_group}
-                                  size="sm"
-                                  variant="outline"
-                                  className="h-7 text-xs"
-                                  onClick={() => handleCreateSuggestedBatches(g.roast_group, g.total_kg)}
-                                >
-                                  <Plus className="h-3 w-3 mr-1" />
-                                  {g.roast_group} (+{suggestedBatches})
-                                </Button>
+                                <TooltipProvider key={g.roast_group} delayDuration={200}>
+                                  <Tooltip>
+                                    <TooltipTrigger asChild>
+                                      <Button
+                                        size="sm"
+                                        variant="outline"
+                                        className="h-7 text-xs"
+                                        aria-label={ariaLabel}
+                                        onClick={() => handleCreateSuggestedBatches(g.roast_group, g.total_kg)}
+                                      >
+                                        <Plus className="h-3 w-3 mr-1" />
+                                        {g.roast_group} (+{suggestedBatches})
+                                      </Button>
+                                    </TooltipTrigger>
+                                    <TooltipContent>
+                                      <div className="text-xs">
+                                        <div>{ariaLabel}</div>
+                                        <div className="text-muted-foreground">
+                                          {remainingNeed.toFixed(1)} kg remaining @ {expectedOutputPerBatch.toFixed(1)} kg/batch
+                                        </div>
+                                      </div>
+                                    </TooltipContent>
+                                  </Tooltip>
+                                </TooltipProvider>
                               );
                             })}
                           </div>


### PR DESCRIPTION
## Summary

- Roast Plan quick-add chips like `GROUP (+89)` had no in-UI explanation of what `+N` meant; one click silently inserted N `roasted_batches` rows.
- Wraps each chip in a Tooltip: *Click to add N planned batch(es) for {group}* plus a second line showing remaining kg demand and kg/batch so the count is grounded.
- Adds a `window.confirm` guard in `handleCreateSuggestedBatches` when `batchCount >= 10` to catch accidental large-count clicks (threshold kept as a local const for tuning).
- Adds `aria-label` on the chip Button mirroring the tooltip text.

Scope is limited to `src/components/production/RoastTab.tsx`. No schema, RPC, or migration changes. Refs F-010 (MINOR).

## Test plan

- [ ] `npm run dev`, log in as ADMIN/OPS, navigate to internal Production → Roast tab.
- [ ] Locate Roast Plan card with quick-add chips. Hover any chip — tooltip shows action text + kg breakdown.
- [ ] Click a low-count chip (e.g. `+4`) — proceeds immediately, toast `Created 4 planned batches`.
- [ ] Click a high-count chip (`+10`+) — confirm dialog appears; Cancel → no DB write; OK → batches created, toast fires.
- [ ] Verify aria-label exposed via screen reader / devtools accessibility tree.
- [ ] `npm run lint`, `npm run test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)