### PR TITLE
F-003: Unify date picker on order forms

### DIFF
--- a/src/components/ui/date-picker.tsx
+++ b/src/components/ui/date-picker.tsx
@@ -1,0 +1,86 @@
+import { useMemo } from 'react';
+import { format, parseISO, isValid, isBefore, isWeekend, startOfDay } from 'date-fns';
+import { CalendarIcon } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { Calendar } from '@/components/ui/calendar';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+
+interface DatePickerProps {
+  value: string | null;
+  onChange: (value: string | null) => void;
+  minDate?: Date;
+  disableWeekends?: boolean;
+  placeholder?: string;
+  compact?: boolean;
+  id?: string;
+  className?: string;
+}
+
+export function DatePicker({
+  value,
+  onChange,
+  minDate,
+  disableWeekends = true,
+  placeholder = 'Select date',
+  compact = false,
+  id,
+  className,
+}: DatePickerProps) {
+  const selected = useMemo(() => {
+    if (!value) return undefined;
+    const parsed = parseISO(value);
+    return isValid(parsed) ? startOfDay(parsed) : undefined;
+  }, [value]);
+
+  const minNormalized = useMemo(
+    () => startOfDay(minDate ?? new Date()),
+    [minDate],
+  );
+
+  const isDisabled = (date: Date) => {
+    if (isBefore(date, minNormalized)) return true;
+    if (disableWeekends && isWeekend(date)) return true;
+    return false;
+  };
+
+  const handleSelect = (date: Date | undefined) => {
+    if (!date) {
+      onChange(null);
+      return;
+    }
+    onChange(format(date, 'yyyy-MM-dd'));
+  };
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          id={id}
+          variant="outline"
+          size={compact ? 'sm' : 'default'}
+          className={cn(
+            'justify-start text-left font-normal',
+            compact ? 'h-8 text-xs px-2' : 'w-full',
+            !selected && 'text-muted-foreground',
+            className,
+          )}
+        >
+          <CalendarIcon className={cn('mr-2', compact && 'h-3 w-3 mr-1')} />
+          {selected ? format(selected, 'EEE MMM d, yyyy') : placeholder}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto p-0" align="start">
+        <Calendar
+          mode="single"
+          selected={selected}
+          onSelect={handleSelect}
+          disabled={isDisabled}
+          initialFocus
+          className="p-3 pointer-events-auto"
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/pages/client/NewOrder.tsx
+++ b/src/pages/client/NewOrder.tsx
@@ -21,6 +21,7 @@ import { LocationSelect } from '@/components/orders/LocationSelect';
 import { CaseQuantityInput } from '@/components/orders/CaseQuantityInput';
 import { useClientOrderingConstraints, validateCaseQuantity } from '@/hooks/useClientOrderingConstraints';
 import { blockNonIntegerKeys } from '@/lib/numericInput';
+import { DatePicker } from '@/components/ui/date-picker';
 import type { GrindOption, DeliveryMethod } from '@/types/database';
 
 interface LineItem {
@@ -75,7 +76,7 @@ export default function NewOrder() {
   const minSpecificDate = useMemo(() => {
     const date = new Date();
     date.setDate(date.getDate() + 3);
-    return date.toISOString().split('T')[0];
+    return date;
   }, []);
 
   const todayIsoDate = useMemo(() => new Date().toISOString().split('T')[0], []);
@@ -881,12 +882,11 @@ export default function NewOrder() {
                     <Label htmlFor="shipDate" className="text-sm">
                       Select date (at least 3 days out)
                     </Label>
-                    <Input
+                    <DatePicker
                       id="shipDate"
-                      type="date"
-                      value={requestedShipDate}
-                      min={minSpecificDate}
-                      onChange={(e) => setRequestedShipDate(e.target.value)}
+                      value={requestedShipDate || null}
+                      onChange={(v) => setRequestedShipDate(v ?? '')}
+                      minDate={minSpecificDate}
                     />
                     {isShipDateInPast && (
                       <p className="text-xs text-amber-600 mt-1">

--- a/src/pages/internal/CreateOrderForClient.tsx
+++ b/src/pages/internal/CreateOrderForClient.tsx
@@ -17,6 +17,7 @@ import { Plus, Minus, Trash2, ArrowLeft, ShieldAlert, AlertCircle } from 'lucide
 import { GramPackagingBadge, formatGramsLabel } from '@/components/GramPackagingBadge';
 import { useClientOrderingConstraints } from '@/hooks/useClientOrderingConstraints';
 import { WorkDeadlinePicker } from '@/components/orders/WorkDeadlinePicker';
+import { DatePicker } from '@/components/ui/date-picker';
 import type { GrindOption } from '@/types/database';
 import type { Database } from '@/integrations/supabase/types';
 import { LocationSelect } from '@/components/orders/LocationSelect';
@@ -720,11 +721,10 @@ export default function CreateOrderForClient() {
               <CardContent className="space-y-4">
                 <div>
                   <Label htmlFor="shipDate">Requested Ship Date</Label>
-                  <Input
+                  <DatePicker
                     id="shipDate"
-                    type="date"
-                    value={requestedShipDate}
-                    onChange={(e) => setRequestedShipDate(e.target.value)}
+                    value={requestedShipDate || null}
+                    onChange={(v) => setRequestedShipDate(v ?? '')}
                   />
                   {isShipDateInPast && (
                     <p className="text-xs text-amber-600 mt-1">


### PR DESCRIPTION
## Summary
- New reusable `DatePicker` component ([src/components/ui/date-picker.tsx](src/components/ui/date-picker.tsx)) built on shadcn `Popover` + `Calendar`. Disables past dates and weekends; emits `'yyyy-MM-dd'`.
- Internal "Create Order for Client" form: replace native `<Input type="date">` for **Requested Ship Date** with `<DatePicker>` so it matches the **Work Deadline** popup three lines below.
- Client portal "New Order" form: same swap; `minSpecificDate` is now a `Date` passed via `minDate`, preserving the existing 3-day minimum.

## Why
F-003 / Test A1.1 / A3 — order form mixed a native HTML date input (typeable) with a custom popup calendar (click-only) three lines apart. Inconsistent UX, and the native input let OPS pick weekends / past dates that conflict with the deadline picker's business-day rules.

## Out of scope
Other native `type="date"` inputs in `AndonBoard`, `Pricing`, `NewQuote`, `ProspectDetail` are intentionally untouched — flag for a separate consistency sweep if wanted.

## Test plan
- [ ] `npm run lint && npm run test` clean
- [ ] `/internal/orders/new-for-client`: Requested Ship Date opens same popup as Work Deadline; Saturday and past dates disabled
- [ ] Submit order — `orders.requested_ship_date` saved correctly
- [ ] `/client/new-order`: pick "Specific date"; first selectable date is today+3

🤖 Generated with [Claude Code](https://claude.com/claude-code)