### PR TITLE
Fix off-by-one date display on DATE columns

### DIFF
--- a/src/components/bookings/PendingReminders.tsx
+++ b/src/components/bookings/PendingReminders.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Bell, Check } from 'lucide-react';
 import { format, addDays } from 'date-fns';
+import { parseDateOnly } from '@/lib/dateOnly';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
 
@@ -77,7 +78,7 @@ export function PendingReminders() {
               <div>
                 <span className="font-medium">{r.coroast_members?.business_name ?? 'Unknown'}</span>
                 <span className="ml-2 text-muted-foreground">
-                  {format(new Date(r.booking_date + 'T00:00:00'), 'EEE, MMM d')}
+                  {format(parseDateOnly(r.booking_date)!, 'EEE, MMM d')}
                 </span>
                 <span className="ml-2 text-muted-foreground">
                   {formatTime(r.start_time)} – {formatTime(r.end_time)}

--- a/src/components/bookings/WaiverHistoryPanel.tsx
+++ b/src/components/bookings/WaiverHistoryPanel.tsx
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { supabase } from '@/integrations/supabase/client';
 import { format } from 'date-fns';
+import { parseDateOnly } from '@/lib/dateOnly';
 
 interface WaiverHistoryPanelProps {
   open: boolean;
@@ -51,7 +52,7 @@ export function WaiverHistoryPanel({ open, onOpenChange, memberId, memberName }:
                 <div className="flex items-center justify-between">
                   <span className="font-medium">
                     {w.coroast_bookings?.booking_date
-                      ? format(new Date(w.coroast_bookings.booking_date + 'T00:00:00'), 'MMM d, yyyy')
+                      ? format(parseDateOnly(w.coroast_bookings.booking_date)!, 'MMM d, yyyy')
                       : 'Unknown date'}
                   </span>
                   <span className="text-destructive font-medium">${Number(w.fee_amount_waived).toFixed(2)}</span>

--- a/src/components/coroast/MemberStorageSection.tsx
+++ b/src/components/coroast/MemberStorageSection.tsx
@@ -4,6 +4,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
 import { format, startOfMonth, endOfMonth } from 'date-fns';
+import { parseDateOnly } from '@/lib/dateOnly';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -272,7 +273,7 @@ export default function MemberStorageSection({ memberId, tier }: MemberStorageSe
                 <tbody>
                   {storageHistory.map((s: any) => {
                     const periodLabel = s.coroast_billing_periods?.period_start
-                      ? format(new Date(s.coroast_billing_periods.period_start + 'T00:00:00'), 'MMM yyyy')
+                      ? format(parseDateOnly(s.coroast_billing_periods.period_start)!, 'MMM yyyy')
                       : '—';
                     const charge = s.paid_pallets * Number(s.rate_per_add_pallet);
                     return (

--- a/src/components/dashboard/CoRoastingTab.tsx
+++ b/src/components/dashboard/CoRoastingTab.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { supabase } from '@/integrations/supabase/client';
 import { startOfWeek, endOfWeek, startOfMonth, endOfMonth, format, subYears, subMonths } from 'date-fns';
+import { parseDateOnly } from '@/lib/dateOnly';
 
 export function CoRoastingTab({ enabled }: { enabled: boolean }) {
   const today = new Date();
@@ -171,7 +172,7 @@ export function CoRoastingTab({ enabled }: { enabled: boolean }) {
               {weekBookings.map((b: any) => (
                 <div key={b.id} className="flex items-center justify-between text-sm border-b last:border-0 pb-2 last:pb-0">
                   <div className="flex items-center gap-3">
-                    <span className="text-muted-foreground">{format(new Date(b.booking_date + 'T00:00:00'), 'EEE MMM d')}</span>
+                    <span className="text-muted-foreground">{format(parseDateOnly(b.booking_date)!, 'EEE MMM d')}</span>
                     <span className="font-medium">{b.accounts?.account_name || 'Unknown'}</span>
                   </div>
                   <div className="flex items-center gap-3 text-muted-foreground">

--- a/src/components/dashboard/GreenCoffeeTab.tsx
+++ b/src/components/dashboard/GreenCoffeeTab.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@/components/ui/badge';
 import { CalendarDays, ChevronRight } from 'lucide-react';
 import { supabase } from '@/integrations/supabase/client';
 import { differenceInDays } from 'date-fns';
+import { parseDateOnly } from '@/lib/dateOnly';
 
 export function GreenCoffeeTab({ enabled }: { enabled: boolean }) {
   const navigate = useNavigate();
@@ -49,9 +50,9 @@ export function GreenCoffeeTab({ enabled }: { enabled: boolean }) {
 
       for (const [rg, lots] of Object.entries(byRG)) {
         for (const lot of lots) {
-          const startDate = lot.green_lots.received_date 
-            ? new Date(lot.green_lots.received_date) 
-            : new Date(lot.green_lots.expected_delivery_date || today);
+          const startDate = parseDateOnly(lot.green_lots.received_date)
+            ?? parseDateOnly(lot.green_lots.expected_delivery_date)
+            ?? today;
           const daysRemaining = differenceInDays(
             new Date(startDate.getTime() + lot.green_lots.estimated_days_to_consume * 86400000),
             today

--- a/src/lib/dateOnly.test.ts
+++ b/src/lib/dateOnly.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { parseDateOnly } from './dateOnly';
+
+describe('parseDateOnly', () => {
+  it('parses YYYY-MM-DD as local midnight', () => {
+    const d = parseDateOnly('2026-05-13')!;
+    expect(d.getFullYear()).toBe(2026);
+    expect(d.getMonth()).toBe(4);
+    expect(d.getDate()).toBe(13);
+    expect(d.getHours()).toBe(0);
+  });
+
+  it('accepts YYYY-MM-DDT... and ignores time', () => {
+    const d = parseDateOnly('2026-05-13T23:59:59Z')!;
+    expect(d.getFullYear()).toBe(2026);
+    expect(d.getMonth()).toBe(4);
+    expect(d.getDate()).toBe(13);
+  });
+
+  it('returns null for null/undefined/empty', () => {
+    expect(parseDateOnly(null)).toBeNull();
+    expect(parseDateOnly(undefined)).toBeNull();
+    expect(parseDateOnly('')).toBeNull();
+  });
+
+  it('returns null for malformed input', () => {
+    expect(parseDateOnly('not-a-date')).toBeNull();
+  });
+});

--- a/src/lib/dateOnly.ts
+++ b/src/lib/dateOnly.ts
@@ -1,0 +1,10 @@
+/**
+ * Parse a Postgres DATE column ("YYYY-MM-DD") as a local-time Date.
+ * Prevents UTC-midnight rendering one day earlier in negative-offset zones.
+ */
+export function parseDateOnly(value: string | null | undefined): Date | null {
+  if (!value) return null;
+  const [y, m, d] = value.slice(0, 10).split('-').map(Number);
+  if (!y || !m || !d) return null;
+  return new Date(y, m - 1, d);
+}

--- a/src/pages/client/OrderHistory.tsx
+++ b/src/pages/client/OrderHistory.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { supabase } from '@/integrations/supabase/client';
 import { usePreview } from '@/contexts/PreviewContext';
 import { format } from 'date-fns';
+import { parseDateOnly } from '@/lib/dateOnly';
 import { ArrowLeft } from 'lucide-react';
 import { toast } from 'sonner';
 import { LocationCodeDisplay } from '@/components/orders/LocationSelect';
@@ -154,7 +155,7 @@ export default function OrderHistory() {
               <div>
                 <strong>Requested Ship Date:</strong>{' '}
                 {selectedOrder.requested_ship_date
-                  ? format(new Date(selectedOrder.requested_ship_date), 'MMM d, yyyy')
+                  ? format(parseDateOnly(selectedOrder.requested_ship_date)!, 'MMM d, yyyy')
                   : '—'}
               </div>
               <div><strong>Created:</strong> {format(new Date(selectedOrder.created_at), 'MMM d, yyyy h:mm a')}</div>
@@ -292,7 +293,7 @@ export default function OrderHistory() {
                       </td>
                       <td className="py-3 pr-4 text-muted-foreground">
                         {o.requested_ship_date
-                          ? format(new Date(o.requested_ship_date), 'MMM d, yyyy')
+                          ? format(parseDateOnly(o.requested_ship_date)!, 'MMM d, yyyy')
                           : '—'}
                       </td>
                       <td className="py-3">

--- a/src/pages/client/Portal.tsx
+++ b/src/pages/client/Portal.tsx
@@ -7,6 +7,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { usePreview } from '@/contexts/PreviewContext';
 import { format } from 'date-fns';
+import { parseDateOnly } from '@/lib/dateOnly';
 import { PlusCircle, Package, Truck, Clock, CheckCircle2 } from 'lucide-react';
 import { LocationCodeDisplay } from '@/components/orders/LocationSelect';
 
@@ -126,7 +127,7 @@ export default function Portal() {
                         </div>
                         <div className="text-sm text-muted-foreground">
                           {order.requested_ship_date 
-                            ? `Ship by ${format(new Date(order.requested_ship_date), 'MMM d')}`
+                            ? `Ship by ${format(parseDateOnly(order.requested_ship_date)!, 'MMM d')}`
                             : `Created ${format(new Date(order.created_at), 'MMM d')}`
                           }
                         </div>

--- a/src/pages/internal/CoRoastLoringSchedule.tsx
+++ b/src/pages/internal/CoRoastLoringSchedule.tsx
@@ -13,6 +13,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { Plus, Pencil, Trash2, Repeat, List, CalendarDays, Clock } from 'lucide-react';
 import { PendingReminders } from '@/components/bookings/PendingReminders';
 import { format } from 'date-fns';
+import { parseDateOnly } from '@/lib/dateOnly';
 import { toast } from 'sonner';
 import {
   LoringBlock, BookingWithMember,
@@ -402,7 +403,7 @@ export default function CoRoastLoringSchedule() {
                           <div>
                             <span className="font-medium">{bk.coroast_members?.business_name ?? 'Unknown Member'}</span>
                             <span className="ml-2 text-sm text-muted-foreground">
-                              {format(new Date(bk.booking_date + 'T00:00:00'), 'EEE, MMM d')}
+                              {format(parseDateOnly(bk.booking_date)!, 'EEE, MMM d')}
                             </span>
                             <span className="ml-2 text-sm text-muted-foreground">
                               {formatTime(bk.start_time)} – {formatTime(bk.end_time)}

--- a/src/pages/internal/CoRoastMemberDetail.tsx
+++ b/src/pages/internal/CoRoastMemberDetail.tsx
@@ -6,6 +6,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
 import { format, startOfYear, subMonths } from 'date-fns';
+import { parseDateOnly } from '@/lib/dateOnly';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -791,7 +792,7 @@ function InvoiceHistorySection({ memberId }: { memberId: string }) {
         ) : (
           <div className="space-y-2">
             {invoiceHistory.map((inv) => {
-              const periodLabel = format(new Date(inv.period_start + 'T00:00:00'), 'MMMM yyyy');
+              const periodLabel = format(parseDateOnly(inv.period_start)!, 'MMMM yyyy');
               return (
                 <div key={inv.id} className="flex items-center justify-between border-b last:border-0 py-2">
                   <div>

--- a/src/pages/internal/OrderDetail.tsx
+++ b/src/pages/internal/OrderDetail.tsx
@@ -10,6 +10,7 @@ import { Badge } from '@/components/ui/badge';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { supabase } from '@/integrations/supabase/client';
 import { format } from 'date-fns';
+import { parseDateOnly } from '@/lib/dateOnly';
 import { ArrowLeft, UserPlus, Truck, Check, AlertTriangle, ExternalLink, Flame, Package, PenSquare, CalendarClock, FileText, Clock, Trash2 } from 'lucide-react';
 import { LocationBadge } from '@/components/orders/LocationSelect';
 import { PackagingBadge, type PackagingVariant } from '@/components/PackagingBadge';
@@ -582,7 +583,7 @@ export default function OrderDetail() {
             <div>
               <strong>Expected Ship Date:</strong>{' '}
               {order.requested_ship_date
-                ? format(new Date(order.requested_ship_date), 'MMM d, yyyy')
+                ? format(parseDateOnly(order.requested_ship_date)!, 'MMM d, yyyy')
                 : '—'}
               <span className="text-xs text-muted-foreground ml-1">(client intent)</span>
             </div>

--- a/src/pages/internal/Orders.tsx
+++ b/src/pages/internal/Orders.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { supabase } from '@/integrations/supabase/client';
 import { format, subDays, startOfDay } from 'date-fns';
+import { parseDateOnly } from '@/lib/dateOnly';
 import { 
   MessageSquare, 
   Plus,
@@ -82,7 +83,7 @@ export default function Orders() {
   // Helper to get the "age reference" date for an order
   const getAgeReference = (order: NonNullable<typeof data>[0]) => {
     if (order.work_deadline_at) return new Date(order.work_deadline_at);
-    if (order.requested_ship_date) return new Date(order.requested_ship_date);
+    if (order.requested_ship_date) return parseDateOnly(order.requested_ship_date)!;
     return new Date(order.created_at);
   };
 
@@ -183,8 +184,8 @@ export default function Orders() {
       if (aDeadline === null && bDeadline !== null) return 1;
       if (aDeadline !== null && bDeadline === null) return -1;
       if (aDeadline === null && bDeadline === null) {
-        const aShip = a.requested_ship_date ? new Date(a.requested_ship_date).getTime() : Infinity;
-        const bShip = b.requested_ship_date ? new Date(b.requested_ship_date).getTime() : Infinity;
+        const aShip = a.requested_ship_date ? parseDateOnly(a.requested_ship_date)!.getTime() : Infinity;
+        const bShip = b.requested_ship_date ? parseDateOnly(b.requested_ship_date)!.getTime() : Infinity;
         if (aShip !== bShip) return aShip - bShip;
         return a.order_number.localeCompare(b.order_number);
       }
@@ -193,8 +194,8 @@ export default function Orders() {
       const directedComparison = deadlineSortDir === 'asc' ? comparison : -comparison;
       if (directedComparison !== 0) return directedComparison;
       
-      const aShip = a.requested_ship_date ? new Date(a.requested_ship_date).getTime() : Infinity;
-      const bShip = b.requested_ship_date ? new Date(b.requested_ship_date).getTime() : Infinity;
+      const aShip = a.requested_ship_date ? parseDateOnly(a.requested_ship_date)!.getTime() : Infinity;
+      const bShip = b.requested_ship_date ? parseDateOnly(b.requested_ship_date)!.getTime() : Infinity;
       if (aShip !== bShip) return aShip - bShip;
       return a.order_number.localeCompare(b.order_number);
     });

--- a/src/pages/internal/SourcingContracts.tsx
+++ b/src/pages/internal/SourcingContracts.tsx
@@ -6,6 +6,7 @@ import { CreateReleaseModal } from '@/components/sourcing/releases/CreateRelease
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
 import { format } from 'date-fns';
+import { parseDateOnly } from '@/lib/dateOnly';
 import { formatPerKg } from '@/lib/formatMoney';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -999,7 +1000,7 @@ function ContractDetailPanel({
                             {lot.status === 'EN_ROUTE' && lot.expected_delivery_date
                               ? `Arriving ${format(new Date(lot.expected_delivery_date + 'T00:00:00'), 'MMM d, yyyy')}`
                               : lot.received_date
-                              ? `Received ${format(new Date(lot.received_date + 'T00:00:00'), 'MMM d, yyyy')}`
+                              ? `Received ${format(parseDateOnly(lot.received_date)!, 'MMM d, yyyy')}`
                               : ''}
                           </p>
                         </div>

--- a/src/pages/internal/SourcingLots.tsx
+++ b/src/pages/internal/SourcingLots.tsx
@@ -6,6 +6,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
 import { formatMoney, formatPerKg, formatPerLb } from '@/lib/formatMoney';
 import { format } from 'date-fns';
+import { parseDateOnly } from '@/lib/dateOnly';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -976,7 +977,7 @@ function LotDetailPanel({
     lines.push(`Bags: ${lot.bags_released}`);
     lines.push(`Bag Size: ${lot.bag_size_kg} kg`);
     lines.push(`kg Received: ${kgReceived}`);
-    if (lot.received_date) lines.push(`Received: ${format(new Date(lot.received_date + 'T00:00:00'), 'MMM d, yyyy')}`);
+    if (lot.received_date) lines.push(`Received: ${format(parseDateOnly(lot.received_date)!, 'MMM d, yyyy')}`);
     if (lot.warehouse_location) lines.push(`Warehouse: ${lot.warehouse_location}`);
     if (lot.exceptions_noted) {
       lines.push(`Exceptions: Yes`);
@@ -1226,7 +1227,7 @@ function LotDetailPanel({
                     )}
                   </div>
                 )}
-                <div><span className="text-muted-foreground">Received:</span> {lot.received_date ? format(new Date(lot.received_date + 'T00:00:00'), 'MMM d, yyyy') : '—'}</div>
+                <div><span className="text-muted-foreground">Received:</span> {lot.received_date ? format(parseDateOnly(lot.received_date)!, 'MMM d, yyyy') : '—'}</div>
                 <div><span className="text-muted-foreground">Carrier:</span> {lot.carrier || '—'}</div>
               </div>
 

--- a/src/pages/member/MemberBilling.tsx
+++ b/src/pages/member/MemberBilling.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
 import { format, startOfMonth, endOfMonth } from 'date-fns';
+import { parseDateOnly } from '@/lib/dateOnly';
 import { TIER_RATES, timeToMinutes } from '@/components/bookings/bookingUtils';
 import type { Database } from '@/integrations/supabase/types';
 
@@ -217,7 +218,7 @@ export default function MemberBilling() {
                 <tbody>
                   {billingHistory.map(inv => (
                     <tr key={inv.id} className="border-b last:border-0">
-                      <td className="py-2">{format(new Date(inv.period_start + 'T00:00:00'), 'MMM yyyy')}</td>
+                      <td className="py-2">{format(parseDateOnly(inv.period_start)!, 'MMM yyyy')}</td>
                       <td className="py-2 text-right">{Number(inv.used_hours).toFixed(1)}h</td>
                       <td className="py-2 text-right">${fmt(Number(inv.base_fee))}</td>
                       <td className="py-2 text-right">{Number(inv.overage_charge) > 0 ? `$${fmt(Number(inv.overage_charge))}` : '—'}</td>

--- a/src/pages/member/MemberSchedule.tsx
+++ b/src/pages/member/MemberSchedule.tsx
@@ -20,6 +20,7 @@ import {
   startOfToday, differenceInHours, parseISO, addDays, getDay,
   isBefore, startOfDay, isAfter,
 } from 'date-fns';
+import { parseDateOnly } from '@/lib/dateOnly';
 import {
   checkOverlap, timeToMinutes, formatTime12, TIER_RATES,
   HOUR_START, HOUR_END, TOTAL_HOURS, ROW_HEIGHT,
@@ -732,7 +733,7 @@ export default function MemberSchedule() {
             return (
               <div className="space-y-4">
                 <div className="space-y-2 text-sm">
-                  <p><strong>Date:</strong> {format(new Date(selectedBooking.booking_date + 'T00:00:00'), 'EEEE, MMMM d, yyyy')}</p>
+                  <p><strong>Date:</strong> {format(parseDateOnly(selectedBooking.booking_date)!, 'EEEE, MMMM d, yyyy')}</p>
                   <p><strong>Time:</strong> {formatTime12(selectedBooking.start_time)} – {formatTime12(selectedBooking.end_time)}</p>
                   <p><strong>Duration:</strong> {Number(selectedBooking.duration_hours || 0).toFixed(1)}h</p>
                   {(selectedBooking as any).notes_member && (


### PR DESCRIPTION
## Summary
- Order detail page (and other DATE-column displays) rendered one day earlier than stored. Root cause: `new Date("2026-05-13")` parses as UTC midnight, then `date-fns format()` renders in local time — west of UTC the calendar day shifts back.
- Adds `parseDateOnly()` helper in [src/lib/dateOnly.ts](src/lib/dateOnly.ts) that parses `YYYY-MM-DD` as local midnight.
- Fixes 5 bug sites (OrderDetail, Orders, OrderHistory, Portal, GreenCoffeeTab) and consolidates 11 sites that previously used the ad-hoc `'T00:00:00'` concat workaround onto the same helper for consistency.

## Why
Ops would plan deliveries off the wrong day — exactly the kind of silent off-by-one that causes real-world missed-by-a-day shipments. F-006 reproducer: order created with Requested Ship Date `2026-05-13` displayed as "May 12, 2026" while the underlying stored value remained `2026-05-13`.

## Test plan
- [x] `npx vitest run` — all 12 tests pass (new `dateOnly.test.ts` covers null/undefined/malformed/timezone-independence)
- [x] `npm run lint` — error count unchanged from baseline (no new lint errors introduced)
- [ ] Manual: log in as Ops in Pacific timezone, create order with Requested Ship Date `2026-05-13`. Order detail Order Info shows **May 13, 2026**. Reopen Edit Order — date input still `2026-05-13`.
- [ ] Manual: verify Orders list, Client Portal, Client OrderHistory show same date entered.
- [ ] Manual: Green Coffee dashboard tab still renders received_date correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)