### PR TITLE
Fix F-008: surface validation on Create Order instead of silent disable

### DIFF
--- a/src/pages/internal/CreateOrderForClient.tsx
+++ b/src/pages/internal/CreateOrderForClient.tsx
@@ -287,6 +287,17 @@ export default function CreateOrderForClient() {
     return lineItems.reduce((sum, li) => sum + (li.price ?? 0) * li.quantity, 0);
   }, [lineItems]);
 
+  const missingRequirements = useMemo(() => {
+    const missing: string[] = [];
+    if (!selectedClientId) missing.push('client');
+    if (clientLocations && clientLocations.length > 0 && !selectedLocationId) missing.push('delivery location');
+    if (lineItems.length === 0) missing.push('at least one product (set quantity > 0)');
+    if (!workDeadlineAt) missing.push('work deadline');
+    const missingPrice = lineItems.find((li) => li.price === null);
+    if (missingPrice) missing.push(`price for "${missingPrice.displayName}"`);
+    return missing;
+  }, [selectedClientId, clientLocations, selectedLocationId, lineItems, workDeadlineAt]);
+
   const handleQuantityInputChange = (productId: string, value: string) => {
     const numericValue = value.replace(/[^0-9]/g, '');
     const qty = numericValue === '' ? 0 : parseInt(numericValue, 10);
@@ -786,10 +797,16 @@ export default function CreateOrderForClient() {
                 <Button
                   className="w-full"
                   onClick={submitOrder}
-                  disabled={submitting || lineItems.length === 0}
+                  disabled={submitting}
                 >
                   {submitting ? 'Creating…' : confirmOnCreate ? 'Create & Confirm Order' : 'Create Order'}
                 </Button>
+                {missingRequirements.length > 0 && (
+                  <div className="flex items-start gap-1 text-xs text-amber-600">
+                    <AlertCircle className="h-3 w-3 mt-0.5 shrink-0" />
+                    <span>Missing: {missingRequirements.join(', ')}</span>
+                  </div>
+                )}
               </CardContent>
             </Card>
           </div>


### PR DESCRIPTION
## Summary
- Loosened the Create Order button's `disabled` prop to `submitting` only — was `submitting || lineItems.length === 0`, which silently greyed the button when the user set all quantities to 0 (each zero-qty entry is auto-removed from `lineItems`).
- Added an inline amber `Missing: …` hint above the button that lists every unmet requirement (client, delivery location, at least one product with qty > 0, work deadline, any missing prices).
- `submitOrder` already toasts each missing-field case, so clicking now actually communicates the problem; the new inline hint means users don't have to click to learn what's missing.

## Why
Test A2.8 (F-008): selecting Amplified, leaving all line-item quantities at 0, filling Requested Ship Date, and skipping Work Deadline left the Create Order button grey with no message. Fails the A3 "confusing error message" criterion — no message at all.

## Test plan
- [ ] `/internal/orders/new` as ADMIN: pick Amplified, leave all qtys at 0, set ship date, skip work deadline → button clickable, amber hint reads `Missing: at least one product (set quantity > 0), work deadline`; click fires toast `Add at least one product`.
- [ ] Set a product qty to 1 → hint updates to `Missing: work deadline`; click fires toast `Please set a work deadline before submitting`.
- [ ] Fill work deadline → hint disappears; click creates order (happy path unchanged).
- [ ] `npm run lint` and `npm run test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)