### PR TITLE
Fix "Unknown Client" in new-order toast (F-002)

### DIFF
--- a/src/hooks/useOrderNotifications.ts
+++ b/src/hooks/useOrderNotifications.ts
@@ -11,6 +11,8 @@ interface OrderNotification {
   order_number: string;
   work_deadline: string | null;
   created_at: string;
+  submitted_by_name: string | null;
+  submitted_by_admin: boolean;
 }
 
 /**
@@ -42,18 +44,25 @@ export function useOrderNotifications() {
           const notification = payload.new as OrderNotification;
           console.log('[useOrderNotifications] New notification:', notification);
           
-          // Show toast with action to view order
-          toast.info(
-            `New order submitted by ${notification.client_name}`,
-            {
-              description: `Order ${notification.order_number}`,
-              duration: 10000,
-              action: {
-                label: 'View',
-                onClick: () => navigate(`/orders/${notification.order_id}`),
-              },
-            }
-          );
+          const isAdminCreated = notification.submitted_by_admin;
+          const submitter = notification.submitted_by_name;
+
+          const title = isAdminCreated
+            ? `New order for ${notification.client_name}`
+            : `New order submitted by ${notification.client_name}`;
+
+          const description = isAdminCreated && submitter
+            ? `Submitted by ${submitter} · Order ${notification.order_number}`
+            : `Order ${notification.order_number}`;
+
+          toast.info(title, {
+            description,
+            duration: 10000,
+            action: {
+              label: 'View',
+              onClick: () => navigate(`/orders/${notification.order_id}`),
+            },
+          });
         }
       )
       .subscribe((status) => {

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -2898,6 +2898,8 @@ export type Database = {
           order_id: string
           order_number: string
           read_by: string[] | null
+          submitted_by_admin: boolean
+          submitted_by_name: string | null
           work_deadline: string | null
         }
         Insert: {
@@ -2907,6 +2909,8 @@ export type Database = {
           order_id: string
           order_number: string
           read_by?: string[] | null
+          submitted_by_admin?: boolean
+          submitted_by_name?: string | null
           work_deadline?: string | null
         }
         Update: {
@@ -2916,6 +2920,8 @@ export type Database = {
           order_id?: string
           order_number?: string
           read_by?: string[] | null
+          submitted_by_admin?: boolean
+          submitted_by_name?: string | null
           work_deadline?: string | null
         }
         Relationships: [

--- a/supabase/functions/notify-new-order/index.ts
+++ b/supabase/functions/notify-new-order/index.ts
@@ -79,7 +79,11 @@ serve(async (req: Request) => {
         order_number,
         work_deadline,
         client_id,
-        client:clients(id, name)
+        account_id,
+        created_by_admin,
+        created_by_user_id,
+        client:clients(id, name),
+        account:accounts(id, account_name)
       `)
       .eq("id", order_id)
       .maybeSingle();
@@ -110,10 +114,27 @@ serve(async (req: Request) => {
       }
     }
 
-    // order.client from a select with join returns an object (not array) when single-relation
+    // Resolve display name. Internal orders set account_id only (no client_id),
+    // client-submitted orders set client_id. Prefer whichever resolves.
     // deno-lint-ignore no-explicit-any
     const clientData = order.client as any;
-    const clientName = clientData?.name || "Unknown Client";
+    // deno-lint-ignore no-explicit-any
+    const accountData = order.account as any;
+    const clientName =
+      clientData?.name ||
+      accountData?.account_name ||
+      "Unknown Client";
+
+    // Resolve submitter display name from profiles
+    let submittedByName: string | null = null;
+    if (order.created_by_user_id) {
+      const { data: profile } = await adminClient
+        .from("profiles")
+        .select("name")
+        .eq("user_id", order.created_by_user_id)
+        .maybeSingle();
+      submittedByName = profile?.name ?? null;
+    }
 
     // Insert notification record (this triggers realtime for OPS/ADMIN users)
     const { error: notifError } = await adminClient
@@ -123,6 +144,8 @@ serve(async (req: Request) => {
         client_name: clientName,
         order_number: order.order_number,
         work_deadline: order.work_deadline,
+        submitted_by_name: submittedByName,
+        submitted_by_admin: order.created_by_admin === true,
       });
 
     if (notifError) {

--- a/supabase/migrations/20260512164614_ba607be0-c10b-41ba-92c7-06155262c724.sql
+++ b/supabase/migrations/20260512164614_ba607be0-c10b-41ba-92c7-06155262c724.sql
@@ -1,0 +1,4 @@
+-- F-002: surface submitter on new-order toast notifications
+ALTER TABLE public.order_notifications
+  ADD COLUMN IF NOT EXISTS submitted_by_name TEXT,
+  ADD COLUMN IF NOT EXISTS submitted_by_admin BOOLEAN NOT NULL DEFAULT false;


### PR DESCRIPTION
## Summary
- Internal-created orders (via `CreateOrderForClient`) write only `account_id`, so `notify-new-order`'s `clients` join returned null and the Admin/Ops broadcast toast fell back to **"Unknown Client"**.
- Edge function now resolves display name via `clients.name` → `accounts.account_name` fallback, and looks up the submitting staff member from `profiles` via `orders.created_by_user_id`.
- Toast text differentiates admin-created (`"New order for X / Submitted by Y · Order N"`) from client-submitted (`"New order submitted by X"` — unchanged).

## Why
Test reference A1.2: OPS user creates order → other OPS/Admin users see "Unknown Client" toast. Confusing once all internal-staff orders surface that way. Also indicates we had no creator attribution in the notification payload even though `created_by_user_id` was being stored.

## Changes
- `supabase/migrations/20260512164614_*.sql` — add `submitted_by_name TEXT`, `submitted_by_admin BOOLEAN` to `order_notifications`
- `supabase/functions/notify-new-order/index.ts` — pull `account_id`, `accounts(account_name)`, `created_by_admin`, `created_by_user_id`; resolve name with fallback; lookup submitter from `profiles`; persist new fields
- `src/hooks/useOrderNotifications.ts` — branch toast title/description on `submitted_by_admin`
- `src/integrations/supabase/types.ts` — patched `order_notifications` Row/Insert/Update

## Deploy notes
After merge, ops needs to:
1. Run new migration (`supabase migration up` / `db push`)
2. Deploy edge function: `supabase functions deploy notify-new-order`

## Test plan
- [ ] Migration applied; `\d order_notifications` shows new columns
- [ ] Edge function deployed
- [ ] **A — internal-created (F-002 repro):** Log in as Test Ops → Create Order for Client → pick Amplified → 3 line items → Submit. From second Ops/Admin window confirm toast reads `"New order for Amplified" / "Submitted by Test Ops · Order ORDXX-NNNNN"`.
- [ ] **B — client-submitted (regression):** Log in as CLIENT → submit order. Admin/Ops toast still reads `"New order submitted by <ClientName>"`.
- [ ] **C — DB:** `select client_name, submitted_by_name, submitted_by_admin from order_notifications order by created_at desc limit 5;` — verify both flows correct, no `"Unknown Client"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)