### PR TITLE
F-014: Add Workflow category to feedback dialog

### DIFF
--- a/src/components/feedback/FeedbackModal.tsx
+++ b/src/components/feedback/FeedbackModal.tsx
@@ -9,6 +9,7 @@ import { toast } from '@/hooks/use-toast';
 
 const CATEGORIES = [
   { value: 'BUG', label: 'Bug Report' },
+  { value: 'WORKFLOW', label: 'Workflow' },
   { value: 'UX_IMPROVEMENT', label: 'UX Improvement' },
   { value: 'FEATURE_REQUEST', label: 'Feature Request' },
   { value: 'OTHER', label: 'Other' },

--- a/src/pages/internal/AdminFeedback.tsx
+++ b/src/pages/internal/AdminFeedback.tsx
@@ -13,7 +13,7 @@ import { X, FileText } from 'lucide-react';
 import { toast } from 'sonner';
 
 const STATUS_OPTIONS = ['NEW', 'ACKNOWLEDGED', 'BUILDING', 'DONE', 'WONT_DO'] as const;
-const CATEGORY_OPTIONS = ['BUG', 'UX_IMPROVEMENT', 'FEATURE_REQUEST', 'OTHER'] as const;
+const CATEGORY_OPTIONS = ['BUG', 'WORKFLOW', 'UX_IMPROVEMENT', 'FEATURE_REQUEST', 'OTHER'] as const;
 
 const STATUS_COLORS: Record<string, string> = {
   NEW: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
@@ -33,6 +33,7 @@ const STATUS_LABELS: Record<string, string> = {
 
 const CATEGORY_LABELS: Record<string, string> = {
   BUG: 'Bug',
+  WORKFLOW: 'Workflow',
   UX_IMPROVEMENT: 'UX',
   FEATURE_REQUEST: 'Feature',
   OTHER: 'Other',

--- a/supabase/migrations/20260512120000_add_workflow_feedback_category.sql
+++ b/supabase/migrations/20260512120000_add_workflow_feedback_category.sql
@@ -1,0 +1,11 @@
+-- F-014: Add WORKFLOW as an allowed feedback category.
+-- Ops users (Chris/Laura/Aaron) primarily report workflow-shaped issues
+-- (process friction, missing steps, handoff gaps) that don't cleanly fit
+-- Bug / UX / Feature.
+
+ALTER TABLE public.feedback_submissions
+  DROP CONSTRAINT IF EXISTS feedback_submissions_category_check;
+
+ALTER TABLE public.feedback_submissions
+  ADD CONSTRAINT feedback_submissions_category_check
+  CHECK (category IN ('BUG', 'WORKFLOW', 'UX_IMPROVEMENT', 'FEATURE_REQUEST', 'OTHER'));


### PR DESCRIPTION
## Summary
- Adds `WORKFLOW` as a fifth allowed value for `feedback_submissions.category`, surfaced as the 2nd option in the cross-cutting Feedback modal.
- Admin triage screen (`/internal/admin-feedback`) gains a Workflow filter and label.
- New migration drops + re-adds the CHECK constraint to include `WORKFLOW`.

## Why
Ops users (Chris/Laura/Aaron) flagged that the MVP test plan asks them to tag submissions as "workflow", but the dropdown only offers Bug / UX / Feature / Other. Workflow-shaped issues (process friction, missing steps, handoff gaps) don't cleanly fit the existing buckets, so a new category keeps triage hygiene without forcing free-text tagging.

## Changes
- `src/components/feedback/FeedbackModal.tsx` — `CATEGORIES` gains `WORKFLOW` (2nd position).
- `src/pages/internal/AdminFeedback.tsx` — `CATEGORY_OPTIONS` + `CATEGORY_LABELS` updated.
- `supabase/migrations/20260512120000_add_workflow_feedback_category.sql` — CHECK constraint replacement.

## Reviewer notes
- `feedback_submissions.category` is `text` (not a Postgres enum), so `src/integrations/supabase/types.ts` does not need to be regenerated.
- Migration uses `DROP CONSTRAINT IF EXISTS` to remain idempotent.

## Test plan
- [ ] Apply migration locally (`supabase db push` or `supabase db reset`).
- [ ] `npm run dev`, sign in as ADMIN/OPS, open sidebar Feedback button → confirm "Workflow" appears as 2nd option.
- [ ] Submit a feedback row with category Workflow → success toast, no CHECK error.
- [ ] Visit `/internal/admin-feedback` → confirm Workflow appears in the category filter and on the submitted row.
- [ ] `npm run lint` and `npm run test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)