### PR TITLE
F-007: Show creator name on internally-created orders

### DIFF
--- a/src/components/internal/OrderEditModal.tsx
+++ b/src/components/internal/OrderEditModal.tsx
@@ -11,10 +11,10 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Badge } from '@/components/ui/badge';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
-import { Plus, Trash2, Edit, UserPlus } from 'lucide-react';
+import { Plus, Trash2, Edit } from 'lucide-react';
+import { CreatedByBadge } from '@/components/orders/CreatedByBadge';
 import type { Database } from '@/integrations/supabase/types';
 
 type DeliveryMethod = Database['public']['Enums']['delivery_method'];
@@ -41,6 +41,7 @@ interface OrderData {
   account_id: string;
   updated_at?: string;
   created_by_admin?: boolean;
+  created_by_user_id?: string | null;
 }
 
 interface OrderEditModalProps {
@@ -257,10 +258,7 @@ export function OrderEditModal({
             <Edit className="h-5 w-5" />
             Edit Order {order.order_number}
             {order.created_by_admin && (
-              <Badge variant="outline" className="ml-2 text-xs">
-                <UserPlus className="h-3 w-3 mr-1" />
-                Admin Created
-              </Badge>
+              <CreatedByBadge userId={order.created_by_user_id} variant="modal" />
             )}
           </DialogTitle>
         </DialogHeader>

--- a/src/components/orders/CreatedByBadge.tsx
+++ b/src/components/orders/CreatedByBadge.tsx
@@ -1,0 +1,31 @@
+import { UserPlus } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { useOrderCreator } from '@/hooks/useOrderCreator';
+
+interface CreatedByBadgeProps {
+  userId: string | null | undefined;
+  variant?: 'header' | 'modal';
+}
+
+export function CreatedByBadge({ userId, variant = 'header' }: CreatedByBadgeProps) {
+  const { data: profile } = useOrderCreator(userId);
+
+  const displayName = profile?.name?.trim() || profile?.email || null;
+  const label = displayName ? `Created by ${displayName}` : 'Internal Created';
+
+  if (variant === 'modal') {
+    return (
+      <Badge variant="outline" className="ml-2 text-xs">
+        <UserPlus className="h-3 w-3 mr-1" />
+        {label}
+      </Badge>
+    );
+  }
+
+  return (
+    <span className="inline-flex items-center gap-1 rounded bg-primary/10 px-2 py-1 text-xs font-medium text-primary">
+      <UserPlus className="h-3 w-3" />
+      {label}
+    </span>
+  );
+}

--- a/src/hooks/useOrderCreator.ts
+++ b/src/hooks/useOrderCreator.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+
+export function useOrderCreator(userId: string | null | undefined) {
+  return useQuery({
+    queryKey: ['order-creator', userId],
+    enabled: !!userId,
+    staleTime: 5 * 60 * 1000,
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('profiles')
+        .select('name, email')
+        .eq('user_id', userId!)
+        .maybeSingle();
+      if (error) throw error;
+      return data;
+    },
+  });
+}

--- a/src/pages/internal/OrderDetail.tsx
+++ b/src/pages/internal/OrderDetail.tsx
@@ -11,8 +11,9 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { supabase } from '@/integrations/supabase/client';
 import { format } from 'date-fns';
 import { parseDateOnly } from '@/lib/dateOnly';
-import { ArrowLeft, UserPlus, Truck, Check, AlertTriangle, ExternalLink, Flame, Package, PenSquare, CalendarClock, FileText, Clock, Trash2 } from 'lucide-react';
+import { ArrowLeft, Truck, Check, AlertTriangle, ExternalLink, Flame, Package, PenSquare, CalendarClock, FileText, Clock, Trash2 } from 'lucide-react';
 import { LocationBadge } from '@/components/orders/LocationSelect';
+import { CreatedByBadge } from '@/components/orders/CreatedByBadge';
 import { PackagingBadge, type PackagingVariant } from '@/components/PackagingBadge';
 import { GramPackagingBadge } from '@/components/GramPackagingBadge';
 import { toast } from 'sonner';
@@ -66,6 +67,7 @@ export default function OrderDetail() {
           shipped_or_ready,
           invoiced,
           created_by_admin,
+          created_by_user_id,
           account_id,
           location_id,
           updated_at,
@@ -514,10 +516,7 @@ export default function OrderDetail() {
             {order.status}
           </span>
           {order.created_by_admin && (
-            <span className="inline-flex items-center gap-1 rounded bg-primary/10 px-2 py-1 text-xs font-medium text-primary">
-              <UserPlus className="h-3 w-3" />
-              Admin Created
-            </span>
+            <CreatedByBadge userId={order.created_by_user_id} />
           )}
           <LocationBadge locationId={(order as any).location_id} />
         </div>
@@ -882,6 +881,7 @@ export default function OrderDetail() {
             status: order.status,
             account_id: (order as any).account_id,
             created_by_admin: order.created_by_admin,
+            created_by_user_id: order.created_by_user_id,
           }}
           lineItems={lineItemsWithPackedStatus.map(li => ({
             id: li.id,


### PR DESCRIPTION
## Summary
- Replace static \"Admin Created\" badge with \"Created by {name}\" resolved from `profiles.name` (email fallback, then `Internal Created` fallback).
- Applies to the order detail header and the edit modal header.
- Presentation-only fix: `orders.created_by_admin` flag and write paths are unchanged.

## Why
F-007 (MINOR): orders created by OPS users were mislabeled \"Admin Created\". The flag means \"internally created,\" not \"created by an ADMIN role.\" Showing the actual creator's display name resolves the ambiguity.

## Files
- New `src/hooks/useOrderCreator.ts` — React Query lookup of `profiles.name`/`email` by `user_id` (5 min staleTime).
- New `src/components/orders/CreatedByBadge.tsx` — shared badge with `variant: 'header' | 'modal'`.
- `src/pages/internal/OrderDetail.tsx` — replaces inline badge; adds `created_by_user_id` to the orders select query and passes it to `OrderEditModal`.
- `src/components/internal/OrderEditModal.tsx` — replaces inline badge; adds `created_by_user_id` to `OrderData` props; drops unused `UserPlus`/`Badge` imports.

## Test plan
- [ ] Log in as ADMIN, open an order created by an OPS user → header shows `Created by {ops user name}`.
- [ ] Open the Edit Order modal on the same order → modal title shows the same name badge.
- [ ] Open an order created by an ADMIN → badge shows the admin's name.
- [ ] Open an order created by a CLIENT (`created_by_admin = false`) → no badge rendered.
- [ ] Older order with null `created_by_user_id` → badge renders `Internal Created` fallback.
- [ ] `npm run lint && npm run test` clean (node_modules absent in worktree — run on main checkout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)