### PR TITLE
Pack tab: surface planned roast batches alongside WIP

### DIFF
--- a/src/components/production/PackRowDrawer.tsx
+++ b/src/components/production/PackRowDrawer.tsx
@@ -24,6 +24,8 @@ interface PackRowDrawerProps {
   unblocksOrders: number;
   wipAvailableKg: number;
   requiredKg: number;
+  plannedKg: number;
+  plannedCount: number;
   wipStatus: WipStatus; // 'full' = green, 'partial' = amber, 'none' = no color
 }
 
@@ -36,6 +38,8 @@ export function PackRowDrawer({
   unblocksOrders,
   wipAvailableKg,
   requiredKg,
+  plannedKg,
+  plannedCount,
   wipStatus,
 }: PackRowDrawerProps) {
   const navigate = useNavigate();
@@ -82,6 +86,11 @@ export function PackRowDrawer({
               </span>
             ) : (
               <span>No remaining demand for this SKU</span>
+            )}
+            {plannedCount > 0 && wipStatus !== 'full' && (
+              <div className="mt-1 text-xs">
+                + {plannedCount} planned batch{plannedCount !== 1 ? 'es' : ''} scheduled (~{plannedKg.toFixed(2)} kg)
+              </div>
             )}
           </div>
         )}

--- a/src/components/production/PackTab.tsx
+++ b/src/components/production/PackTab.tsx
@@ -26,7 +26,7 @@ import { type PackagingVariant } from '@/components/PackagingBadge';
 import { SortablePackRow } from './SortablePackRow';
 import type { DateFilterConfig } from './types';
 // Use AUTHORITATIVE inventory hooks - computed from source-of-truth tables
-import { useAuthoritativeWip } from '@/hooks/useAuthoritativeInventory';
+import { useAuthoritativeWip, useAuthoritativePlannedWip } from '@/hooks/useAuthoritativeInventory';
 import { AuthoritativeSummaryPanel } from './AuthoritativeTotals';
 import { filterOrderByWorkStart } from '@/lib/productionScheduling';
 
@@ -58,6 +58,8 @@ interface ProductDemand {
   hasTimeSensitive: boolean;
   wipAvailableKg: number;
   requiredKg: number;
+  plannedKg: number;
+  plannedCount: number;
   wipStatus: 'full' | 'partial' | 'none'; // NEW: WIP status for color coding
   earliestShipDate: string | null;
   shortage: number;
@@ -150,6 +152,7 @@ export function PackTab({ dateFilterConfig, today }: PackTabProps) {
   // ========== AUTHORITATIVE INVENTORY (from source-of-truth tables) ==========
   // WIP = sum(roasted_batches.actual_output_kg) - sum(packing_runs.kg_consumed)
   const { data: authWip } = useAuthoritativeWip();
+  const { data: plannedWip } = useAuthoritativePlannedWip();
   
   // Use authoritative WIP for roasted inventory display
   const roastedInventory = useMemo(() => {
@@ -210,6 +213,8 @@ export function PackTab({ dateFilterConfig, today }: PackTabProps) {
           shipDates: [],
           wipAvailableKg: 0,
           requiredKg: 0,
+          plannedKg: 0,
+          plannedCount: 0,
           wipStatus: 'none' as const, // NEW: WIP status for color coding
         };
       }
@@ -261,6 +266,11 @@ export function PackTab({ dateFilterConfig, today }: PackTabProps) {
       
       product.wipAvailableKg = wipAvailableKg;
       product.requiredKg = requiredKg;
+
+      // Planned-batch hint (informational, not counted in WIP)
+      const plannedInfo = product.roast_group ? plannedWip?.[product.roast_group] : undefined;
+      product.plannedKg = plannedInfo?.planned_kg ?? 0;
+      product.plannedCount = plannedInfo?.count ?? 0;
       
       // NEW: WIP status for color coding
       // - 'full': enough WIP to complete entire row (wipAvailable >= requiredKg)
@@ -278,7 +288,7 @@ export function PackTab({ dateFilterConfig, today }: PackTabProps) {
     }
 
     return Object.values(productMap).map(({ orderIds, shipDates, ...rest }) => rest);
-  }, [orderLineItems, checkmarks, packingByProductUnits, roastedInventory, products]);
+  }, [orderLineItems, checkmarks, packingByProductUnits, roastedInventory, products, plannedWip]);
 
   // Sort products by pack_display_order only (manual ordering)
   // NO automatic reprioritization - order is strictly user-controlled
@@ -579,6 +589,9 @@ export function PackTab({ dateFilterConfig, today }: PackTabProps) {
                       const headerWipKg = product.roast_group
                         ? (roastedInventory[product.roast_group] ?? 0)
                         : 0;
+                      const headerPlanned = product.roast_group
+                        ? plannedWip?.[product.roast_group]
+                        : undefined;
                       
                       return (
                         <React.Fragment key={product.product_id}>
@@ -595,6 +608,12 @@ export function PackTab({ dateFilterConfig, today }: PackTabProps) {
                                   {product.roast_group && (
                                     <span className="text-xs font-medium text-muted-foreground">
                                       {headerWipKg.toFixed(1)} kg WIP available
+                                      {headerPlanned && headerPlanned.count > 0 && (
+                                        <>
+                                          {' · '}
+                                          {headerPlanned.count} planned (~{headerPlanned.planned_kg.toFixed(1)} kg)
+                                        </>
+                                      )}
                                     </span>
                                   )}
                                 </div>
@@ -615,6 +634,8 @@ export function PackTab({ dateFilterConfig, today }: PackTabProps) {
                           unblocksOrders={product.unblocksOrders}
                           wipAvailableKg={product.wipAvailableKg}
                           requiredKg={product.requiredKg}
+                          plannedKg={product.plannedKg}
+                          plannedCount={product.plannedCount}
                           packingRun={packing}
                           isExpanded={isExpanded}
                           onToggleExpand={() => setExpandedProductId(isExpanded ? null : product.product_id)}

--- a/src/components/production/SortablePackRow.tsx
+++ b/src/components/production/SortablePackRow.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { Badge } from '@/components/ui/badge';
-import { ChevronDown, ChevronRight, Check, AlertTriangle, Clock, ShoppingCart, CheckCircle, AlertCircle, GripVertical } from 'lucide-react';
+import { ChevronDown, ChevronRight, Check, AlertTriangle, Clock, ShoppingCart, CheckCircle, AlertCircle, GripVertical, Layers } from 'lucide-react';
 import { PackagingBadge, type PackagingVariant } from '@/components/PackagingBadge';
 import { InlinePackingControl } from './InlinePackingControl';
 import { PackRowDrawer } from './PackRowDrawer';
@@ -32,6 +32,8 @@ interface SortablePackRowProps {
   unblocksOrders: number;
   wipAvailableKg: number;
   requiredKg: number;
+  plannedKg: number;
+  plannedCount: number;
   packingRun: PackingRun | undefined;
   isExpanded: boolean;
   onToggleExpand: () => void;
@@ -53,6 +55,8 @@ export function SortablePackRow({
   unblocksOrders,
   wipAvailableKg,
   requiredKg,
+  plannedKg,
+  plannedCount,
   packingRun,
   isExpanded,
   onToggleExpand,
@@ -163,6 +167,12 @@ export function SortablePackRow({
                 WIP partial
               </Badge>
             )}
+            {wipStatus !== 'full' && plannedCount > 0 && (
+              <Badge variant="outline" className="text-xs">
+                <Layers className="h-3 w-3 mr-1" />
+                {plannedCount} planned (~{plannedKg.toFixed(1)} kg)
+              </Badge>
+            )}
           </div>
           <div className="text-xs text-muted-foreground">
             {bagSizeG}g • {sku || 'No SKU'}
@@ -215,6 +225,8 @@ export function SortablePackRow({
           unblocksOrders={unblocksOrders}
           wipAvailableKg={wipAvailableKg}
           requiredKg={requiredKg}
+          plannedKg={plannedKg}
+          plannedCount={plannedCount}
           wipStatus={wipStatus}
         />
       )}

--- a/src/hooks/useAuthoritativeInventory.ts
+++ b/src/hooks/useAuthoritativeInventory.ts
@@ -359,6 +359,38 @@ export function useAuthoritativeWip() {
 }
 
 /**
+ * Planned-batch summary by roast_group.
+ * Informational only — does NOT count toward WIP.
+ * Skips batches earmarked for a blend (planned_for_blend_roast_group set)
+ * and batches already consumed by a blend (consumed_by_blend_at set).
+ */
+export interface PlannedWipByGroup {
+  count: number;
+  planned_kg: number;
+}
+
+export function useAuthoritativePlannedWip() {
+  const { data: batches, isLoading } = useRoastedBatches();
+
+  const planned = useMemo((): Record<string, PlannedWipByGroup> => {
+    const result: Record<string, PlannedWipByGroup> = {};
+    for (const b of batches ?? []) {
+      if (b.status !== 'PLANNED') continue;
+      if (b.planned_for_blend_roast_group) continue;
+      if (b.consumed_by_blend_at) continue;
+      if (!b.roast_group) continue;
+      const entry = result[b.roast_group] ?? { count: 0, planned_kg: 0 };
+      entry.count += 1;
+      entry.planned_kg += Number(b.planned_output_kg ?? 0);
+      result[b.roast_group] = entry;
+    }
+    return result;
+  }, [batches]);
+
+  return { data: planned, isLoading };
+}
+
+/**
  * Authoritative FG by product
  * FG = sum(units_packed) - sum(units_picked for OPEN orders)
  */


### PR DESCRIPTION
## Summary

- Pack tab rows like `COLOMBIA_LA_COLMENA_BEEHIVE_2` headline "522 units demanded / 0.0 kg WIP", giving packers no signal that planned roast batches are already scheduled. This PR adds an informational "(N planned, ~X kg)" hint sourced from `roasted_batches` where `status='PLANNED'`.
- WIP math and color status are unchanged — the hint is purely a clarity signal. Surfaced in three spots: roast-group header row, row badge (when WIP is not full), and the expanded drawer banner.
- Blend-component batches (`planned_for_blend_roast_group` set) and already-consumed batches are excluded so the hint matches existing WIP conventions.

## What changed

- `src/hooks/useAuthoritativeInventory.ts` — new `useAuthoritativePlannedWip()` hook; reuses existing `useRoastedBatches` query (no extra fetch).
- `src/components/production/PackTab.tsx` — threads `plannedKg`/`plannedCount` per row; group header now reads `X.X kg WIP available · N planned (~Y kg)`.
- `src/components/production/SortablePackRow.tsx` — outline `Layers` badge `N planned (~Y kg)` when row is not WIP-full and planned batches exist.
- `src/components/production/PackRowDrawer.tsx` — secondary line under WIP banner: `+ N planned batches scheduled (~Y kg)`.

Reference: F-013 / C1.2 / D-incidental. Severity: MINOR (clarity).

## Test plan

- [ ] Open `/production?tab=pack` as ADMIN/OPS.
- [ ] Roast group with 0 kg WIP + `roasted_batches` row(s) where `status='PLANNED'`: header shows `0.0 kg WIP available · N planned (~Y kg)`; row shows "N planned" badge; expanded drawer shows `+ N planned batches scheduled (~Y kg)`.
- [ ] Roast group with full WIP and no planned batches: green row unchanged, no planned hint.
- [ ] Blend-component batch (`planned_for_blend_roast_group` populated): NOT counted toward component group's planned hint.
- [ ] `npm run lint`, `npm run test`, `tsc --noEmit` all clean (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)