### PR TITLE
Show other members' bookings on member calendar (grey, redacted)

### DIFF
--- a/src/components/bookings/bookingUtils.ts
+++ b/src/components/bookings/bookingUtils.ts
@@ -110,6 +110,8 @@ export function checkAvailabilityWindow(
   return null;
 }
 
+export type BusySlot = { booking_date: string; start_time: string; end_time: string };
+
 export function checkOverlap(
   date: string,
   startTime: string,
@@ -118,6 +120,7 @@ export function checkOverlap(
   bookings: BookingRow[],
   excludeBookingId?: string,
   windows?: AvailabilityWindow[],
+  busySlots?: BusySlot[],
 ): string | null {
   // Check availability window first
   if (windows) {
@@ -145,6 +148,17 @@ export function checkOverlap(
     const bEnd = timeToMinutes(bk.end_time);
     if (startMin < bEnd && endMin > bStart) {
       return `Conflicts with existing booking for ${bk.accounts?.account_name ?? 'a member'} (${formatTime12(bk.start_time)} – ${formatTime12(bk.end_time)})`;
+    }
+  }
+
+  if (busySlots) {
+    for (const s of busySlots) {
+      if (s.booking_date !== date) continue;
+      const bStart = timeToMinutes(s.start_time);
+      const bEnd = timeToMinutes(s.end_time);
+      if (startMin < bEnd && endMin > bStart) {
+        return `Time slot is already booked (${formatTime12(s.start_time)} – ${formatTime12(s.end_time)})`;
+      }
     }
   }
 

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -4407,6 +4407,14 @@ export type Database = {
         Args: { p_client_id: string }
         Returns: Json
       }
+      get_coroast_busy_slots: {
+        Args: { p_from: string; p_to: string }
+        Returns: {
+          booking_date: string
+          start_time: string
+          end_time: string
+        }[]
+      }
       get_order_delete_preflight: {
         Args: { p_order_id: string }
         Returns: Json

--- a/src/pages/member/MemberSchedule.tsx
+++ b/src/pages/member/MemberSchedule.tsx
@@ -24,7 +24,7 @@ import { parseDateOnly } from '@/lib/dateOnly';
 import {
   checkOverlap, timeToMinutes, formatTime12, TIER_RATES,
   HOUR_START, HOUR_END, TOTAL_HOURS, ROW_HEIGHT,
-  type BookingRow, type BlockRow, type AvailabilityWindow,
+  type BookingRow, type BlockRow, type AvailabilityWindow, type BusySlot,
 } from '@/components/bookings/bookingUtils';
 import { AvailabilityTimeSelect } from '@/components/bookings/AvailabilityTimeSelect';
 import { DAYS_OF_WEEK, DAY_LABELS, JS_DAY_TO_STRING } from '@/components/coroast/types';
@@ -170,6 +170,25 @@ export default function MemberSchedule() {
     },
   });
 
+  // Other members' bookings on the shared roaster — redacted to (date, start, end) by the
+  // get_coroast_busy_slots SECURITY DEFINER RPC. Direct SELECT is RLS-restricted to the
+  // caller's own account, so we use the RPC to surface "this slot is taken" without
+  // leaking member names, notes, or account ids.
+  const { data: otherBusy = [] } = useQuery({
+    queryKey: ['member-portal-other-busy'],
+    queryFn: async () => {
+      const from = format(new Date(), 'yyyy-MM-dd');
+      const to = format(addWeeks(new Date(), 13), 'yyyy-MM-dd');
+      const { data, error } = await supabase.rpc('get_coroast_busy_slots', {
+        p_from: from,
+        p_to: to,
+      });
+      if (error) throw error;
+      return (data ?? []) as BusySlot[];
+    },
+    enabled: !!memberId,
+  });
+
   // Hours used this month
   const currentMonthStr = format(new Date(), 'yyyy-MM');
   const hoursUsedThisMonth = useMemo(() => {
@@ -217,8 +236,24 @@ export default function MemberSchedule() {
       });
     }
 
+    // Other-member bookings — redacted, render as non-clickable grey blocks.
+    otherBusy.forEach((s, idx) => {
+      result.push({
+        id: `obs-${idx}`,
+        dateStr: s.booking_date,
+        startMin: timeToMinutes(s.start_time),
+        endMin: timeToMinutes(s.end_time),
+        label: 'Unavailable',
+        tooltip: `Unavailable: ${formatTime12(s.start_time)} – ${formatTime12(s.end_time)}`,
+        bgColor: OTHER_COLOR.bg,
+        textColor: OTHER_COLOR.text,
+        isBlock: true,
+        isMine: false,
+      });
+    });
+
     return result;
-  }, [blocks, allBookings, memberId]);
+  }, [blocks, allBookings, otherBusy, memberId]);
 
   const eventsByDate = useMemo(() => {
     const map = new Map<string, CalendarEvent[]>();
@@ -321,7 +356,7 @@ export default function MemberSchedule() {
         // Client-side overlap pre-check for clearer per-date errors before hitting RPC
         for (const d of dates) {
           const ds = format(d, 'yyyy-MM-dd');
-          const overlap = checkOverlap(ds, formStartTime, formEndTime, blocks, allBookings as BookingRow[]);
+          const overlap = checkOverlap(ds, formStartTime, formEndTime, blocks, allBookings as BookingRow[], undefined, undefined, otherBusy);
           if (overlap) throw new Error(`${format(d, 'MMM d')}: ${overlap}`);
         }
 
@@ -353,7 +388,7 @@ export default function MemberSchedule() {
           toast.success(`Created ${created} recurring bookings`);
         }
       } else {
-        const overlap = checkOverlap(saveDateStr, formStartTime, formEndTime, blocks, allBookings as BookingRow[]);
+        const overlap = checkOverlap(saveDateStr, formStartTime, formEndTime, blocks, allBookings as BookingRow[], undefined, undefined, otherBusy);
         if (overlap) throw new Error(overlap);
 
         const { error } = await supabase.rpc('create_member_booking', {
@@ -371,6 +406,7 @@ export default function MemberSchedule() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['member-portal-bookings'] });
+      queryClient.invalidateQueries({ queryKey: ['member-portal-other-busy'] });
       setBookingOpen(false);
       setShowConfirm(false);
     },
@@ -387,6 +423,7 @@ export default function MemberSchedule() {
       toast.success('Booking cancelled');
       setSelectedBooking(null);
       queryClient.invalidateQueries({ queryKey: ['member-portal-bookings'] });
+      queryClient.invalidateQueries({ queryKey: ['member-portal-other-busy'] });
     },
     onError: (err: Error) => toast.error(err.message || 'Failed to cancel booking'),
   });

--- a/supabase/migrations/20260512170000_a20fe65c-d997-4a58-8471-11ddbec5d26d.sql
+++ b/supabase/migrations/20260512170000_a20fe65c-d997-4a58-8471-11ddbec5d26d.sql
@@ -1,0 +1,51 @@
+-- Member-portal calendar: redacted busy-slot reader for the shared Loring roaster.
+--
+-- The SELECT policy on coroast_bookings is account-scoped, so a member can only
+-- see their own bookings. That hides other members' bookings from the member-portal
+-- calendar, which then lets the user open the booking dialog over an occupied slot
+-- and only fails on the SECURITY DEFINER create_member_booking RPC (which bypasses
+-- RLS and sees all bookings). The spec calls for other-member bookings to render
+-- as grey "Unavailable" blocks with no identifying info.
+--
+-- This RPC returns only (booking_date, start_time, end_time) for active bookings
+-- that do NOT belong to the caller's account(s), gated to active COROASTING
+-- members. Mirrors the global-read pattern used by coroast_loring_blocks without
+-- broadening direct SELECT on the underlying table.
+
+CREATE OR REPLACE FUNCTION public.get_coroast_busy_slots(
+  p_from date,
+  p_to   date
+)
+RETURNS TABLE (booking_date date, start_time time, end_time time)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.account_users au
+    JOIN public.accounts a ON a.id = au.account_id
+    WHERE au.user_id = auth.uid()
+      AND au.is_active = true
+      AND 'COROASTING' = ANY(a.programs)
+  ) THEN
+    RAISE EXCEPTION 'Not authorized' USING ERRCODE = '42501';
+  END IF;
+
+  RETURN QUERY
+  SELECT cb.booking_date, cb.start_time, cb.end_time
+  FROM public.coroast_bookings cb
+  WHERE cb.booking_date BETWEEN p_from AND p_to
+    AND cb.status IN ('CONFIRMED', 'COMPLETED', 'NO_SHOW')
+    AND NOT EXISTS (
+      SELECT 1 FROM public.account_users au2
+      WHERE au2.account_id = cb.account_id
+        AND au2.user_id = auth.uid()
+        AND au2.is_active = true
+    );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_coroast_busy_slots(date, date) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_coroast_busy_slots(date, date) TO authenticated;


### PR DESCRIPTION
## Summary

- Member-portal calendar now renders other members' confirmed bookings on the shared Loring roaster as non-clickable grey "Unavailable" blocks, matching the existing `coroast_loring_blocks` styling.
- No identifying info is exposed — payload contains only `(booking_date, start_time, end_time)`.
- Inline conflict error now fires before Confirm instead of after.

## Why

The SELECT policy on `coroast_bookings` is account-scoped:

```sql
USING (EXISTS (
  SELECT 1 FROM public.account_users au
  WHERE au.account_id = coroast_bookings.account_id
    AND au.user_id = auth.uid()
    AND au.is_active = true
));
```

So a member can only read their own account's bookings. The member-portal calendar in `src/pages/member/MemberSchedule.tsx` queried `coroast_bookings` directly with no client-side filter — but RLS stripped out other members' rows. Slots looked free until `create_member_booking` (SECURITY DEFINER, bypasses RLS) raised `"Time slot conflicts with an existing booking"` on confirm.

Per spec, other members' bookings must render as grey blocks with no name/notes/colour visible.

## What changed

**New migration** `supabase/migrations/20260512170000_a20fe65c-d997-4a58-8471-11ddbec5d26d.sql`
- `get_coroast_busy_slots(p_from date, p_to date)` SECURITY DEFINER RPC.
- Returns only `(booking_date, start_time, end_time)` — no `member_id`, `account_id`, `notes`, `recurring_block_id`, `status`, no row id.
- Gated: caller must be an active member of a COROASTING account (mirrors the global-read pattern on `coroast_loring_blocks`). Otherwise raises `42501`.
- Excludes bookings from the caller's own accounts — those still flow through the existing `allBookings` query with full detail.
- EXECUTE granted to `authenticated` only; revoked from PUBLIC.
- Underlying RLS on `coroast_bookings` untouched.

**Front-end** `src/pages/member/MemberSchedule.tsx`
- New `otherBusy` query calling the RPC over today → +13 weeks.
- Third loop in the `events` `useMemo` pushes the redacted rows as `OTHER_COLOR` grey blocks with `isBlock: true, isMine: false`, so the existing `cursor-not-allowed` styling at `:508` applies and `handleEventClick` early-returns.
- `checkOverlap` calls at the recurring and single-booking paths now pass `otherBusy` for an inline error before `Confirm Booking`.
- Both `create` and `cancel` mutations now invalidate `['member-portal-other-busy']` alongside `['member-portal-bookings']`.

**`checkOverlap`** `src/components/bookings/bookingUtils.ts`
- Optional 8th `busySlots?: BusySlot[]` arg + new `BusySlot` type. Existing admin caller (`BookingFormDialog.tsx`) is unchanged — arg is optional.

**Types** `src/integrations/supabase/types.ts`
- Hand-added `get_coroast_busy_slots` entry. Will be overwritten cleanly next time `supabase gen types` runs.

## Out of scope

- Admin/ops calendar (already correct, uses ADMIN/OPS policy).
- Print stylesheets.
- Existing RLS on `coroast_bookings`.
- Hour-ledger sign convention.

## Test plan

- [ ] Apply migration; verify with `select pg_get_functiondef('public.get_coroast_busy_slots(date,date)'::regprocedure);`
- [ ] Log in as a non-COROASTING client → RPC returns `42501 Not authorized`.
- [ ] Log in as `jim-test-member` → calendar shows grey "Unavailable" blocks where another member has a CONFIRMED booking; tooltip shows only the time range, no name.
- [ ] Click a grey block → no booking modal opens.
- [ ] Click an empty slot and submit a conflicting time → inline error appears **before** clicking Confirm.
- [ ] Own bookings still render in member colour and remain clickable for cancellation.
- [ ] Network inspector: response payload for `get_coroast_busy_slots` contains only `booking_date`, `start_time`, `end_time` fields.
- [ ] Admin/ops calendar still shows full booking details (unchanged code path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)