### PR TITLE
Fix member portal billing stuck on Loading

### DIFF
--- a/src/lib/coroastPricing.ts
+++ b/src/lib/coroastPricing.ts
@@ -148,10 +148,11 @@ export async function resolveAccountPricing(accountId: string): Promise<Resolved
     .from('accounts')
     .select(ACCOUNT_PRICING_COLUMNS)
     .eq('id', accountId)
-    .single();
+    .maybeSingle();
 
-  if (error || !account) {
-    throw error ?? new Error('Account not found');
+  if (error) throw error;
+  if (!account) {
+    throw new Error('Account row not found or not accessible');
   }
 
   const accountRow = account as unknown as AccountPricingRow;

--- a/src/pages/member/MemberBilling.tsx
+++ b/src/pages/member/MemberBilling.tsx
@@ -5,6 +5,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { usePreview } from '@/contexts/PreviewContext';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
 import { Info } from 'lucide-react';
@@ -30,7 +31,12 @@ export default function MemberBilling() {
   const effectiveAccountId = previewAccountId ?? authUser?.accountId;
   const accountId = effectiveAccountId;
 
-  const { data: member } = useQuery({
+  const {
+    data: member,
+    isLoading: memberLoading,
+    error: memberError,
+    refetch: refetchMember,
+  } = useQuery({
     queryKey: ['my-account-billing', accountId],
     queryFn: async () => {
       const { data, error } = await supabase
@@ -39,12 +45,18 @@ export default function MemberBilling() {
         .eq('id', accountId!)
         .maybeSingle();
       if (error) throw error;
+      if (!data) throw new Error('Account row not found or not accessible');
       return data;
     },
     enabled: !!accountId,
   });
 
-  const { data: pricing } = useQuery({
+  const {
+    data: pricing,
+    isLoading: pricingLoading,
+    error: pricingError,
+    refetch: refetchPricing,
+  } = useQuery({
     queryKey: ['coroast-resolved-pricing', accountId],
     queryFn: () => resolveAccountPricing(accountId!),
     enabled: !!accountId,
@@ -123,8 +135,51 @@ export default function MemberBilling() {
     enabled: !!accountId,
   });
 
-  if (!member || !pricing) {
+  if (!accountId) {
+    return (
+      <div className="p-6 max-w-3xl mx-auto">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">No account linked</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground">
+              Your user is not linked to a co-roasting account. Please contact an administrator.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (memberLoading || pricingLoading) {
     return <div className="p-6"><p className="text-muted-foreground">Loading…</p></div>;
+  }
+
+  if (memberError || pricingError || !member || !pricing) {
+    const message =
+      (memberError instanceof Error && memberError.message) ||
+      (pricingError instanceof Error && pricingError.message) ||
+      'Unable to load billing.';
+    return (
+      <div className="p-6 max-w-3xl mx-auto">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg text-destructive">Couldn't load billing</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <p className="text-sm text-muted-foreground">{message}</p>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => { refetchMember(); refetchPricing(); }}
+            >
+              Retry
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
   }
 
   const fmt = (n: number) => n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });


### PR DESCRIPTION
## Summary
- `/member-portal/billing` previously gated all UI on `!member || !pricing` with no error branch, so any RLS deny, missing account row, or unresolved `accountId` left the page on the Loading placeholder indefinitely.
- `MemberBilling` now renders three explicit states: **no account linked**, **loading**, and **error** (with the underlying message and a Retry button that refetches both queries).
- `resolveAccountPricing` switched from `.single()` to `.maybeSingle()` and throws an actionable `"Account row not found or not accessible"` error instead of the opaque PGRST116.

## Why
Admin preview into a co-roasting account (and any client whose pricing/account query errored) showed a perpetual "Loading…" spinner with no signal as to why. The page now distinguishes pending from failed and gives the user a recovery path.

## Test plan
- [ ] `npm run dev`, sign in as ADMIN, preview a co-roasting account, navigate to `/member-portal/billing` → pricing table, current-month card, and billing history render.
- [ ] Preview an account with `coroast_tier = NULL` → renders with `MEMBER` tier defaults.
- [ ] Set `sessionStorage.previewAccountId` to a bogus UUID, reload `/member-portal/billing` → error card with message and working Retry button (no spinner loop).
- [ ] Sign in as the actual CLIENT user → `/member-portal/billing` loads pricing + current-month bookings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)