### PR TITLE
Fix F-016 RLS recursion on account_users-joining tables

### DIFF
--- a/supabase/migrations/20260513120000_fix_f016_rls_recursion.sql
+++ b/supabase/migrations/20260513120000_fix_f016_rls_recursion.sql
@@ -1,0 +1,124 @@
+-- F-016: Fix HTTP 500/503 on accounts/profiles/products/price_list/order_line_items/feedback_submissions.
+--
+-- Symptom: REST calls return 500 (42P17 infinite recursion) or 503 (statement timeout) for
+-- authenticated Admin/Ops users on every table whose RLS joins public.account_users.
+--
+-- Root cause: migration 20260509212831 introduced self-referential EXISTS subqueries inside
+-- RLS policies on account_users / accounts / profiles / account_user_locations. Follow-up
+-- migrations 20260510034657 and 20260510040238 added SECURITY DEFINER helpers
+-- (is_account_member, profile_is_on_my_account, account_user_is_on_my_account,
+-- account_id_for_account_user) but the live DB still has at least one recursive variant in
+-- place — likely under a differently spelled policy name that DROP POLICY IF EXISTS missed.
+--
+-- This migration is idempotent: it re-declares the helpers, force-drops every known recursive
+-- variant by name, and recreates the SELECT policies via the SECURITY DEFINER helpers. Tables
+-- that only join account_users from the outside (products, price_list, order_line_items,
+-- feedback_submissions) are intentionally untouched — once the underlying recursion is gone,
+-- their existing EXISTS subqueries succeed.
+
+-- ── Helpers (no-op if already present from 20260510034657 / 20260510040238) ────────────────
+CREATE OR REPLACE FUNCTION public.is_account_member(_account_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.account_users
+    WHERE account_id = _account_id
+      AND user_id = auth.uid()
+      AND is_active = true
+  );
+$$;
+REVOKE ALL ON FUNCTION public.is_account_member(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.is_account_member(uuid) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.account_id_for_account_user(_account_user_id uuid)
+RETURNS uuid
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT account_id FROM public.account_users WHERE id = _account_user_id;
+$$;
+REVOKE ALL ON FUNCTION public.account_id_for_account_user(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.account_id_for_account_user(uuid) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.profile_is_on_my_account(_profile_user_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.account_users teammate
+    JOIN public.account_users self_au
+      ON self_au.account_id = teammate.account_id
+    WHERE teammate.user_id = _profile_user_id
+      AND self_au.user_id = auth.uid()
+      AND self_au.is_active = true
+  );
+$$;
+REVOKE ALL ON FUNCTION public.profile_is_on_my_account(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.profile_is_on_my_account(uuid) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.account_user_is_on_my_account(_account_user_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.account_users target_au
+    JOIN public.account_users self_au
+      ON self_au.account_id = target_au.account_id
+    WHERE target_au.id = _account_user_id
+      AND self_au.user_id = auth.uid()
+      AND self_au.is_active = true
+  );
+$$;
+REVOKE ALL ON FUNCTION public.account_user_is_on_my_account(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.account_user_is_on_my_account(uuid) TO authenticated;
+
+-- ── account_users: drop every known recursive variant, recreate via helper ─────────────────
+DROP POLICY IF EXISTS "Account members can read their account team" ON public.account_users;
+DROP POLICY IF EXISTS "Account members can read teammate account_users" ON public.account_users;
+DROP POLICY IF EXISTS "Users can read account_users in their account" ON public.account_users;
+DROP POLICY IF EXISTS "Account members can read account_users" ON public.account_users;
+DROP POLICY IF EXISTS "Users can read teammate account_users" ON public.account_users;
+
+CREATE POLICY "Account members can read their account team"
+  ON public.account_users FOR SELECT TO authenticated
+  USING (public.is_account_member(account_id));
+
+-- ── accounts: drop every known recursive variant, recreate via helper ──────────────────────
+DROP POLICY IF EXISTS "Account members can read their account" ON public.accounts;
+DROP POLICY IF EXISTS "Account members can read their own account" ON public.accounts;
+DROP POLICY IF EXISTS "Users can read their own account" ON public.accounts;
+
+CREATE POLICY "Account members can read their account"
+  ON public.accounts FOR SELECT TO authenticated
+  USING (public.is_account_member(id));
+
+-- ── profiles: drop every known recursive variant, recreate via helper ──────────────────────
+DROP POLICY IF EXISTS "Account members can read teammate profiles" ON public.profiles;
+DROP POLICY IF EXISTS "Users can read teammate profiles" ON public.profiles;
+
+CREATE POLICY "Account members can read teammate profiles"
+  ON public.profiles FOR SELECT TO authenticated
+  USING (public.profile_is_on_my_account(user_id));
+
+-- ── account_user_locations: drop every known recursive variant, recreate via helper ────────
+DROP POLICY IF EXISTS "Account members can read team account_user_locations" ON public.account_user_locations;
+DROP POLICY IF EXISTS "Users can read their own account_user_locations" ON public.account_user_locations;
+DROP POLICY IF EXISTS "Account members can read account_user_locations" ON public.account_user_locations;
+
+CREATE POLICY "Account members can read team account_user_locations"
+  ON public.account_user_locations FOR SELECT TO authenticated
+  USING (public.account_user_is_on_my_account(account_user_id));


### PR DESCRIPTION
## Summary
- Adds idempotent migration `20260513120000_fix_f016_rls_recursion.sql` that re-declares four SECURITY DEFINER helpers, force-drops every known recursive policy variant on `account_users` / `accounts` / `profiles` / `account_user_locations`, and recreates the SELECT policies via the helpers.
- Resolves F-016: HTTP 500 (`42P17 infinite recursion`) on `GET /rest/v1/{profiles,accounts,products,price_list,order_line_items}` and HTTP 503 (statement timeout) on `HEAD /rest/v1/feedback_submissions` for authenticated Admin/Ops users.

## Why
Migration `20260509212831` introduced self-referential EXISTS subqueries inside RLS policies on `account_users` and friends. Follow-ups `20260510034657` and `20260510040238` added SECURITY DEFINER helpers but at least one recursive variant remained live (likely under a differently spelled policy name that the prior `DROP POLICY IF EXISTS` missed). Every downstream table whose RLS joins `account_users` (`products`, `price_list`, `order_line_items`, `feedback_submissions`) inherited the failure.

Downstream tables are intentionally untouched — their outer EXISTS subqueries succeed once the underlying recursion is gone.

## Test plan
- [ ] Apply migration to live project `cgdzjkryygwlyygeznrb` (`supabase db push` or dashboard).
- [ ] Probe `pg_policies` for the four touched tables — every `qual` should reference `is_account_member` / `profile_is_on_my_account` / `account_user_is_on_my_account`, never an inline self-join.
- [ ] Log in as `jim-test-admin@mailsac.com`: `/accounts` lists rows; `/products` lists rows; New Product modal client dropdown populates.
- [ ] Devtools network: all six REST endpoints return 200; `HEAD /rest/v1/feedback_submissions` returns 200.
- [ ] Repeat for `jim-test-ops@mailsac.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)