### PR TITLE
Fix F-017: route coroast members to /member-portal on login

### DIFF
--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -99,8 +99,9 @@ export function ProtectedRoute({ children, allowedRoles }: ProtectedRouteProps) 
     }
   }
 
-  // CLIENT user on standard portal routes but is coroast-only — redirect to member portal
-  if (authUser.role === 'CLIENT' && isCoroastMember && !authUser.canPlaceOrders && location.pathname.startsWith('/portal')) {
+  // CLIENT coroast members default to /member-portal on the bare /portal landing.
+  // Exact match preserves access to /portal/* sub-routes for hybrid users.
+  if (authUser.role === 'CLIENT' && isCoroastMember && location.pathname === '/portal') {
     return <Navigate to="/member-portal" replace />;
   }
 

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -15,6 +15,28 @@ export default function AuthCallback() {
     navigate('/auth', { replace: true });
   };
 
+  const resolveClientLanding = async (userId: string): Promise<'/member-portal' | '/portal'> => {
+    const { data: accountUser } = await supabase
+      .from('account_users')
+      .select('account_id, can_book_roaster')
+      .eq('user_id', userId)
+      .eq('is_active', true)
+      .maybeSingle();
+
+    if (!accountUser?.account_id || !accountUser.can_book_roaster) {
+      return '/portal';
+    }
+
+    const { data: acct } = await supabase
+      .from('accounts')
+      .select('programs')
+      .eq('id', accountUser.account_id)
+      .maybeSingle();
+
+    const programs = (acct?.programs as string[] | null) ?? [];
+    return programs.includes('COROASTING') ? '/member-portal' : '/portal';
+  };
+
   useEffect(() => {
     const handleCallback = async () => {
       try {
@@ -68,7 +90,8 @@ export default function AuthCallback() {
             }
 
             if (roleData.role === 'CLIENT') {
-              navigate('/portal', { replace: true });
+              const landing = await resolveClientLanding(data.user.id);
+              navigate(landing, { replace: true });
             } else {
               navigate('/production', { replace: true });
             }
@@ -92,7 +115,8 @@ export default function AuthCallback() {
           }
 
           if (roleData.role === 'CLIENT') {
-            navigate('/portal', { replace: true });
+            const landing = await resolveClientLanding(session.user.id);
+            navigate(landing, { replace: true });
           } else {
             navigate('/production', { replace: true });
           }


### PR DESCRIPTION
## Summary
- Post-login redirect (`AuthCallback`) now sends CLIENT users with `can_book_roaster=true` and `accounts.programs` containing `COROASTING` to `/member-portal` instead of always landing on `/portal`.
- `ProtectedRoute` `/portal` → `/member-portal` divert now triggers for any coroast member (drops the `!canPlaceOrders` gate) and uses exact path match so hybrid users (orders + coroast) still reach `/portal/new-order`, `/portal/orders`, etc. via direct navigation.

## Why
Test member `jim-test-member@mailsac.com` was landing on `/portal` with sidebar label "Client". Root cause: `AuthCallback` redirect was role-only (no membership check), and `ProtectedRoute` only diverted coroast-only users (`!canPlaceOrders`). Hybrid members fell through.

`app_role` enum has no `MEMBER` — coroast membership is derived from `account_users.can_book_roaster && accounts.programs.includes('COROASTING')`. Detection contract mirrors existing logic in `ProtectedRoute.tsx:34-40` and `AuthContext.tsx:88-113`.

## Files
- `src/pages/AuthCallback.tsx` — added `resolveClientLanding(userId)`; both CLIENT branches use it.
- `src/components/auth/ProtectedRoute.tsx` — exact-match divert, drops `canPlaceOrders` gate.

## Test plan
- [ ] Log in as `jim-test-member@mailsac.com` → lands on `/member-portal`, sidebar shows "Member".
- [ ] Log in as pure CLIENT (no `COROASTING` in `accounts.programs`) → lands on `/portal`, sidebar shows "Client".
- [ ] Log in as hybrid CLIENT (`can_place_orders=true` + `can_book_roaster=true` + `COROASTING`) → lands on `/member-portal`, can navigate to `/portal/new-order` manually.
- [ ] Log in as ADMIN / OPS → lands on `/production` (unchanged).
- [ ] Verify `account_users` row for test member has `is_active=true`, `can_book_roaster=true`, and account `programs @> ARRAY['COROASTING']`. If misconfigured, fix data — not a code regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)