### PR TITLE
Add Shopify-related columns to Supabase types

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -3128,6 +3128,10 @@ export type Database = {
           order_id: string
           product_id: string
           quantity_units: number
+          shipped_quantity: number | null
+          short_ship_reason: string | null
+          short_ship_recorded_at: string | null
+          short_ship_recorded_by: string | null
           unit_price_locked: number
         }
         Insert: {
@@ -3138,6 +3142,10 @@ export type Database = {
           order_id: string
           product_id: string
           quantity_units: number
+          shipped_quantity?: number | null
+          short_ship_reason?: string | null
+          short_ship_recorded_at?: string | null
+          short_ship_recorded_by?: string | null
           unit_price_locked: number
         }
         Update: {
@@ -3148,6 +3156,10 @@ export type Database = {
           order_id?: string
           product_id?: string
           quantity_units?: number
+          shipped_quantity?: number | null
+          short_ship_reason?: string | null
+          short_ship_recorded_at?: string | null
+          short_ship_recorded_by?: string | null
           unit_price_locked?: number
         }
         Relationships: [
@@ -3235,6 +3247,9 @@ export type Database = {
           roasted: boolean
           ship_display_order: number | null
           shipped_or_ready: boolean
+          shopify_pull_log_id: string | null
+          shopify_source_id: string | null
+          source_channel: string
           status: Database["public"]["Enums"]["order_status"]
           updated_at: string
           work_deadline: string | null
@@ -3263,6 +3278,9 @@ export type Database = {
           roasted?: boolean
           ship_display_order?: number | null
           shipped_or_ready?: boolean
+          shopify_pull_log_id?: string | null
+          shopify_source_id?: string | null
+          source_channel?: string
           status?: Database["public"]["Enums"]["order_status"]
           updated_at?: string
           work_deadline?: string | null
@@ -3291,6 +3309,9 @@ export type Database = {
           roasted?: boolean
           ship_display_order?: number | null
           shipped_or_ready?: boolean
+          shopify_pull_log_id?: string | null
+          shopify_source_id?: string | null
+          source_channel?: string
           status?: Database["public"]["Enums"]["order_status"]
           updated_at?: string
           work_deadline?: string | null


### PR DESCRIPTION
## Summary
- Plumbs new Shopify integration schema into `src/integrations/supabase/types.ts` so TypeScript stops being lying.
- Adds `shopify_source_id`, `shopify_pull_log_id`, `source_channel` to `orders` Row/Insert/Update.
- Adds `shipped_quantity`, `short_ship_reason`, `short_ship_recorded_at`, `short_ship_recorded_by` to `order_line_items` Row/Insert/Update.

## Why hand-patched instead of `supabase gen types`
Regen requires `SUPABASE_ACCESS_TOKEN` / `supabase login`; neither was available in this environment. Columns added match exactly what the migration applied (nullable / defaulted), so partial-column inserts everywhere in the codebase remain valid.

## Known gap
The four new tables — `shopify_sources`, `shopify_product_mappings`, `shopify_pull_log`, `shopify_bundle_source_orders` — are NOT in `types.ts` yet. Their column shapes were not available locally, and no code currently references them, so omitting them does not break the type-check. A follow-up `supabase gen types typescript --project-id cgdzjkryygwlyygeznrb --schema public > src/integrations/supabase/types.ts` (run with credentials) will fill them in.

## Audit
Every existing insert/upsert on `orders` and `order_line_items` is partial; every select is named-column (no `*`). New nullable/defaulted fields slot in without code changes. No UI, hook, page, or business-logic edits in this PR.

## Test plan
- [x] `tsc --noEmit` passes (exit 0)
- [x] `grep` confirms all seven new columns present in Row/Insert/Update across both tables
- [ ] Reviewer: confirm no objection to deferring the four new-table type stubs until a credentialed regen

🤖 Generated with [Claude Code](https://claude.com/claude-code)