### PR TITLE
Shopify integration foundation + admin debug page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,6 +54,7 @@ import InventoryLedger from "@/pages/internal/InventoryLedger";
 import AdminTools from "@/pages/internal/AdminTools";
 import UsersAccess from "@/pages/internal/UsersAccess";
 import AdminFeedback from "@/pages/internal/AdminFeedback";
+import ShopifyDebug from "@/pages/internal/ShopifyDebug";
 import Portal from "@/pages/client/Portal";
 import NewOrder from "@/pages/client/NewOrder";
 import OrderHistory from "@/pages/client/OrderHistory";
@@ -295,6 +296,11 @@ const App = () => (
             <Route path="/admin/feedback" element={
               <ProtectedRoute allowedRoles={['ADMIN']}>
                 <InternalLayout><AdminFeedback /></InternalLayout>
+              </ProtectedRoute>
+            } />
+            <Route path="/admin/shopify-debug" element={
+              <ProtectedRoute allowedRoles={['ADMIN']}>
+                <InternalLayout><ShopifyDebug /></InternalLayout>
               </ProtectedRoute>
             } />
 

--- a/src/pages/internal/ShopifyDebug.tsx
+++ b/src/pages/internal/ShopifyDebug.tsx
@@ -1,0 +1,405 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+
+// Shopify tables/columns are new and types.ts has not been regenerated yet.
+// Cast at call sites until `supabase gen types` runs.
+const sb = supabase as unknown as {
+  from: (t: string) => ReturnType<typeof supabase.from>;
+};
+
+function describeError(err: unknown): string {
+  if (!err) return 'Unknown error';
+  if (typeof err === 'string') return err;
+  if (err instanceof Error) return err.message;
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}
+
+interface SourceRow {
+  id: string;
+  store_name: string;
+  store_slug: string;
+  is_active: boolean;
+  created_at: string;
+}
+
+interface PullLogRow {
+  id: string;
+  shopify_source_id: string;
+  result: string;
+  trigger_type: string;
+  orders_retrieved: number;
+  orders_included: number;
+  orders_quarantined: number;
+  created_at: string;
+}
+
+export default function ShopifyDebug() {
+  const qc = useQueryClient();
+
+  const sourcesQuery = useQuery({
+    queryKey: ['debug_shopify_sources'],
+    queryFn: async (): Promise<SourceRow[]> => {
+      const { data, error } = await sb
+        .from('shopify_sources')
+        .select('id, store_name, store_slug, is_active, created_at')
+        .order('created_at', { ascending: false });
+      if (error) throw error;
+      return (data ?? []) as unknown as SourceRow[];
+    },
+  });
+
+  const pullLogQuery = useQuery({
+    queryKey: ['debug_shopify_pull_log'],
+    queryFn: async () => {
+      const recent = await sb
+        .from('shopify_pull_log')
+        .select(
+          'id, shopify_source_id, result, trigger_type, orders_retrieved, orders_included, orders_quarantined, created_at',
+        )
+        .order('created_at', { ascending: false })
+        .limit(5);
+      if (recent.error) throw recent.error;
+      const countRes = await sb
+        .from('shopify_pull_log')
+        .select('id', { count: 'exact', head: true });
+      if (countRes.error) throw countRes.error;
+      return {
+        rows: (recent.data ?? []) as unknown as PullLogRow[],
+        total: countRes.count ?? 0,
+      };
+    },
+  });
+
+  const orderStatsQuery = useQuery({
+    queryKey: ['debug_orders_source_stats'],
+    queryFn: async () => {
+      const orders = () =>
+        (supabase.from('orders') as unknown as {
+          select: (
+            s: string,
+            opts: { count: 'exact'; head: true },
+          ) => {
+            eq: (col: string, val: string) => Promise<{ count: number | null; error: unknown }>;
+            not: (
+              col: string,
+              op: string,
+              val: null,
+            ) => Promise<{ count: number | null; error: unknown }>;
+            then: <T>(
+              fn: (v: { count: number | null; error: unknown }) => T,
+            ) => Promise<T>;
+          };
+        }).select('id', { count: 'exact', head: true });
+
+      const total = await orders();
+      if (total.error) throw total.error;
+
+      const manual = await orders().eq('source_channel', 'manual');
+      if (manual.error) throw manual.error;
+
+      const auto = await orders().eq('source_channel', 'shopify_auto');
+      if (auto.error) throw auto.error;
+
+      const fallback = await orders().eq('source_channel', 'shopify_manual_fallback');
+      if (fallback.error) throw fallback.error;
+
+      const linked = await orders().not('shopify_source_id', 'is', null);
+      if (linked.error) throw linked.error;
+
+      return {
+        total: total.count ?? 0,
+        manual: manual.count ?? 0,
+        auto: auto.count ?? 0,
+        fallback: fallback.count ?? 0,
+        linked: linked.count ?? 0,
+      };
+    },
+  });
+
+  const lineItemStatsQuery = useQuery({
+    queryKey: ['debug_line_item_short_ship'],
+    queryFn: async () => {
+      const li = () =>
+        (supabase.from('order_line_items') as unknown as {
+          select: (
+            s: string,
+            opts: { count: 'exact'; head: true },
+          ) => {
+            eq: (col: string, val: string) => Promise<{ count: number | null; error: unknown }>;
+            not: (
+              col: string,
+              op: string,
+              val: null,
+            ) => Promise<{ count: number | null; error: unknown }>;
+            then: <T>(
+              fn: (v: { count: number | null; error: unknown }) => T,
+            ) => Promise<T>;
+          };
+        }).select('id', { count: 'exact', head: true });
+
+      const total = await li();
+      if (total.error) throw total.error;
+
+      const anyShort = await li().not('short_ship_reason', 'is', null);
+      if (anyShort.error) throw anyShort.error;
+
+      const deferred = await li().eq('short_ship_reason', 'deferred');
+      if (deferred.error) throw deferred.error;
+
+      const abandoned = await li().eq('short_ship_reason', 'abandoned');
+      if (abandoned.error) throw abandoned.error;
+
+      return {
+        total: total.count ?? 0,
+        any: anyShort.count ?? 0,
+        deferred: deferred.count ?? 0,
+        abandoned: abandoned.count ?? 0,
+      };
+    },
+  });
+
+  const invalidateAll = () => {
+    qc.invalidateQueries({ queryKey: ['debug_shopify_sources'] });
+    qc.invalidateQueries({ queryKey: ['debug_shopify_pull_log'] });
+    qc.invalidateQueries({ queryKey: ['debug_orders_source_stats'] });
+  };
+
+  const insertTestSource = async () => {
+    try {
+      const { data: account, error: accountErr } = await supabase
+        .from('accounts')
+        .select('id')
+        .limit(1)
+        .single();
+      if (accountErr) throw accountErr;
+      if (!account?.id) throw new Error('No account found to link');
+
+      const slug = `test-source-${Date.now()}`;
+      const { error } = await sb.from('shopify_sources').insert({
+        store_name: 'TEST',
+        store_slug: slug,
+        linked_account_id: account.id,
+        store_url: 'https://test.myshopify.com',
+        pull_cadence: 'manual',
+        is_active: false,
+      } as never);
+      if (error) throw error;
+      toast.success(`Inserted source ${slug}`);
+      invalidateAll();
+    } catch (err) {
+      toast.error(`Insert source failed: ${describeError(err)}`);
+    }
+  };
+
+  const deleteAllTestSources = async () => {
+    try {
+      const { data, error } = await sb
+        .from('shopify_sources')
+        .delete()
+        .eq('store_name', 'TEST')
+        .select('id');
+      if (error) throw error;
+      toast.success(`Deleted ${data?.length ?? 0} TEST sources (FK cascade applied)`);
+      invalidateAll();
+    } catch (err) {
+      toast.error(`Delete failed: ${describeError(err)}`);
+    }
+  };
+
+  const insertTestPullLog = async () => {
+    try {
+      const { data: latest, error: srcErr } = await sb
+        .from('shopify_sources')
+        .select('id')
+        .eq('store_name', 'TEST')
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      if (srcErr) throw srcErr;
+      if (!latest?.id) throw new Error('Insert a TEST source first');
+
+      const { error } = await sb.from('shopify_pull_log').insert({
+        shopify_source_id: (latest as { id: string }).id,
+        result: 'success',
+        trigger_type: 'manual',
+        orders_retrieved: 5,
+        orders_included: 4,
+        orders_quarantined: 1,
+      } as never);
+      if (error) throw error;
+      toast.success('Inserted pull log entry');
+      qc.invalidateQueries({ queryKey: ['debug_shopify_pull_log'] });
+    } catch (err) {
+      toast.error(`Insert pull log failed: ${describeError(err)}`);
+    }
+  };
+
+  const orderStats = orderStatsQuery.data;
+  const lineStats = lineItemStatsQuery.data;
+
+  return (
+    <div className="p-6 space-y-6 max-w-5xl">
+      <div>
+        <h1 className="text-2xl font-bold">Shopify Debug</h1>
+        <p className="text-sm text-muted-foreground">
+          Admin-only smoke test for the Shopify integration foundation. Ugly on purpose.
+        </p>
+      </div>
+
+      {/* Section 1 — Sources */}
+      <Card>
+        <CardHeader>
+          <CardTitle>1. Sources</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="flex gap-2">
+            <Button onClick={insertTestSource}>Insert test source</Button>
+            <Button variant="destructive" onClick={deleteAllTestSources}>
+              Delete all test sources
+            </Button>
+          </div>
+          <div className="text-sm">
+            Total rows: <strong>{sourcesQuery.data?.length ?? '—'}</strong>
+            {sourcesQuery.error && (
+              <span className="text-destructive ml-2">
+                Error: {describeError(sourcesQuery.error)}
+              </span>
+            )}
+          </div>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>id</TableHead>
+                <TableHead>store_name</TableHead>
+                <TableHead>store_slug</TableHead>
+                <TableHead>is_active</TableHead>
+                <TableHead>created_at</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {(sourcesQuery.data ?? []).map((r) => (
+                <TableRow key={r.id}>
+                  <TableCell className="font-mono text-xs">{r.id.slice(0, 8)}…</TableCell>
+                  <TableCell>{r.store_name}</TableCell>
+                  <TableCell>{r.store_slug}</TableCell>
+                  <TableCell>{String(r.is_active)}</TableCell>
+                  <TableCell>{r.created_at}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      {/* Section 2 — Pull log */}
+      <Card>
+        <CardHeader>
+          <CardTitle>2. Pull log</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <Button onClick={insertTestPullLog}>Insert test pull log entry</Button>
+          <div className="text-sm">
+            Total rows: <strong>{pullLogQuery.data?.total ?? '—'}</strong>
+            {pullLogQuery.error && (
+              <span className="text-destructive ml-2">
+                Error: {describeError(pullLogQuery.error)}
+              </span>
+            )}
+          </div>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>id</TableHead>
+                <TableHead>source</TableHead>
+                <TableHead>result</TableHead>
+                <TableHead>trigger</TableHead>
+                <TableHead>retrieved / included / quarantined</TableHead>
+                <TableHead>created_at</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {(pullLogQuery.data?.rows ?? []).map((r) => (
+                <TableRow key={r.id}>
+                  <TableCell className="font-mono text-xs">{r.id.slice(0, 8)}…</TableCell>
+                  <TableCell className="font-mono text-xs">
+                    {r.shopify_source_id.slice(0, 8)}…
+                  </TableCell>
+                  <TableCell>{r.result}</TableCell>
+                  <TableCell>{r.trigger_type}</TableCell>
+                  <TableCell>
+                    {r.orders_retrieved} / {r.orders_included} / {r.orders_quarantined}
+                  </TableCell>
+                  <TableCell>{r.created_at}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      {/* Section 3 — Orders source linkage */}
+      <Card>
+        <CardHeader>
+          <CardTitle>3. Orders source linkage</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          {orderStatsQuery.error && (
+            <div className="text-destructive">
+              Error: {describeError(orderStatsQuery.error)}
+            </div>
+          )}
+          <div>Total orders: <strong>{orderStats?.total ?? '—'}</strong></div>
+          <div>source_channel = manual: <strong>{orderStats?.manual ?? '—'}</strong></div>
+          <div>source_channel = shopify_auto: <strong>{orderStats?.auto ?? '—'}</strong></div>
+          <div>
+            source_channel = shopify_manual_fallback:{' '}
+            <strong>{orderStats?.fallback ?? '—'}</strong>
+          </div>
+          <div>shopify_source_id IS NOT NULL: <strong>{orderStats?.linked ?? '—'}</strong></div>
+          <p className="text-muted-foreground pt-2">
+            This confirms the new orders columns are queryable. Should show all manual right
+            now.
+          </p>
+        </CardContent>
+      </Card>
+
+      {/* Section 4 — Line item short-ship */}
+      <Card>
+        <CardHeader>
+          <CardTitle>4. Line item short-ship</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          {lineItemStatsQuery.error && (
+            <div className="text-destructive">
+              Error: {describeError(lineItemStatsQuery.error)}
+            </div>
+          )}
+          <div>Total line items: <strong>{lineStats?.total ?? '—'}</strong></div>
+          <div>short_ship_reason IS NOT NULL: <strong>{lineStats?.any ?? '—'}</strong></div>
+          <div>short_ship_reason = deferred: <strong>{lineStats?.deferred ?? '—'}</strong></div>
+          <div>
+            short_ship_reason = abandoned: <strong>{lineStats?.abandoned ?? '—'}</strong>
+          </div>
+          <p className="text-muted-foreground pt-2">
+            Should be all-null right now. The fields exist; nothing has used them yet.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/supabase/migrations/20260513130000_416b0dee-68c7-498a-a825-3ecf88b23281.sql
+++ b/supabase/migrations/20260513130000_416b0dee-68c7-498a-a825-3ecf88b23281.sql
@@ -1,0 +1,82 @@
+-- Shopify integration foundation: tables + new columns on orders / order_line_items.
+-- Step 1 of a multi-step Shopify rollout. Tables created empty; UI in /admin/shopify-debug.
+
+CREATE TABLE public.shopify_sources (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  store_name text NOT NULL,
+  store_slug text NOT NULL UNIQUE,
+  linked_account_id uuid NOT NULL REFERENCES public.accounts(id) ON DELETE CASCADE,
+  store_url text NOT NULL,
+  pull_cadence text NOT NULL DEFAULT 'manual'
+    CHECK (pull_cadence IN ('manual','hourly','daily')),
+  is_active boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE public.shopify_product_mappings (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  shopify_source_id uuid NOT NULL REFERENCES public.shopify_sources(id) ON DELETE CASCADE,
+  shopify_product_id text NOT NULL,
+  shopify_variant_id text,
+  product_id uuid REFERENCES public.products(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (shopify_source_id, shopify_product_id, shopify_variant_id)
+);
+
+CREATE TABLE public.shopify_pull_log (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  shopify_source_id uuid NOT NULL REFERENCES public.shopify_sources(id) ON DELETE CASCADE,
+  result text NOT NULL CHECK (result IN ('success','partial','error')),
+  trigger_type text NOT NULL CHECK (trigger_type IN ('manual','scheduled','webhook')),
+  orders_retrieved integer NOT NULL DEFAULT 0,
+  orders_included integer NOT NULL DEFAULT 0,
+  orders_quarantined integer NOT NULL DEFAULT 0,
+  error_message text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE public.shopify_bundle_source_orders (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  shopify_source_id uuid NOT NULL REFERENCES public.shopify_sources(id) ON DELETE CASCADE,
+  shopify_order_id text NOT NULL,
+  order_id uuid REFERENCES public.orders(id) ON DELETE SET NULL,
+  bundle_status text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (shopify_source_id, shopify_order_id)
+);
+
+ALTER TABLE public.orders
+  ADD COLUMN source_channel text NOT NULL DEFAULT 'manual'
+    CHECK (source_channel IN ('manual','shopify_auto','shopify_manual_fallback')),
+  ADD COLUMN shopify_source_id uuid REFERENCES public.shopify_sources(id) ON DELETE SET NULL;
+
+ALTER TABLE public.order_line_items
+  ADD COLUMN short_ship_reason text
+    CHECK (short_ship_reason IN ('deferred','abandoned'));
+
+ALTER TABLE public.shopify_sources ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.shopify_product_mappings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.shopify_pull_log ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.shopify_bundle_source_orders ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY shopify_sources_admin_all ON public.shopify_sources
+  FOR ALL TO authenticated
+  USING (has_role(auth.uid(), 'ADMIN'::app_role))
+  WITH CHECK (has_role(auth.uid(), 'ADMIN'::app_role));
+
+CREATE POLICY shopify_product_mappings_admin_all ON public.shopify_product_mappings
+  FOR ALL TO authenticated
+  USING (has_role(auth.uid(), 'ADMIN'::app_role))
+  WITH CHECK (has_role(auth.uid(), 'ADMIN'::app_role));
+
+CREATE POLICY shopify_pull_log_admin_all ON public.shopify_pull_log
+  FOR ALL TO authenticated
+  USING (has_role(auth.uid(), 'ADMIN'::app_role))
+  WITH CHECK (has_role(auth.uid(), 'ADMIN'::app_role));
+
+CREATE POLICY shopify_bundle_source_orders_admin_all ON public.shopify_bundle_source_orders
+  FOR ALL TO authenticated
+  USING (has_role(auth.uid(), 'ADMIN'::app_role))
+  WITH CHECK (has_role(auth.uid(), 'ADMIN'::app_role));


### PR DESCRIPTION
## Summary
- Adds 4 new Shopify tables (`shopify_sources`, `shopify_product_mappings`, `shopify_pull_log`, `shopify_bundle_source_orders`) plus new columns: `orders.source_channel`, `orders.shopify_source_id`, `order_line_items.short_ship_reason`. All admin-only via `has_role` RLS.
- Adds hidden ADMIN-only smoke-test page at `/admin/shopify-debug` (not surfaced in nav) for verifying inserts, FK cascade, and queryability of the new columns before Step 2 builds real UI.
- Migration committed under `supabase/migrations/`; same SQL must be run via Lovable's SQL editor since Lovable owns this project's Supabase connection.

## Why
Step 1 of the Shopify integration. Build a thin foundation and confirm the schema is wired up end-to-end before investing in real UI work.

## Reviewer notes
- Page uses local `as unknown as` casts on supabase calls because `src/integrations/supabase/types.ts` has not yet been regenerated against the new tables/columns. Once Lovable applies the SQL and regens types, casts become harmless and can be cleaned up later.
- Route is intentionally absent from `InternalLayout` sidebar — URL access only. ADMIN-only via `ProtectedRoute`; OPS/CLIENT redirect to `/dashboard`, unauth to `/auth`.
- Every mutation toasts full error message (verbose by design).

## Test plan
- [ ] Run migration SQL in Lovable SQL editor; confirm no errors.
- [ ] Regenerate `src/integrations/supabase/types.ts` and confirm new tables/columns appear.
- [ ] `npm install && npm run build` succeeds.
- [ ] Log in as ADMIN → visit `/admin/shopify-debug`:
  - Section 3 shows total orders, all `manual`, 0 Shopify-linked.
  - Section 4 shows total line items, 0 with `short_ship_reason`.
  - Insert test source → row appears, count increments.
  - Insert pull log entry → row appears, count increments.
  - Delete all test sources → sources drop to 0; pull log count also drops (FK cascade).
- [ ] Log in as OPS → visit URL → redirected to `/dashboard`.
- [ ] Log out → visit URL → redirected to `/auth`.
- [ ] Confirm route is absent from sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)