### PR TITLE
chore: pagination, composite indexes, final types regen

### DIFF
--- a/src/hooks/usePaginatedQuery.ts
+++ b/src/hooks/usePaginatedQuery.ts
@@ -1,0 +1,91 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useQuery, type QueryKey } from '@tanstack/react-query';
+import type { PostgrestError } from '@supabase/supabase-js';
+
+export interface PaginatedPage<T> {
+  rows: T[];
+  nextOffset: number | null;
+  totalEstimate?: number | null;
+}
+
+export interface UsePaginatedQueryOptions<T> {
+  queryKey: QueryKey;
+  pageSize?: number;
+  fetchPage: (params: { offset: number; limit: number }) => Promise<{
+    rows: T[];
+    count?: number | null;
+  }>;
+  enabled?: boolean;
+}
+
+export interface UsePaginatedQueryResult<T> {
+  rows: T[];
+  isLoading: boolean;
+  isFetching: boolean;
+  error: PostgrestError | Error | null;
+  hasMore: boolean;
+  loadMore: () => void;
+  reset: () => void;
+  total: number | null;
+  pageSize: number;
+  loadedCount: number;
+  refetch: () => Promise<unknown>;
+}
+
+const DEFAULT_PAGE_SIZE = 50;
+
+/**
+ * Offset-cursor pagination for Supabase list queries.
+ *
+ * The caller supplies `fetchPage({ offset, limit })`. The hook tracks `limit`
+ * locally and grows it by `pageSize` on `loadMore`. We use a single growing
+ * window (rather than a stack of pages) so the rendered list stays a simple
+ * flat array and stable sort/filter logic in the page component does not need
+ * to merge page boundaries.
+ */
+export function usePaginatedQuery<T>({
+  queryKey,
+  pageSize = DEFAULT_PAGE_SIZE,
+  fetchPage,
+  enabled = true,
+}: UsePaginatedQueryOptions<T>): UsePaginatedQueryResult<T> {
+  const [limit, setLimit] = useState(pageSize);
+
+  const effectiveKey = useMemo(() => [...queryKey, { limit }], [queryKey, limit]);
+
+  const query = useQuery({
+    queryKey: effectiveKey,
+    queryFn: () => fetchPage({ offset: 0, limit }),
+    enabled,
+  });
+
+  const rows = query.data?.rows ?? [];
+  const total = query.data?.count ?? null;
+  const loadedCount = rows.length;
+  const hasMore =
+    total !== null && total !== undefined
+      ? loadedCount < total
+      : loadedCount >= limit;
+
+  const loadMore = useCallback(() => {
+    setLimit((prev) => prev + pageSize);
+  }, [pageSize]);
+
+  const reset = useCallback(() => {
+    setLimit(pageSize);
+  }, [pageSize]);
+
+  return {
+    rows,
+    isLoading: query.isLoading,
+    isFetching: query.isFetching,
+    error: (query.error as PostgrestError | Error | null) ?? null,
+    hasMore,
+    loadMore,
+    reset,
+    total,
+    pageSize,
+    loadedCount,
+    refetch: query.refetch,
+  };
+}

--- a/src/pages/internal/Inventory.tsx
+++ b/src/pages/internal/Inventory.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import { Trash2 } from 'lucide-react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { usePaginatedQuery } from '@/hooks/usePaginatedQuery';
 import { useSearchParams, Link } from 'react-router-dom';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -321,13 +322,21 @@ export default function Inventory() {
 
   // ===== Finished Goods Tab =====
   
-  // Fetch FG inventory with product details
-  const { data: fgInventory } = useQuery({
+  // Fetch FG inventory with product details (paginated).
+  const {
+    rows: fgInventory,
+    hasMore: fgHasMore,
+    loadMore: loadMoreFg,
+    isFetching: fgIsFetching,
+    total: fgTotal,
+  } = usePaginatedQuery<FgInventoryRow>({
     queryKey: ['fg-inventory'],
-    queryFn: async () => {
-      const { data, error } = await supabase
+    pageSize: 50,
+    fetchPage: async ({ offset, limit }) => {
+      const { data, error, count } = await supabase
         .from('fg_inventory')
-        .select(`
+        .select(
+          `
           id,
           product_id,
           units_on_hand,
@@ -340,10 +349,13 @@ export default function Inventory() {
             packaging_variant,
             client:clients(name)
           )
-        `)
-        .order('updated_at', { ascending: false });
+        `,
+          { count: 'exact' }
+        )
+        .order('updated_at', { ascending: false })
+        .range(offset, offset + limit - 1);
       if (error) throw error;
-      return (data ?? []) as unknown as FgInventoryRow[];
+      return { rows: (data ?? []) as unknown as FgInventoryRow[], count };
     },
   });
 
@@ -650,6 +662,21 @@ export default function Inventory() {
                       ))}
                   </tbody>
                 </table>
+              )}
+              {fgHasMore && (
+                <div className="pt-4 flex justify-center">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="text-xs text-muted-foreground hover:text-foreground"
+                    onClick={loadMoreFg}
+                    disabled={fgIsFetching}
+                  >
+                    {fgIsFetching
+                      ? 'Loading…'
+                      : `Load more${fgTotal ? ` (${fgInventory.length} of ${fgTotal})` : ''}`}
+                  </Button>
+                </div>
               )}
             </CardContent>
           </Card>

--- a/src/pages/internal/Orders.tsx
+++ b/src/pages/internal/Orders.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { usePaginatedQuery } from '@/hooks/usePaginatedQuery';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -42,23 +43,38 @@ export default function Orders() {
     status: string;
   }>({ open: false, orderId: '', orderNumber: '', status: '' });
 
-  // Update URL when history days changes
+  // Update URL when history days changes. Also expand the server-side
+  // pagination window so the additional days have rows to filter against.
   const loadMoreHistory = () => {
     const newDays = historyDays + HISTORY_INCREMENT;
     setSearchParams({ historyDays: String(newDays) });
+    if (hasMoreFromServer) {
+      loadMoreOrders();
+    }
   };
 
-  // Fetch orders with line items for progress calculation
-  const { data, isLoading, error, refetch } = useQuery({
+  // Fetch orders with line items for progress calculation (paginated).
+  const {
+    rows: data,
+    isLoading,
+    error,
+    refetch,
+    hasMore: hasMoreFromServer,
+    loadMore: loadMoreOrders,
+    total: totalOrdersInDb,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } = usePaginatedQuery<any>({
     queryKey: ['orders'],
-    queryFn: async () => {
-      const { data, error } = await supabase
+    pageSize: 100,
+    fetchPage: async ({ offset, limit }) => {
+      const { data, error, count } = await supabase
         .from('orders')
-        .select(`
-          id, 
-          order_number, 
-          status, 
-          requested_ship_date, 
+        .select(
+          `
+          id,
+          order_number,
+          status,
+          requested_ship_date,
           work_deadline,
           work_deadline_at,
           internal_ops_notes,
@@ -72,11 +88,14 @@ export default function Orders() {
             client:clients(name),
             account:accounts(account_name),
             order_line_items(id, product_id, quantity_units)
-        `)
-        .order('created_at', { ascending: false });
+        `,
+          { count: 'exact' }
+        )
+        .order('created_at', { ascending: false })
+        .range(offset, offset + limit - 1);
 
       if (error) throw error;
-      return data ?? [];
+      return { rows: data ?? [], count };
     },
   });
 
@@ -279,7 +298,7 @@ export default function Orders() {
                   : `No orders in the last ${historyDays} days.`}
               </p>
               {/* Always show load more when there may be older orders */}
-              {!needsInvoicingFilter && totalOrderCount > 0 && historyDays < 90 && (
+              {!needsInvoicingFilter && (totalOrdersInDb ?? totalOrderCount) > 0 && historyDays < 90 && (
                 <div className="flex justify-center">
                   <Button
                     variant="ghost"
@@ -447,7 +466,7 @@ export default function Orders() {
               })}
 
               {/* Load more history control - show if there are hidden orders OR if we might have more */}
-              {!needsInvoicingFilter && historyDays < 90 && (hasMoreHistory || totalOrderCount > visibleOrders.length) && (
+              {!needsInvoicingFilter && historyDays < 90 && (hasMoreHistory || hasMoreFromServer || totalOrderCount > visibleOrders.length) && (
                 <div className="pt-4 flex justify-center">
                   <Button
                     variant="ghost"

--- a/supabase/migrations/20260514162848_perf_indexes.sql
+++ b/supabase/migrations/20260514162848_perf_indexes.sql
@@ -1,0 +1,20 @@
+-- Performance: composite index supporting the standard RLS subquery pattern.
+--
+-- Hot pattern across account-scoped tables:
+--   EXISTS (
+--     SELECT 1 FROM public.account_users au
+--     WHERE au.account_id = <table>.account_id
+--       AND au.user_id = auth.uid()
+--       AND au.is_active = true
+--   )
+--
+-- The existing single-column indexes (idx_account_users_account_id,
+-- idx_account_users_user_id) require a heap lookup to filter on the other two
+-- predicates. A composite (account_id, user_id, is_active) lets the planner
+-- satisfy all three predicates from the index alone.
+--
+-- Uses CREATE INDEX (not CONCURRENTLY) because Supabase migrations run in a
+-- transaction and account_users is small; the SHARE lock is brief.
+
+CREATE INDEX IF NOT EXISTS idx_account_users_account_user_active
+  ON public.account_users (account_id, user_id, is_active);


### PR DESCRIPTION
## Summary
- Add `usePaginatedQuery` shared hook (offset-cursor pagination using Supabase `.range()` + `count: exact`).
- Wire pagination into `src/pages/internal/Orders.tsx` (100/page, integrated with existing "Load more days" UI) and `src/pages/internal/Inventory.tsx` finished-goods list (50/page, new "Load more" control).
- Add composite index `account_users (account_id, user_id, is_active)` to cover the standard RLS subquery pattern (`EXISTS (SELECT 1 FROM account_users au WHERE au.account_id = X AND au.user_id = auth.uid() AND au.is_active = true)`) used across account-scoped tables. Existing single-column indexes required a heap lookup to satisfy the other two predicates.
- Final `supabase gen types` is a no-op — index-only migration produces no schema-shape change, so `types.ts` is unchanged. Remote regen also blocked by CLI account perms in this environment.

## Notes
- `EXPLAIN` not run: no local Docker/Supabase and `psql` not present. Index choice driven by static RLS scan (matches CLAUDE.md "Standard RLS read pattern").
- Aggregation queries in `Inventory.tsx` (WIP transactions / adjustments) intentionally left unpaginated — they need the full result set for correctness.
- Lint/typecheck/vitest all green for changed files. Playwright did not run: pre-existing missing `lovable-agent-playwright-config` package on this machine, unrelated to this branch.

## Test plan
- [ ] `npm run lint` — no new errors introduced (baseline pre-existing)
- [ ] `npx tsc --noEmit` clean
- [ ] `npm run test` passes (18/18)
- [ ] Manual: open `/internal/orders`, scroll, click "Load 7 more days" — verify older orders appear and active orders remain pinned
- [ ] Manual: open `/internal/inventory` FG tab, click "Load more" — verify next page appended
- [ ] Verify migration applies cleanly against staging and `\d account_users` shows new composite index

🤖 Generated with [Claude Code](https://claude.com/claude-code)