### PR TITLE
fix(edge-fns): input validation, shared role enum, CORS allowlist

### DIFF
--- a/supabase/functions/_shared/cors.test.ts
+++ b/supabase/functions/_shared/cors.test.ts
@@ -1,0 +1,56 @@
+import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts';
+import { corsHeadersFor, isOriginAllowed } from './cors.ts';
+
+function withEnv(vars: Record<string, string | undefined>, fn: () => void) {
+  const prev: Record<string, string | undefined> = {};
+  for (const k of Object.keys(vars)) prev[k] = Deno.env.get(k);
+  try {
+    for (const [k, v] of Object.entries(vars)) {
+      if (v === undefined) Deno.env.delete(k);
+      else Deno.env.set(k, v);
+    }
+    fn();
+  } finally {
+    for (const [k, v] of Object.entries(prev)) {
+      if (v === undefined) Deno.env.delete(k);
+      else Deno.env.set(k, v);
+    }
+  }
+}
+
+Deno.test('corsHeadersFor echoes allowed origin', () => {
+  withEnv({ CORS_ALLOWED_ORIGINS: 'https://app.example.com,http://localhost:8080' }, () => {
+    const req = new Request('https://fn.example.com/', {
+      headers: { Origin: 'https://app.example.com' },
+    });
+    const h = corsHeadersFor(req);
+    assertEquals(h['Access-Control-Allow-Origin'], 'https://app.example.com');
+    assertEquals(h['Vary'], 'Origin');
+  });
+});
+
+Deno.test('corsHeadersFor falls back to first allowed origin when request origin not allowed', () => {
+  withEnv({ CORS_ALLOWED_ORIGINS: 'https://app.example.com,http://localhost:8080' }, () => {
+    const req = new Request('https://fn.example.com/', {
+      headers: { Origin: 'https://evil.example.com' },
+    });
+    const h = corsHeadersFor(req);
+    assertEquals(h['Access-Control-Allow-Origin'], 'https://app.example.com');
+  });
+});
+
+Deno.test('corsHeadersFor never returns wildcard', () => {
+  withEnv({ CORS_ALLOWED_ORIGINS: 'https://app.example.com' }, () => {
+    const req = new Request('https://fn.example.com/');
+    const h = corsHeadersFor(req);
+    assertEquals(h['Access-Control-Allow-Origin'] === '*', false);
+  });
+});
+
+Deno.test('isOriginAllowed honors allowlist', () => {
+  withEnv({ CORS_ALLOWED_ORIGINS: 'https://app.example.com' }, () => {
+    assertEquals(isOriginAllowed('https://app.example.com'), true);
+    assertEquals(isOriginAllowed('https://evil.example.com'), false);
+    assertEquals(isOriginAllowed(null), false);
+  });
+});

--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -1,0 +1,32 @@
+// Shared CORS helpers for edge functions.
+// Allowed origins come from CORS_ALLOWED_ORIGINS (comma-separated) with a
+// sensible fallback to SITE_URL plus local dev. Set CORS_ALLOWED_ORIGINS in
+// the Supabase project to override.
+
+const DEFAULT_DEV_ORIGIN = 'http://localhost:8080';
+
+function loadAllowedOrigins(): string[] {
+  const raw = Deno.env.get('CORS_ALLOWED_ORIGINS');
+  if (raw && raw.trim().length > 0) {
+    return raw.split(',').map((s) => s.trim()).filter(Boolean);
+  }
+  const siteUrl = Deno.env.get('SITE_URL') || 'https://homeislandcoffeepartners.lovable.app';
+  return [siteUrl, DEFAULT_DEV_ORIGIN];
+}
+
+export function corsHeadersFor(req: Request): Record<string, string> {
+  const allowed = loadAllowedOrigins();
+  const origin = req.headers.get('Origin') || '';
+  const allowOrigin = allowed.includes(origin) ? origin : allowed[0];
+  return {
+    'Access-Control-Allow-Origin': allowOrigin,
+    'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Vary': 'Origin',
+  };
+}
+
+export function isOriginAllowed(origin: string | null): boolean {
+  if (!origin) return false;
+  return loadAllowedOrigins().includes(origin);
+}

--- a/supabase/functions/_shared/role.test.ts
+++ b/supabase/functions/_shared/role.test.ts
@@ -1,0 +1,38 @@
+import { assertEquals, assertThrows } from 'https://deno.land/std@0.224.0/assert/mod.ts';
+import { APP_ROLES, isAppRole, assertAppRole, isOneOfRoles } from './role.ts';
+
+Deno.test('APP_ROLES contains exactly ADMIN, OPS, CLIENT', () => {
+  assertEquals([...APP_ROLES].sort(), ['ADMIN', 'CLIENT', 'OPS']);
+});
+
+Deno.test('isAppRole accepts valid roles', () => {
+  assertEquals(isAppRole('ADMIN'), true);
+  assertEquals(isAppRole('OPS'), true);
+  assertEquals(isAppRole('CLIENT'), true);
+});
+
+Deno.test('isAppRole rejects invalid/non-string values', () => {
+  assertEquals(isAppRole('admin'), false);
+  assertEquals(isAppRole('SUPERUSER'), false);
+  assertEquals(isAppRole(''), false);
+  assertEquals(isAppRole(null), false);
+  assertEquals(isAppRole(undefined), false);
+  assertEquals(isAppRole(42), false);
+  assertEquals(isAppRole({ role: 'ADMIN' }), false);
+});
+
+Deno.test('assertAppRole returns role for valid input', () => {
+  assertEquals(assertAppRole('OPS'), 'OPS');
+});
+
+Deno.test('assertAppRole throws for invalid input', () => {
+  assertThrows(() => assertAppRole('NOPE'), Error, 'Invalid role');
+  assertThrows(() => assertAppRole(null), Error, 'Invalid role');
+});
+
+Deno.test('isOneOfRoles filters to subset', () => {
+  assertEquals(isOneOfRoles('ADMIN', ['ADMIN', 'OPS']), true);
+  assertEquals(isOneOfRoles('OPS', ['ADMIN', 'OPS']), true);
+  assertEquals(isOneOfRoles('CLIENT', ['ADMIN', 'OPS']), false);
+  assertEquals(isOneOfRoles('bogus', ['ADMIN', 'OPS']), false);
+});

--- a/supabase/functions/_shared/role.ts
+++ b/supabase/functions/_shared/role.ts
@@ -1,0 +1,20 @@
+// Shared role enum + validation for edge functions.
+// Keep in sync with the `app_role` Postgres enum and AuthContext role usage.
+
+export const APP_ROLES = ['ADMIN', 'OPS', 'CLIENT'] as const;
+export type AppRole = typeof APP_ROLES[number];
+
+export function isAppRole(value: unknown): value is AppRole {
+  return typeof value === 'string' && (APP_ROLES as readonly string[]).includes(value);
+}
+
+export function assertAppRole(value: unknown): AppRole {
+  if (!isAppRole(value)) {
+    throw new Error(`Invalid role: expected one of ${APP_ROLES.join(', ')}`);
+  }
+  return value;
+}
+
+export function isOneOfRoles(value: unknown, allowed: readonly AppRole[]): value is AppRole {
+  return isAppRole(value) && allowed.includes(value);
+}

--- a/supabase/functions/_shared/validation.test.ts
+++ b/supabase/functions/_shared/validation.test.ts
@@ -1,0 +1,37 @@
+import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts';
+import { isValidEmail, isNonEmptyString, MAX_EMAIL_LEN } from './validation.ts';
+
+Deno.test('isValidEmail accepts well-formed addresses', () => {
+  assertEquals(isValidEmail('foo@bar.com'), true);
+  assertEquals(isValidEmail('first.last+tag@sub.example.co.uk'), true);
+  assertEquals(isValidEmail('a@b.c'), true);
+});
+
+Deno.test('isValidEmail rejects malformed addresses', () => {
+  assertEquals(isValidEmail(''), false);
+  assertEquals(isValidEmail('plainstring'), false);
+  assertEquals(isValidEmail('missing@dot'), false);
+  assertEquals(isValidEmail('@nouser.com'), false);
+  assertEquals(isValidEmail('user@'), false);
+  assertEquals(isValidEmail('has spaces@bar.com'), false);
+  assertEquals(isValidEmail('double@@bar.com'), false);
+});
+
+Deno.test('isValidEmail rejects non-strings', () => {
+  assertEquals(isValidEmail(null), false);
+  assertEquals(isValidEmail(undefined), false);
+  assertEquals(isValidEmail(42), false);
+  assertEquals(isValidEmail({}), false);
+});
+
+Deno.test('isValidEmail enforces length cap', () => {
+  const longLocal = 'a'.repeat(MAX_EMAIL_LEN);
+  assertEquals(isValidEmail(`${longLocal}@b.co`), false);
+});
+
+Deno.test('isNonEmptyString', () => {
+  assertEquals(isNonEmptyString('x'), true);
+  assertEquals(isNonEmptyString(''), false);
+  assertEquals(isNonEmptyString(null), false);
+  assertEquals(isNonEmptyString(0), false);
+});

--- a/supabase/functions/_shared/validation.ts
+++ b/supabase/functions/_shared/validation.ts
@@ -1,0 +1,13 @@
+// Shared input validators for edge functions.
+
+// RFC5322-ish — not exhaustive, rejects obvious garbage and over-length.
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+export const MAX_EMAIL_LEN = 254;
+
+export function isValidEmail(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0 && value.length <= MAX_EMAIL_LEN && EMAIL_RE.test(value);
+}
+
+export function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}

--- a/supabase/functions/invite-account-user/index.ts
+++ b/supabase/functions/invite-account-user/index.ts
@@ -1,9 +1,7 @@
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.49.1';
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
+import { corsHeadersFor } from '../_shared/cors.ts';
+import { isOneOfRoles } from '../_shared/role.ts';
+import { isValidEmail, isNonEmptyString } from '../_shared/validation.ts';
 
 const SITE_URL = Deno.env.get('SITE_URL') || 'https://homeislandcoffeepartners.lovable.app';
 
@@ -20,6 +18,7 @@ interface InviteAccountUserRequest {
 }
 
 Deno.serve(async (req) => {
+  const corsHeaders = corsHeadersFor(req);
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders });
   }
@@ -57,14 +56,22 @@ Deno.serve(async (req) => {
       .eq('user_id', callingUser.id)
       .single();
 
-    if (!roleData || !['ADMIN', 'OPS'].includes(roleData.role)) {
+    if (!roleData || !isOneOfRoles(roleData.role, ['ADMIN', 'OPS'])) {
       return new Response(
         JSON.stringify({ error: 'Only admins and ops can invite account users' }),
         { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
-    const body: InviteAccountUserRequest = await req.json();
+    let body: InviteAccountUserRequest;
+    try {
+      body = await req.json();
+    } catch {
+      return new Response(
+        JSON.stringify({ error: 'Invalid JSON body' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
     const {
       email, account_id, is_owner, can_place_orders, can_book_roaster,
       can_manage_locations, can_invite_users, location_access,
@@ -74,7 +81,21 @@ Deno.serve(async (req) => {
     if (!email || !account_id) {
       return new Response(
         JSON.stringify({ error: 'Email and account_id are required' }),
-        { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    if (!isValidEmail(email)) {
+      return new Response(
+        JSON.stringify({ error: 'Invalid email format' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    if (!isNonEmptyString(account_id)) {
+      return new Response(
+        JSON.stringify({ error: 'account_id must be a non-empty string' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }
 

--- a/supabase/functions/invite-user/index.ts
+++ b/supabase/functions/invite-user/index.ts
@@ -1,24 +1,21 @@
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.49.1';
+import { corsHeadersFor } from '../_shared/cors.ts';
+import { APP_ROLES, type AppRole, isAppRole } from '../_shared/role.ts';
+import { isValidEmail } from '../_shared/validation.ts';
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
-
-// Canonical app URL - use environment variable with fallback to published URL
-// IMPORTANT: Set SITE_URL environment variable in production
 const SITE_URL = Deno.env.get('SITE_URL') || 'https://homeislandcoffeepartners.lovable.app';
 
 interface InviteRequest {
   email: string;
-  role: 'ADMIN' | 'OPS' | 'CLIENT';
+  role: AppRole;
   client_id?: string;
   coroast_member_id?: string;
   name?: string;
-  generate_link_only?: boolean; // DEV: return link instead of sending email
+  generate_link_only?: boolean;
 }
 
 Deno.serve(async (req) => {
+  const corsHeaders = corsHeadersFor(req);
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders });
   }
@@ -58,7 +55,7 @@ Deno.serve(async (req) => {
       .eq('user_id', callingUser.id)
       .single();
 
-    if (roleError || roleData?.role !== 'ADMIN') {
+    if (roleError || !isAppRole(roleData?.role) || roleData.role !== 'ADMIN') {
       console.error('[invite-user] Not admin:', roleError?.message, roleData);
       return new Response(
         JSON.stringify({ error: 'Only admins can invite users' }),
@@ -67,7 +64,15 @@ Deno.serve(async (req) => {
     }
 
     // Parse request
-    const body: InviteRequest = await req.json();
+    let body: InviteRequest;
+    try {
+      body = await req.json();
+    } catch {
+      return new Response(
+        JSON.stringify({ error: 'Invalid JSON body' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
     const { email, role, client_id, coroast_member_id, name, generate_link_only = false } = body;
 
     console.log('[invite-user] Invite requested for:', email, 'role:', role, 'generate_link_only:', generate_link_only);
@@ -80,9 +85,16 @@ Deno.serve(async (req) => {
       );
     }
 
-    if (!['ADMIN', 'OPS', 'CLIENT'].includes(role)) {
+    if (!isValidEmail(email)) {
       return new Response(
-        JSON.stringify({ error: 'Invalid role. Must be ADMIN, OPS, or CLIENT' }),
+        JSON.stringify({ error: 'Invalid email format' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    if (!isAppRole(role)) {
+      return new Response(
+        JSON.stringify({ error: `Invalid role. Must be one of ${APP_ROLES.join(', ')}` }),
         { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }


### PR DESCRIPTION
## Summary
- Add input validation (email regex+length, JSON parse guard, non-empty checks) to `invite-user` and `invite-account-user` edge functions
- Introduce `supabase/functions/_shared/role.ts` with `APP_ROLES` enum + type guards; replace raw string role comparisons
- Replace wildcard CORS with origin allowlist via new `_shared/cors.ts`; configurable via `CORS_ALLOWED_ORIGINS` env var (falls back to `SITE_URL` + `http://localhost:8080`)
- Add Deno unit tests for `role`, `validation`, and `cors` shared utils

## Deployment note
Set `CORS_ALLOWED_ORIGINS` (comma-separated) in the Supabase project env to lock down origins. If unset, falls back to existing `SITE_URL` + local dev — no new domains hardcoded.

## Test plan
- [ ] Deno tests pass: `deno test supabase/functions/_shared/`
- [ ] Existing vitest suite still green: `npm run test`
- [ ] Smoke: invite a new user via admin UI (happy path)
- [ ] Smoke: POST `invite-user` with malformed email → 400 JSON error
- [ ] Smoke: POST `invite-user` with invalid role → 400 JSON error
- [ ] Smoke: POST `invite-account-user` with missing `account_id` → 400 (was 200)
- [ ] Verify preflight OPTIONS responds with allowlisted origin, not `*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)