### PR TITLE
fix(coroast): add account_id to coroast_recurring_blocks + fix admin booking writes

### DIFF
--- a/src/components/bookings/BookingFormDialog.tsx
+++ b/src/components/bookings/BookingFormDialog.tsx
@@ -204,7 +204,7 @@ export function BookingFormDialog({
         const { data: recurBlock, error: rbErr } = await supabase
           .from('coroast_recurring_blocks')
           .insert({
-            member_id: memberId,
+            account_id: memberId,
             day_of_week: recurringDay as any,
             start_time: formStartTime,
             end_time: formEndTime,

--- a/supabase/migrations/20260514120000_coroast_recurring_blocks_account_id.sql
+++ b/supabase/migrations/20260514120000_coroast_recurring_blocks_account_id.sql
@@ -1,0 +1,65 @@
+-- Add account_id to coroast_recurring_blocks and rewrite member-read RLS to
+-- the account-scoped subquery pattern used elsewhere in the coroast schema.
+--
+-- Backfill source: member_id. Per the 20260414230648 migration the FK from
+-- member_id -> coroast_members(id) was dropped and member_id became nullable;
+-- admin and member-portal write paths have since been populating member_id
+-- with the account UUID. Rows whose member_id matches an accounts.id row
+-- are backfilled; the migration fails loudly if any rows would be left NULL.
+--
+-- member_id is intentionally NOT dropped in this migration. It remains
+-- nullable for backwards compatibility while admin/RPC writes are migrated
+-- to account_id. A follow-up migration can drop it once writes are clean.
+
+BEGIN;
+
+ALTER TABLE public.coroast_recurring_blocks
+  ADD COLUMN account_id uuid REFERENCES public.accounts(id) ON DELETE CASCADE;
+
+UPDATE public.coroast_recurring_blocks rb
+SET account_id = rb.member_id
+WHERE rb.account_id IS NULL
+  AND rb.member_id IS NOT NULL
+  AND EXISTS (SELECT 1 FROM public.accounts a WHERE a.id = rb.member_id);
+
+DO $$
+DECLARE
+  v_orphans integer;
+BEGIN
+  SELECT count(*) INTO v_orphans
+  FROM public.coroast_recurring_blocks
+  WHERE account_id IS NULL;
+
+  IF v_orphans > 0 THEN
+    RAISE EXCEPTION
+      'coroast_recurring_blocks: % row(s) have NULL account_id after backfill; resolve orphans before applying',
+      v_orphans;
+  END IF;
+END $$;
+
+ALTER TABLE public.coroast_recurring_blocks
+  ALTER COLUMN account_id SET NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_coroast_recurring_blocks_account
+  ON public.coroast_recurring_blocks (account_id);
+
+-- Rewrite member-read RLS: old policy gated only on program membership,
+-- letting any active COROASTING user read every recurring block. Replace
+-- with the standard account-scoped subquery used on coroast_bookings etc.
+DROP POLICY IF EXISTS "Active co-roasting members can read coroast_recurring_blocks"
+  ON public.coroast_recurring_blocks;
+
+CREATE POLICY "Account members can read coroast_recurring_blocks"
+  ON public.coroast_recurring_blocks
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.account_users au
+      WHERE au.account_id = coroast_recurring_blocks.account_id
+        AND au.user_id = auth.uid()
+        AND au.is_active = true
+    )
+  );
+
+COMMIT;


### PR DESCRIPTION
## Summary
- Adds `account_id` column (NOT NULL, FK to `accounts(id)` ON DELETE CASCADE) to `coroast_recurring_blocks`, backfilled from `member_id` (which has been carrying account UUIDs since the `coroast_members` FK was dropped in `20260414230648`).
- Rewrites the member-read RLS policy on `coroast_recurring_blocks` to the standard account-scoped subquery pattern. The old policy gated only on COROASTING program membership and exposed every account's recurring blocks to every active member.
- Fixes [BookingFormDialog.tsx](src/components/bookings/BookingFormDialog.tsx:207) so the admin recurring-booking INSERT writes `account_id` (was writing `member_id` only).
- `member_id` left nullable for now; a follow-up will drop it once all write paths are confirmed clean.

## Notes
- Migration aborts via `RAISE EXCEPTION` if any row would have NULL `account_id` after backfill — backfill is verified at migration runtime since Supabase is not directly reachable from this environment.
- Types regen (`supabase gen types`) was **not** run in this PR: local CLI needs Docker (unavailable) and remote `--project-id` queries were not permitted in this session. Run `supabase gen types typescript --project-id cgdzjkryygwlyygeznrb > src/integrations/supabase/types.ts` manually after merge and commit as a follow-up.

## Test plan
- [ ] Apply migration on staging; verify `coroast_recurring_blocks.account_id` is NOT NULL and matches `member_id` for existing rows
- [ ] Admin recurring booking flow: create a weekly recurring booking; row appears in `coroast_recurring_blocks` with `account_id` set
- [ ] Member portal: a co-roasting user only sees recurring blocks for accounts they belong to (not all accounts)
- [ ] Existing single (non-recurring) admin booking flow unaffected
- [ ] `npm run test` passes (verified locally — 18/18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)