### PR TITLE
fix(coroast): normalize hours_delta sign + record 50% cancel ledger entry

### DIFF
--- a/src/components/bookings/BookingDetailModal.tsx
+++ b/src/components/bookings/BookingDetailModal.tsx
@@ -11,6 +11,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
 import { formatTime12, timeToMinutes, TIER_RATES, type BookingRow, type MemberRow } from './bookingUtils';
 import { useAccountPricing } from '@/hooks/useAccountPricing';
+import { refundedHoursFiftyPercent } from '@/lib/coroastHoursLedger';
 
 interface BookingDetailModalProps {
   open: boolean;
@@ -102,7 +103,12 @@ export function BookingDetailModal({ open, onOpenChange, booking, members, allBo
         cancelled_at: new Date().toISOString(),
       }).eq('id', booking.id);
       if (error) throw error;
-      // 50% fee — hours not returned
+      await supabase.from('coroast_hour_ledger').insert({
+        member_id: booking.member_id, billing_period_id: booking.billing_period_id,
+        booking_id: booking.id, entry_type: 'BOOKING_RETURNED' as any,
+        hours_delta: refundedHoursFiftyPercent(durationHrs),
+        notes: `50% cancellation for ${booking.booking_date}`,
+      });
     },
     onSuccess: () => { toast.success(`Booking cancelled (50% fee: $${(fullFee * 0.5).toFixed(0)})`); invalidateAll(); onOpenChange(false); },
     onError: () => toast.error('Failed to cancel booking'),

--- a/src/lib/coroastHoursLedger.test.ts
+++ b/src/lib/coroastHoursLedger.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import {
+  HOURS_LEDGER_SIGN,
+  consumedHours,
+  refundedHours,
+  refundedHoursFiftyPercent,
+} from './coroastHoursLedger';
+
+type LedgerEntry = {
+  entry_type: 'BOOKING_CONFIRMED' | 'BOOKING_RETURNED';
+  hours_delta: number;
+};
+
+const sumLedger = (entries: LedgerEntry[]) =>
+  entries.reduce((acc, e) => acc + e.hours_delta, 0);
+
+describe('coroastHoursLedger sign convention', () => {
+  it('defines POSITIVE = consumed, NEGATIVE = refunded', () => {
+    expect(HOURS_LEDGER_SIGN.CONSUMED).toBe(1);
+    expect(HOURS_LEDGER_SIGN.REFUNDED).toBe(-1);
+  });
+
+  it('consumedHours always returns a positive delta', () => {
+    expect(consumedHours(2)).toBe(2);
+    expect(consumedHours(-2)).toBe(2);
+    expect(consumedHours(0.5)).toBe(0.5);
+  });
+
+  it('refundedHours always returns a negative delta', () => {
+    expect(refundedHours(2)).toBe(-2);
+    expect(refundedHours(-2)).toBe(-2);
+    expect(refundedHours(0.5)).toBe(-0.5);
+  });
+
+  it('refundedHoursFiftyPercent returns negative half of duration', () => {
+    expect(refundedHoursFiftyPercent(4)).toBe(-2);
+    expect(refundedHoursFiftyPercent(3)).toBe(-1.5);
+  });
+});
+
+describe('billing period ledger sums', () => {
+  // Simulates the four flows specified in the task. Each booking is 4 hours.
+  // Net hours_delta over a billing period must equal what the member is billed for.
+
+  const DURATION = 4;
+
+  it('full booking with no cancellation: net = +duration (consumed)', () => {
+    const ledger: LedgerEntry[] = [
+      { entry_type: 'BOOKING_CONFIRMED', hours_delta: consumedHours(DURATION) },
+    ];
+    expect(sumLedger(ledger)).toBe(4);
+  });
+
+  it('48h-cancel (free, ≥48h notice): net = 0 hours billed', () => {
+    const ledger: LedgerEntry[] = [
+      { entry_type: 'BOOKING_CONFIRMED', hours_delta: consumedHours(DURATION) },
+      { entry_type: 'BOOKING_RETURNED', hours_delta: refundedHours(DURATION) },
+    ];
+    expect(sumLedger(ledger)).toBe(0);
+  });
+
+  it('free cancellation refund equals the original consumption', () => {
+    const consumed = consumedHours(DURATION);
+    const refunded = refundedHours(DURATION);
+    expect(consumed + refunded).toBe(0);
+  });
+
+  it('50%-cancel (24–48h notice): net = +half duration billed', () => {
+    const ledger: LedgerEntry[] = [
+      { entry_type: 'BOOKING_CONFIRMED', hours_delta: consumedHours(DURATION) },
+      { entry_type: 'BOOKING_RETURNED', hours_delta: refundedHoursFiftyPercent(DURATION) },
+    ];
+    expect(sumLedger(ledger)).toBe(2);
+  });
+
+  it('100%-cancel (no-show / <24h): no refund entry, full duration billed', () => {
+    const ledger: LedgerEntry[] = [
+      { entry_type: 'BOOKING_CONFIRMED', hours_delta: consumedHours(DURATION) },
+    ];
+    expect(sumLedger(ledger)).toBe(4);
+  });
+
+  it('multiple bookings + mixed cancellations sum correctly across a period', () => {
+    const ledger: LedgerEntry[] = [
+      // Booking A: 4h, free-cancelled
+      { entry_type: 'BOOKING_CONFIRMED', hours_delta: consumedHours(4) },
+      { entry_type: 'BOOKING_RETURNED', hours_delta: refundedHours(4) },
+      // Booking B: 2h, 50%-cancelled
+      { entry_type: 'BOOKING_CONFIRMED', hours_delta: consumedHours(2) },
+      { entry_type: 'BOOKING_RETURNED', hours_delta: refundedHoursFiftyPercent(2) },
+      // Booking C: 3h, kept
+      { entry_type: 'BOOKING_CONFIRMED', hours_delta: consumedHours(3) },
+    ];
+    // A: 0, B: 1, C: 3  => 4
+    expect(sumLedger(ledger)).toBe(4);
+  });
+});

--- a/src/lib/coroastHoursLedger.ts
+++ b/src/lib/coroastHoursLedger.ts
@@ -1,0 +1,30 @@
+/**
+ * Canonical sign convention for `coroast_hour_ledger.hours_delta`.
+ *
+ * POSITIVE = hours consumed (a booking debits the account's hour balance)
+ * NEGATIVE = hours refunded (a cancellation credits hours back)
+ *
+ * Every write to `coroast_hour_ledger` — from the admin UI, member-portal
+ * SECURITY DEFINER RPCs, or any future automation — must match this rule so
+ * that `SUM(hours_delta)` over a billing period equals net hours consumed.
+ */
+export const HOURS_LEDGER_SIGN = {
+  CONSUMED: 1,
+  REFUNDED: -1,
+} as const;
+
+export function consumedHours(hours: number): number {
+  return Math.abs(hours) * HOURS_LEDGER_SIGN.CONSUMED;
+}
+
+export function refundedHours(hours: number): number {
+  return Math.abs(hours) * HOURS_LEDGER_SIGN.REFUNDED;
+}
+
+/**
+ * Hours refunded on a 50% cancellation (24–48h notice): half the booking
+ * duration is credited back, the other half is billed via cancellation_fee_amt.
+ */
+export function refundedHoursFiftyPercent(durationHours: number): number {
+  return refundedHours(durationHours * 0.5);
+}

--- a/supabase/migrations/20260514120000_fix_hours_delta_sign.sql
+++ b/supabase/migrations/20260514120000_fix_hours_delta_sign.sql
@@ -1,0 +1,135 @@
+-- ============================================================
+-- Fix coroast_hour_ledger.hours_delta sign convention
+--
+-- Canonical convention (also documented in src/lib/coroastHoursLedger.ts):
+--   POSITIVE = hours consumed
+--   NEGATIVE = hours refunded
+--
+-- The member-portal RPCs in 20260501195324_*.sql wrote opposite signs:
+--   create_member_booking  inserted a NEGATIVE delta for BOOKING_CONFIRMED
+--   cancel_member_booking  inserted a POSITIVE delta for BOOKING_RETURNED
+--
+-- This migration replaces both functions so their ledger writes match the
+-- admin-UI convention. No other behaviour changes; signatures unchanged.
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.create_member_booking(
+  p_account_id uuid,
+  p_booking_date date,
+  p_start_time time,
+  p_end_time time,
+  p_notes text DEFAULT NULL,
+  p_recurring_block_id uuid DEFAULT NULL
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_booking_id uuid;
+  v_billing_period_id uuid;
+  v_hours numeric;
+BEGIN
+  PERFORM public._assert_active_coroast_member(p_account_id);
+
+  IF p_start_time >= p_end_time THEN
+    RAISE EXCEPTION 'Invalid time range';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM public.coroast_bookings cb
+    WHERE cb.booking_date = p_booking_date
+      AND cb.status NOT IN ('CANCELLED_FREE', 'CANCELLED_CHARGED', 'CANCELLED_WAIVED', 'NO_SHOW')
+      AND cb.start_time < p_end_time
+      AND cb.end_time   > p_start_time
+  ) THEN
+    RAISE EXCEPTION 'Time slot conflicts with an existing booking';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM public.coroast_loring_blocks lb
+    WHERE lb.block_date = p_booking_date
+      AND lb.start_time < p_end_time
+      AND lb.end_time   > p_start_time
+  ) THEN
+    RAISE EXCEPTION 'Time slot conflicts with an unavailability block';
+  END IF;
+
+  v_billing_period_id := public._get_or_create_billing_period(p_account_id, p_booking_date);
+  v_hours := ROUND(EXTRACT(EPOCH FROM (p_end_time - p_start_time)) / 3600.0, 2);
+
+  INSERT INTO public.coroast_bookings (
+    account_id, billing_period_id, booking_date, start_time, end_time,
+    notes_member, recurring_block_id, status, created_by
+  ) VALUES (
+    p_account_id, v_billing_period_id, p_booking_date, p_start_time, p_end_time,
+    NULLIF(TRIM(COALESCE(p_notes, '')), ''), p_recurring_block_id,
+    'CONFIRMED'::coroast_booking_status, auth.uid()
+  )
+  RETURNING id INTO v_booking_id;
+
+  INSERT INTO public.coroast_hour_ledger (
+    account_id, billing_period_id, booking_id, entry_type, hours_delta, notes, created_by
+  ) VALUES (
+    p_account_id, v_billing_period_id, v_booking_id,
+    'BOOKING_CONFIRMED'::coroast_ledger_entry_type,
+    v_hours, -- POSITIVE: bookings consume hours
+    'Self-serve booking on ' || to_char(p_booking_date, 'YYYY-MM-DD'),
+    auth.uid()
+  );
+
+  RETURN v_booking_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.cancel_member_booking(p_booking_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_account_id uuid;
+  v_billing_period_id uuid;
+  v_booking_date date;
+  v_status coroast_booking_status;
+  v_duration numeric;
+BEGIN
+  SELECT account_id, billing_period_id, booking_date, status, duration_hours
+    INTO v_account_id, v_billing_period_id, v_booking_date, v_status, v_duration
+    FROM public.coroast_bookings
+   WHERE id = p_booking_id;
+
+  IF v_account_id IS NULL THEN
+    RAISE EXCEPTION 'Booking not found';
+  END IF;
+
+  PERFORM public._assert_active_coroast_member(v_account_id);
+
+  IF v_status IN ('CANCELLED_FREE','CANCELLED_CHARGED','CANCELLED_WAIVED','NO_SHOW','COMPLETED') THEN
+    RAISE EXCEPTION 'Booking is not cancellable';
+  END IF;
+
+  IF v_booking_date < CURRENT_DATE THEN
+    RAISE EXCEPTION 'Cannot cancel a past booking';
+  END IF;
+
+  UPDATE public.coroast_bookings
+     SET status = 'CANCELLED_FREE'::coroast_booking_status,
+         cancelled_at = now(),
+         cancelled_by = auth.uid(),
+         updated_at = now()
+   WHERE id = p_booking_id;
+
+  INSERT INTO public.coroast_hour_ledger (
+    account_id, billing_period_id, booking_id, entry_type, hours_delta, notes, created_by
+  ) VALUES (
+    v_account_id, v_billing_period_id, p_booking_id,
+    'BOOKING_RETURNED'::coroast_ledger_entry_type,
+    -ROUND(COALESCE(v_duration, 0), 2), -- NEGATIVE: refunds the hours
+    'Member-initiated cancellation',
+    auth.uid()
+  );
+END;
+$$;


### PR DESCRIPTION
## Summary

- Adopt a single canonical sign convention for `coroast_hour_ledger.hours_delta`: **POSITIVE = hours consumed**, **NEGATIVE = hours refunded**. Documented as a named constant in `src/lib/coroastHoursLedger.ts`.
- Flip the signs in the member-portal SECURITY DEFINER RPCs (`create_member_booking`, `cancel_member_booking`) so they match the admin-UI convention already used in `BookingFormDialog.tsx` and `BookingDetailModal.tsx`.
- `cancel50PctMutation` in `BookingDetailModal.tsx` now writes a negative half-hours `BOOKING_RETURNED` ledger row — previously the 50% cancellation path wrote no ledger entry at all, so the account was double-charged (full hours consumed + 50% cancellation fee).

## Why

`CLAUDE.md` flags the sign mismatch: admin UI uses positive-for-consumed, member RPCs used the opposite. Net effect: `SUM(hours_delta)` over a billing period did not match what the member should actually be billed for, and 50% cancellations silently lost hours back to the pool without crediting the member.

## Files

- `src/lib/coroastHoursLedger.ts` *(new)* — `HOURS_LEDGER_SIGN` constant + `consumedHours` / `refundedHours` / `refundedHoursFiftyPercent` helpers.
- `supabase/migrations/20260514120000_fix_hours_delta_sign.sql` *(new)* — `CREATE OR REPLACE` for both RPCs; signatures unchanged, only ledger insert signs flipped.
- `src/components/bookings/BookingDetailModal.tsx` — `cancel50PctMutation` inserts a `BOOKING_RETURNED` row with `hours_delta = refundedHoursFiftyPercent(durationHrs)` (negative half).
- `src/lib/coroastHoursLedger.test.ts` *(new)* — 10 unit tests covering sign convention + full / 48h-cancel / free-cancel / 50%-cancel / 100%-no-show / mixed-period flows; asserts ledger sums match expected billing-period totals.

## Out of scope (per task brief)

- `supabase/types.ts` regeneration — deferred to the next migration cycle (S2).
- `coroast_recurring_blocks` admin-flow bug noted in `CLAUDE.md` — S2.
- Tier-rate / pricing logic — S3.

## Test plan

- [x] `npm run test` — 28/28 passing (10 new in `coroastHoursLedger.test.ts`).
- [x] `npm run lint` — no new errors introduced in changed files; the `as any` cast added in `cancel50PctMutation` matches the existing pattern on the surrounding ledger inserts (lines 88, 157) and is part of the project's pre-existing lint baseline.
- [ ] After merge: apply migration locally, exercise create / free-cancel / 50%-cancel flows in the admin UI, confirm `SUM(hours_delta)` for the billing period matches the invoice line.
- [ ] After merge: exercise the member-portal self-serve booking + cancellation flow, confirm ledger signs match the admin path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)