### PR TITLE
Add My Numbers calculator to manufacturing client portal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,6 +64,7 @@ import MemberSchedule from "@/pages/member/MemberSchedule";
 import MemberBilling from "@/pages/member/MemberBilling";
 import MemberAccount from "@/pages/member/MemberAccount";
 import MyNumbers from "@/pages/member/MyNumbers";
+import ClientMyNumbers from "@/pages/client/MyNumbers";
 import NotFound from "@/pages/NotFound";
 import ExplorePage from "@/pages/public/ExplorePage";
 
@@ -328,6 +329,16 @@ const App = () => (
             <Route path="/portal/account" element={
               <ProtectedRoute allowedRoles={['CLIENT']}>
                 <ClientLayout><Account /></ClientLayout>
+              </ProtectedRoute>
+            } />
+            <Route path="/portal/numbers" element={
+              <ProtectedRoute allowedRoles={['CLIENT']}>
+                <ClientLayout><ClientMyNumbers /></ClientLayout>
+              </ProtectedRoute>
+            } />
+            <Route path="/client/numbers" element={
+              <ProtectedRoute allowedRoles={['CLIENT']}>
+                <ClientLayout><ClientMyNumbers /></ClientLayout>
               </ProtectedRoute>
             } />
 

--- a/src/components/client/numbers/ClientInputsPanel.tsx
+++ b/src/components/client/numbers/ClientInputsPanel.tsx
@@ -1,0 +1,356 @@
+import { useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { Slider } from '@/components/ui/slider';
+import { Switch } from '@/components/ui/switch';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { ChevronDown, HelpCircle } from 'lucide-react';
+import { unitLabel, type DisplayUnit } from '@/lib/unitEconomics';
+import type { ClientUnitEconomicsInputs, PaceMode } from '@/lib/clientUnitEconomics';
+import type { ClientPrefills, ClientProductPrefill } from '@/lib/clientUnitEconomicsPrefill';
+import { cn } from '@/lib/utils';
+
+interface Props {
+  inputs: ClientUnitEconomicsInputs;
+  onChange: (next: ClientUnitEconomicsInputs) => void;
+  prefills: ClientPrefills | undefined;
+}
+
+function NumberField({
+  value, onChange, placeholder, step = '0.01', min,
+}: {
+  value: number | null;
+  onChange: (v: number | null) => void;
+  placeholder?: string;
+  step?: string;
+  min?: number;
+}) {
+  return (
+    <Input
+      type="number"
+      inputMode="decimal"
+      step={step}
+      min={min}
+      value={value ?? ''}
+      placeholder={placeholder}
+      onChange={(e) => {
+        const v = e.target.value;
+        onChange(v === '' ? null : Number(v));
+      }}
+    />
+  );
+}
+
+function Section({
+  title, children, defaultOpen = true,
+}: { title: string; children: React.ReactNode; defaultOpen?: boolean }) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <Card>
+      <Collapsible open={open} onOpenChange={setOpen}>
+        <CollapsibleTrigger asChild>
+          <CardHeader className="cursor-pointer select-none flex flex-row items-center justify-between py-3 px-4">
+            <CardTitle className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+              {title}
+            </CardTitle>
+            <ChevronDown className={cn('h-4 w-4 text-muted-foreground transition-transform', open && 'rotate-180')} />
+          </CardHeader>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <CardContent className="px-4 pb-4 pt-0 space-y-3">{children}</CardContent>
+        </CollapsibleContent>
+      </Collapsible>
+    </Card>
+  );
+}
+
+function HelpHint({ text }: { text: string }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button type="button" className="inline-flex" tabIndex={-1}>
+          <HelpCircle className="h-3.5 w-3.5 text-muted-foreground" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-xs text-xs">{text}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+export function ClientInputsPanel({ inputs, onChange, prefills }: Props) {
+  const set = <K extends keyof ClientUnitEconomicsInputs>(k: K, v: ClientUnitEconomicsInputs[K]) =>
+    onChange({ ...inputs, [k]: v });
+
+  const products: ClientProductPrefill[] = prefills?.products ?? [];
+  const seasonalAvailable = prefills?.seasonalPaceKgPerMonth != null;
+  const currentPace = prefills?.currentPaceKgPerMonth ?? 0;
+  const seasonalPace = prefills?.seasonalPaceKgPerMonth ?? null;
+
+  const handleProductChange = (productId: string) => {
+    const p = products.find(x => x.productId === productId);
+    if (!p) return;
+    onChange({
+      ...inputs,
+      productId: p.productId,
+      productName: p.productName,
+      bagSizeG: p.bagSizeG,
+      costPerBagFromUs: p.avgPricePerBag,
+    });
+  };
+
+  const handlePaceChange = (mode: PaceMode) => {
+    const next = mode === 'SEASONAL' && seasonalPace != null ? seasonalPace : currentPace;
+    onChange({ ...inputs, paceMode: mode, monthlyKg: next > 0 ? Number(next.toFixed(2)) : inputs.monthlyKg });
+  };
+
+  return (
+    <div className="space-y-3">
+      {/* Display unit */}
+      <Card>
+        <CardContent className="p-4 space-y-3">
+          <Label className="text-sm font-semibold">I want to see costs per…</Label>
+          <RadioGroup
+            value={inputs.displayUnit}
+            onValueChange={(v) => set('displayUnit', v as DisplayUnit)}
+            className="grid grid-cols-3 gap-2"
+          >
+            {(['BAG', 'KG', 'LB'] as DisplayUnit[]).map(u => (
+              <Label
+                key={u}
+                className={cn(
+                  'flex items-center justify-center gap-2 rounded-md border px-3 py-2 cursor-pointer text-sm',
+                  inputs.displayUnit === u ? 'border-primary bg-primary/5 font-semibold' : 'border-border',
+                )}
+              >
+                <RadioGroupItem value={u} className="sr-only" />
+                {u === 'BAG' ? 'Bag' : u === 'KG' ? 'Kilogram' : 'Pound'}
+              </Label>
+            ))}
+          </RadioGroup>
+          {inputs.displayUnit === 'BAG' && (
+            <div className="space-y-1.5">
+              <Label className="text-xs text-muted-foreground">Bag size (grams)</Label>
+              <NumberField
+                value={inputs.bagSizeG}
+                onChange={(v) => set('bagSizeG', v ?? 340)}
+                step="1"
+                min={1}
+              />
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Product + cost from us */}
+      <Section title="Your cost from Home Island">
+        {products.length > 0 ? (
+          <>
+            {products.length > 1 && (
+              <div className="space-y-1.5">
+                <Label className="text-xs">Product</Label>
+                <Select value={inputs.productId ?? ''} onValueChange={handleProductChange}>
+                  <SelectTrigger><SelectValue placeholder="Select product" /></SelectTrigger>
+                  <SelectContent>
+                    {products.map(p => (
+                      <SelectItem key={p.productId} value={p.productId}>
+                        {p.productName} ({p.bagSizeG}g · {p.bagsShipped90d} bags / 90d)
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+            <div className="space-y-1.5">
+              <Label className="text-xs flex items-center gap-1.5">
+                Your cost per bag (from Home Island)
+                <HelpHint text="Average price you paid for this product over the last 90 days. Adjust if your contract pricing differs." />
+              </Label>
+              <NumberField
+                value={inputs.costPerBagFromUs}
+                onChange={(v) => set('costPerBagFromUs', v)}
+                placeholder="e.g. 12.50"
+              />
+              <p className="text-[11px] text-muted-foreground">
+                Pre-filled from your recent orders — adjust as needed.
+              </p>
+            </div>
+          </>
+        ) : (
+          <div className="space-y-1.5">
+            <Label className="text-xs">Your cost per bag (from Home Island)</Label>
+            <NumberField
+              value={inputs.costPerBagFromUs}
+              onChange={(v) => set('costPerBagFromUs', v)}
+              placeholder="e.g. 12.50"
+            />
+            <p className="text-[11px] text-muted-foreground">
+              No recent orders to pre-fill from — enter the price you pay per bag.
+            </p>
+          </div>
+        )}
+      </Section>
+
+      <Section title="Volume">
+        <div className="space-y-2">
+          <Label className="text-xs">Pace assumption</Label>
+          <RadioGroup
+            value={inputs.paceMode}
+            onValueChange={(v) => handlePaceChange(v as PaceMode)}
+            className={cn('grid gap-2', seasonalAvailable ? 'grid-cols-2' : 'grid-cols-1')}
+          >
+            <Label
+              className={cn(
+                'flex flex-col items-start gap-0.5 rounded-md border px-3 py-2 cursor-pointer text-xs',
+                inputs.paceMode === 'CURRENT' ? 'border-primary bg-primary/5 font-semibold' : 'border-border',
+              )}
+            >
+              <RadioGroupItem value="CURRENT" className="sr-only" />
+              <span>Current pace (last 3 months)</span>
+              <span className="text-[11px] text-muted-foreground font-normal">
+                {currentPace > 0 ? `${currentPace.toFixed(1)} kg/mo` : 'No recent orders'}
+              </span>
+            </Label>
+            {seasonalAvailable && (
+              <Label
+                className={cn(
+                  'flex flex-col items-start gap-0.5 rounded-md border px-3 py-2 cursor-pointer text-xs',
+                  inputs.paceMode === 'SEASONAL' ? 'border-primary bg-primary/5 font-semibold' : 'border-border',
+                )}
+              >
+                <RadioGroupItem value="SEASONAL" className="sr-only" />
+                <span>Seasonal pace (same quarter last year)</span>
+                <span className="text-[11px] text-muted-foreground font-normal">
+                  {seasonalPace!.toFixed(1)} kg/mo
+                </span>
+              </Label>
+            )}
+          </RadioGroup>
+        </div>
+        <div className="space-y-1.5">
+          <Label className="text-xs">Kg roasted per month</Label>
+          <NumberField
+            value={inputs.monthlyKg}
+            onChange={(v) => set('monthlyKg', v)}
+            placeholder="e.g. 80"
+          />
+        </div>
+      </Section>
+
+      <Section title="Packaging (extras)" defaultOpen={false}>
+        <div className="space-y-1.5">
+          <Label className="text-xs flex items-center gap-1.5">
+            Extra packaging cost per bag
+            <HelpHint text="Only your add-ons — custom labels, inserts, gift packaging. The bag itself is already in your cost from us." />
+          </Label>
+          <NumberField
+            value={inputs.extraPackagingPerBag}
+            onChange={(v) => set('extraPackagingPerBag', v)}
+            placeholder="e.g. 0.45"
+          />
+          {inputs.displayUnit !== 'BAG' && (
+            <p className="text-[11px] text-muted-foreground">
+              Packaging only applies when costs are shown per bag.
+            </p>
+          )}
+        </div>
+      </Section>
+
+      <Section title="Labour" defaultOpen={false}>
+        <div className="flex items-center justify-between">
+          <Label htmlFor="cli-labour" className="text-xs cursor-pointer">
+            Include labour in my costs?
+          </Label>
+          <Switch
+            id="cli-labour"
+            checked={inputs.includeLabour}
+            onCheckedChange={(v) => set('includeLabour', v)}
+          />
+        </div>
+        {inputs.includeLabour && (
+          <div className="grid grid-cols-2 gap-2">
+            <div className="space-y-1">
+              <Label className="text-[11px] text-muted-foreground">Hours per batch</Label>
+              <NumberField
+                value={inputs.labourHoursPerBatch}
+                onChange={(v) => set('labourHoursPerBatch', v ?? 0)}
+                step="0.1"
+                min={0}
+              />
+            </div>
+            <div className="space-y-1">
+              <Label className="text-[11px] text-muted-foreground">Rate $/hour</Label>
+              <NumberField
+                value={inputs.labourRatePerHr}
+                onChange={(v) => set('labourRatePerHr', v ?? 0)}
+                step="0.50"
+                min={0}
+              />
+            </div>
+          </div>
+        )}
+      </Section>
+
+      <Section title="Overhead" defaultOpen={false}>
+        <div className="space-y-1.5">
+          <Label className="text-xs flex items-center gap-1.5">
+            Monthly overhead $
+            <HelpHint text="Rent, insurance, staff, utilities — anything fixed that doesn't scale with volume." />
+          </Label>
+          <NumberField
+            value={inputs.overheadMonthly}
+            onChange={(v) => set('overheadMonthly', v)}
+            placeholder="e.g. 2500"
+          />
+        </div>
+      </Section>
+
+      <Section title="Pricing">
+        <PriceWithSlider
+          label={`Wholesale price per ${unitLabel(inputs.displayUnit)}`}
+          value={inputs.wholesalePrice}
+          onChange={(v) => set('wholesalePrice', v)}
+          maxRef={inputs.retailPrice ?? 30}
+        />
+        <PriceWithSlider
+          label={`Retail price per ${unitLabel(inputs.displayUnit)}`}
+          value={inputs.retailPrice}
+          onChange={(v) => set('retailPrice', v)}
+          maxRef={inputs.retailPrice ?? 30}
+        />
+      </Section>
+    </div>
+  );
+}
+
+function PriceWithSlider({
+  label, value, onChange, maxRef,
+}: {
+  label: string;
+  value: number | null;
+  onChange: (v: number | null) => void;
+  maxRef: number;
+}) {
+  const max = Math.max(20, maxRef * 2);
+  return (
+    <div className="space-y-1.5">
+      <Label className="text-xs">{label}</Label>
+      <div className="flex items-center gap-3">
+        <div className="w-24">
+          <NumberField value={value} onChange={onChange} step="0.25" min={0} placeholder="0.00" />
+        </div>
+        <Slider
+          value={[value ?? 0]}
+          min={0}
+          max={max}
+          step={0.25}
+          onValueChange={([v]) => onChange(v)}
+          className="flex-1"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/client/numbers/MSRPCard.tsx
+++ b/src/components/client/numbers/MSRPCard.tsx
@@ -1,0 +1,62 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Slider } from '@/components/ui/slider';
+import { Label } from '@/components/ui/label';
+import { unitLabel } from '@/lib/unitEconomics';
+import type { ClientUnitEconomicsInputs } from '@/lib/clientUnitEconomics';
+
+interface Props {
+  inputs: ClientUnitEconomicsInputs;
+  suggestedRetailPrice: number;
+  totalCost: number;
+  onTargetMarginChange: (pct: number) => void;
+  onApply: () => void;
+}
+
+export function MSRPCard({ inputs, suggestedRetailPrice, totalCost, onTargetMarginChange, onApply }: Props) {
+  const fmt = (n: number) => `$${n.toFixed(2)}`;
+  const valid = totalCost > 0 && suggestedRetailPrice > 0 && Number.isFinite(suggestedRetailPrice);
+
+  return (
+    <Card className="border-[hsl(207_67%_33%)] bg-[hsl(207_67%_33%/0.04)]">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          Suggested MSRP — per {unitLabel(inputs.displayUnit)}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex items-baseline justify-between gap-3">
+          <span className="text-3xl font-bold tabular-nums text-[hsl(207_67%_33%)]">
+            {valid ? fmt(suggestedRetailPrice) : '—'}
+          </span>
+          {valid && (
+            <button
+              type="button"
+              onClick={onApply}
+              className="text-xs text-[hsl(207_67%_33%)] hover:underline"
+            >
+              Use this as my retail price
+            </button>
+          )}
+        </div>
+
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-between text-xs text-muted-foreground">
+            <Label>Target retail margin</Label>
+            <span className="tabular-nums font-medium">{inputs.targetRetailMarginPct}%</span>
+          </div>
+          <Slider
+            value={[inputs.targetRetailMarginPct]}
+            min={30}
+            max={70}
+            step={1}
+            onValueChange={([v]) => onTargetMarginChange(v)}
+          />
+        </div>
+
+        <p className="text-[11px] text-muted-foreground">
+          Starting point only — adjust based on your market, competition, and positioning.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/layout/ClientLayout.tsx
+++ b/src/components/layout/ClientLayout.tsx
@@ -14,6 +14,7 @@ import {
   X,
   ShoppingBag,
   Eye,
+  Calculator,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import hiIcon from '@/assets/home-island-icon.png';
@@ -23,18 +24,25 @@ interface ClientLayoutProps {
 }
 
 // Client-only navigation items
-const navItems = [
+const baseNavItems = [
   { to: '/portal', label: 'Home', icon: Home, end: true },
   { to: '/portal/new-order', label: 'New Order', icon: PlusCircle },
   { to: '/portal/orders', label: 'My Orders', icon: ClipboardList },
   { to: '/portal/products', label: 'My Products', icon: ShoppingBag },
-  { to: '/portal/account', label: 'Account', icon: User },
 ];
+const numbersNavItem = { to: '/client/numbers', label: 'My Numbers', icon: Calculator };
+const accountNavItem = { to: '/portal/account', label: 'Account', icon: User };
 
 export function ClientLayout({ children }: ClientLayoutProps) {
   const { authUser, signOut } = useAuth();
   const navigate = useNavigate();
   const { isPreviewMode, previewAccountName, previewAccountId, exitPreview } = usePreview();
+  const showNumbers = !!authUser?.canPlaceOrders && !authUser?.canBookRoaster;
+  const navItems = [
+    ...baseNavItems,
+    ...(showNumbers ? [numbersNavItem] : []),
+    accountNavItem,
+  ];
   const [sidebarOpen, setSidebarOpen] = React.useState(false);
   const [accountSheetOpen, setAccountSheetOpen] = React.useState(false);
 

--- a/src/hooks/useClientUnitEconomicsScenarios.ts
+++ b/src/hooks/useClientUnitEconomicsScenarios.ts
@@ -1,0 +1,87 @@
+import { useEffect, useRef, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import {
+  DEFAULT_CLIENT_INPUTS,
+  type ClientUnitEconomicsInputs,
+} from '@/lib/clientUnitEconomics';
+
+export interface ClientScenarioRow {
+  id: string;
+  account_id: string;
+  name: string;
+  inputs: ClientUnitEconomicsInputs;
+  created_at: string;
+  updated_at: string;
+}
+
+export function useClientScenarios(accountId: string | null) {
+  return useQuery({
+    queryKey: ['client-ue-scenarios', accountId],
+    enabled: !!accountId,
+    queryFn: async (): Promise<ClientScenarioRow[]> => {
+      if (!accountId) return [];
+      const { data, error } = await supabase
+        .from('client_unit_economics_scenarios')
+        .select('id, account_id, name, inputs, created_at, updated_at')
+        .eq('account_id', accountId)
+        .order('updated_at', { ascending: false });
+      if (error) throw error;
+      return (data ?? []).map(r => ({
+        ...r,
+        inputs: { ...DEFAULT_CLIENT_INPUTS, ...((r.inputs as Record<string, unknown>) || {}) } as ClientUnitEconomicsInputs,
+      })) as ClientScenarioRow[];
+    },
+  });
+}
+
+export function useClientScenarioAutoSave(
+  scenarioId: string | null,
+  inputs: ClientUnitEconomicsInputs,
+  enabled: boolean,
+) {
+  const [status, setStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
+  const lastSerialised = useRef<string>('');
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const qc = useQueryClient();
+
+  useEffect(() => {
+    if (!enabled || !scenarioId) return;
+    const serialised = JSON.stringify(inputs);
+    if (lastSerialised.current === '') {
+      lastSerialised.current = serialised;
+      return;
+    }
+    if (lastSerialised.current === serialised) return;
+
+    if (timer.current) clearTimeout(timer.current);
+    setStatus('saving');
+    timer.current = setTimeout(async () => {
+      const { error } = await supabase
+        .from('client_unit_economics_scenarios')
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .update({ inputs: inputs as any })
+        .eq('id', scenarioId);
+      if (error) {
+        setStatus('error');
+        console.error('[client-ue-autosave] failed', error);
+      } else {
+        lastSerialised.current = serialised;
+        setStatus('saved');
+        qc.invalidateQueries({ queryKey: ['client-ue-scenarios'] });
+        setTimeout(() => setStatus(s => (s === 'saved' ? 'idle' : s)), 1800);
+      }
+    }, 1500);
+
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, [scenarioId, inputs, enabled, qc]);
+
+  useEffect(() => {
+    lastSerialised.current = '';
+    setStatus('idle');
+  }, [scenarioId]);
+
+  return status;
+}

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1445,6 +1445,50 @@ export type Database = {
         }
         Relationships: []
       }
+      client_unit_economics_scenarios: {
+        Row: {
+          account_id: string
+          created_at: string
+          created_by: string
+          id: string
+          inputs: Json
+          name: string
+          notes: string | null
+          outputs: Json | null
+          updated_at: string
+        }
+        Insert: {
+          account_id: string
+          created_at?: string
+          created_by: string
+          id?: string
+          inputs?: Json
+          name?: string
+          notes?: string | null
+          outputs?: Json | null
+          updated_at?: string
+        }
+        Update: {
+          account_id?: string
+          created_at?: string
+          created_by?: string
+          id?: string
+          inputs?: Json
+          name?: string
+          notes?: string | null
+          outputs?: Json | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "client_unit_economics_scenarios_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       coroast_unit_economics_scenarios: {
         Row: {
           account_id: string | null

--- a/src/lib/clientUnitEconomics.ts
+++ b/src/lib/clientUnitEconomics.ts
@@ -1,0 +1,138 @@
+/**
+ * Client (wholesale buyer) Unit Economics — wraps the shared engine in src/lib/unitEconomics.ts.
+ *
+ * Manufacturing clients buy finished roasted coffee from us. Their per-bag cost from Home Island
+ * replaces the green+roasting cost stack used by the co-roasting calculator. We translate the
+ * client-shaped inputs into UnitEconomicsInputs and reuse the existing math.
+ */
+import {
+  DEFAULT_INPUTS,
+  costPerUnit,
+  marginAt,
+  monthlyView,
+  type UnitEconomicsInputs,
+  type DisplayUnit,
+  type CostBreakdown,
+  type MarginRow,
+  type MonthlyView,
+} from '@/lib/unitEconomics';
+
+export type PaceMode = 'CURRENT' | 'SEASONAL';
+
+export interface ClientUnitEconomicsInputs {
+  displayUnit: DisplayUnit;       // BAG | KG | LB
+  bagSizeG: number;
+
+  // Which JIM product this scenario models (optional but recommended)
+  productId: string | null;
+  productName: string | null;
+
+  // Pace / volume
+  paceMode: PaceMode;
+  monthlyKg: number | null;
+
+  // Per-bag cost paid TO Home Island (pre-fills from order history)
+  costPerBagFromUs: number | null;
+
+  // Additional per-bag packaging the client adds (their own labels, inserts, etc.)
+  extraPackagingPerBag: number | null;
+
+  // Labour
+  includeLabour: boolean;
+  labourHoursPerBatch: number;
+  labourRatePerHr: number;
+  batchSizeKg: number;
+
+  // Overhead
+  overheadMonthly: number | null;
+
+  // Pricing
+  wholesalePrice: number | null;
+  retailPrice: number | null;
+  wholesalePct: number;
+
+  // MSRP suggestion
+  targetRetailMarginPct: number;
+}
+
+export const DEFAULT_CLIENT_INPUTS: ClientUnitEconomicsInputs = {
+  displayUnit: 'BAG',
+  bagSizeG: 340,
+  productId: null,
+  productName: null,
+  paceMode: 'CURRENT',
+  monthlyKg: null,
+  costPerBagFromUs: null,
+  extraPackagingPerBag: null,
+  includeLabour: false,
+  labourHoursPerBatch: 0,
+  labourRatePerHr: 25,
+  batchSizeKg: 40,
+  overheadMonthly: null,
+  wholesalePrice: null,
+  retailPrice: null,
+  wholesalePct: 50,
+  targetRetailMarginPct: 50,
+};
+
+/**
+ * Translate client-shaped inputs into the shared UnitEconomicsInputs shape so we can reuse
+ * the existing math engine without modification.
+ *
+ * Strategy: stash the client's per-bag cost from us into the "green" slot, converting it
+ * to a $/kg value that — when multiplied by (bagSizeG/1000) and a zero-loss factor —
+ * reproduces the original per-bag cost exactly.
+ */
+export function toEngineInputs(c: ClientUnitEconomicsInputs): UnitEconomicsInputs {
+  const bagG = Math.max(1, c.bagSizeG || 340);
+  const costPerBag = c.costPerBagFromUs ?? 0;
+  // costPerKg such that (bagG / 1000) * costPerKg == costPerBag
+  const costPerKgRoasted = costPerBag * (1000 / bagG);
+
+  return {
+    ...DEFAULT_INPUTS,
+    displayUnit: c.displayUnit,
+    bagSizeG: bagG,
+    greenPriceUnit: 'KG',
+    greenPrice: c.costPerBagFromUs == null ? null : costPerKgRoasted,
+    yieldLossPct: 0,
+    packagingPerBag: c.extraPackagingPerBag,
+    tier: null,
+    forecastOverage: false,
+    includeLabour: c.includeLabour,
+    labourHoursPerBatch: c.labourHoursPerBatch,
+    labourRatePerHr: c.labourRatePerHr,
+    batchSizeKg: c.batchSizeKg,
+    overheadMonthly: c.overheadMonthly,
+    monthlyKg: c.monthlyKg,
+    wholesalePrice: c.wholesalePrice,
+    retailPrice: c.retailPrice,
+    wholesalePct: c.wholesalePct,
+  };
+}
+
+export interface ClientCalcResult {
+  engineInputs: UnitEconomicsInputs;
+  perUnit: CostBreakdown;
+  wholesaleMargin: MarginRow;
+  retailMargin: MarginRow;
+  monthly: MonthlyView;
+  suggestedRetailPrice: number;
+}
+
+export function calculateClientUnitEconomics(c: ClientUnitEconomicsInputs): ClientCalcResult {
+  const engineInputs = toEngineInputs(c);
+  const perUnit = costPerUnit(engineInputs);
+  const wholesaleMargin = marginAt(c.wholesalePrice, perUnit.total);
+  const retailMargin = marginAt(c.retailPrice, perUnit.total);
+  const monthly = monthlyView(engineInputs, perUnit);
+
+  // Suggested MSRP: price such that (price - cost) / price = targetMargin%
+  // → price = cost / (1 - targetMargin)
+  const tgt = Math.min(0.99, Math.max(0, (c.targetRetailMarginPct || 0) / 100));
+  const suggestedRetailPrice = tgt < 1
+    ? perUnit.total / (1 - tgt || 1)
+    : perUnit.total * 2;
+
+  return { engineInputs, perUnit, wholesaleMargin, retailMargin, monthly, suggestedRetailPrice };
+}

--- a/src/lib/clientUnitEconomicsPrefill.ts
+++ b/src/lib/clientUnitEconomicsPrefill.ts
@@ -1,0 +1,145 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+
+export interface ClientProductPrefill {
+  productId: string;
+  productName: string;
+  bagSizeG: number;
+  bagsShipped90d: number;
+  kgShipped90d: number;
+  avgPricePerBag: number;
+}
+
+export interface ClientPrefills {
+  /** Trailing 3-month average kg/month shipped to this account. */
+  currentPaceKgPerMonth: number;
+  /** Same quarter last year (kg averaged across same calendar 90-day window 1y ago), if available. */
+  seasonalPaceKgPerMonth: number | null;
+  /** True when seasonal data should be the default pre-fill. */
+  preferSeasonal: boolean;
+  /** Per-product summary, sorted by most-shipped first. */
+  products: ClientProductPrefill[];
+  /** Top product id (largest kg shipped in last 90 days), if any. */
+  defaultProductId: string | null;
+}
+
+interface OrderRow {
+  id: string;
+  account_id: string | null;
+  status: string;
+  created_at: string;
+}
+
+interface LineRow {
+  order_id: string;
+  product_id: string;
+  shipped_quantity: number | null;
+  quantity_units: number;
+  unit_price_locked: number;
+  product: { product_name: string | null; bag_size_g: number | null } | null;
+}
+
+function daysBack(days: number): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - days);
+  return d.toISOString();
+}
+
+function isCurrentlyInSeasonalShoulder(): boolean {
+  // Café shoulder seasons: within 30 days of Mar/Apr or Sep/Oct transitions.
+  const now = new Date();
+  const month = now.getUTCMonth(); // 0-indexed
+  // Treat Feb-Apr and Aug-Oct as shoulder windows.
+  return month === 1 || month === 2 || month === 3 || month === 7 || month === 8 || month === 9;
+}
+
+async function fetchShippedForWindow(accountId: string, startISO: string, endISO: string) {
+  const { data: orders, error: oErr } = await supabase
+    .from('orders')
+    .select('id, account_id, status, created_at')
+    .eq('account_id', accountId)
+    .eq('status', 'SHIPPED')
+    .gte('created_at', startISO)
+    .lte('created_at', endISO);
+  if (oErr) throw oErr;
+  const orderIds = (orders ?? []).map((o: OrderRow) => o.id);
+  if (orderIds.length === 0) return [] as LineRow[];
+
+  const { data: lines, error: lErr } = await supabase
+    .from('order_line_items')
+    .select('order_id, product_id, shipped_quantity, quantity_units, unit_price_locked, product:products(product_name, bag_size_g)')
+    .in('order_id', orderIds);
+  if (lErr) throw lErr;
+  return (lines ?? []) as unknown as LineRow[];
+}
+
+export function useClientPrefills(accountId: string | null) {
+  return useQuery({
+    queryKey: ['client-ue-prefills', accountId],
+    enabled: !!accountId,
+    queryFn: async (): Promise<ClientPrefills> => {
+      if (!accountId) {
+        return { currentPaceKgPerMonth: 0, seasonalPaceKgPerMonth: null, preferSeasonal: false, products: [], defaultProductId: null };
+      }
+
+      const now = new Date();
+      const start90 = daysBack(90);
+      const yearAgoEnd = new Date(now); yearAgoEnd.setUTCFullYear(yearAgoEnd.getUTCFullYear() - 1);
+      const yearAgoStart = new Date(yearAgoEnd); yearAgoStart.setUTCDate(yearAgoStart.getUTCDate() - 90);
+
+      const [recent, yearAgo] = await Promise.all([
+        fetchShippedForWindow(accountId, start90, now.toISOString()),
+        fetchShippedForWindow(accountId, yearAgoStart.toISOString(), yearAgoEnd.toISOString()),
+      ]);
+
+      const productAgg = new Map<string, { name: string; bagSizeG: number; bags: number; kg: number; revenue: number }>();
+      let totalKg90 = 0;
+      for (const l of recent) {
+        const qty = l.shipped_quantity ?? l.quantity_units ?? 0;
+        if (qty <= 0) continue;
+        const bagG = l.product?.bag_size_g ?? 340;
+        const kg = (qty * bagG) / 1000;
+        totalKg90 += kg;
+        const cur = productAgg.get(l.product_id) ?? {
+          name: l.product?.product_name ?? 'Product',
+          bagSizeG: bagG,
+          bags: 0, kg: 0, revenue: 0,
+        };
+        cur.bags += qty;
+        cur.kg += kg;
+        cur.revenue += qty * (l.unit_price_locked ?? 0);
+        productAgg.set(l.product_id, cur);
+      }
+
+      let totalKgYearAgo = 0;
+      for (const l of yearAgo) {
+        const qty = l.shipped_quantity ?? l.quantity_units ?? 0;
+        if (qty <= 0) continue;
+        const bagG = l.product?.bag_size_g ?? 340;
+        totalKgYearAgo += (qty * bagG) / 1000;
+      }
+
+      const products: ClientProductPrefill[] = Array.from(productAgg.entries())
+        .map(([productId, v]) => ({
+          productId,
+          productName: v.name,
+          bagSizeG: v.bagSizeG,
+          bagsShipped90d: v.bags,
+          kgShipped90d: v.kg,
+          avgPricePerBag: v.bags > 0 ? v.revenue / v.bags : 0,
+        }))
+        .sort((a, b) => b.kgShipped90d - a.kgShipped90d);
+
+      const seasonalKgPerMonth = yearAgo.length > 0 ? totalKgYearAgo / 3 : null;
+      const preferSeasonal = seasonalKgPerMonth != null && isCurrentlyInSeasonalShoulder();
+
+      return {
+        currentPaceKgPerMonth: totalKg90 / 3,
+        seasonalPaceKgPerMonth: seasonalKgPerMonth,
+        preferSeasonal,
+        products,
+        defaultProductId: products[0]?.productId ?? null,
+      };
+    },
+  });
+}

--- a/src/pages/client/MyNumbers.tsx
+++ b/src/pages/client/MyNumbers.tsx
@@ -1,0 +1,449 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useReactToPrint } from 'react-to-print';
+import { useAuth } from '@/contexts/AuthContext';
+import { usePreview } from '@/contexts/PreviewContext';
+import { supabase } from '@/integrations/supabase/client';
+import { useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import {
+  AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+  AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent } from '@/components/ui/card';
+import { Plus, Copy, Pencil, Trash2, Printer, Check, Loader2 } from 'lucide-react';
+import { OutputsPanel } from '@/components/unit-economics/OutputsPanel';
+import { CostBreakdownChart } from '@/components/unit-economics/CostBreakdownChart';
+import { ClientInputsPanel } from '@/components/client/numbers/ClientInputsPanel';
+import { MSRPCard } from '@/components/client/numbers/MSRPCard';
+import {
+  DEFAULT_CLIENT_INPUTS, calculateClientUnitEconomics,
+  type ClientUnitEconomicsInputs,
+} from '@/lib/clientUnitEconomics';
+import { unitLabel, unitLabelPlural } from '@/lib/unitEconomics';
+import { formatCurrency } from '@/lib/currency';
+import {
+  useClientScenarios, useClientScenarioAutoSave, type ClientScenarioRow,
+} from '@/hooks/useClientUnitEconomicsScenarios';
+import { useClientPrefills, type ClientPrefills } from '@/lib/clientUnitEconomicsPrefill';
+
+function seedFromPrefills(base: ClientUnitEconomicsInputs, prefills: ClientPrefills | undefined): ClientUnitEconomicsInputs {
+  if (!prefills) return base;
+  const topProduct = prefills.products[0];
+  const pace = prefills.preferSeasonal && prefills.seasonalPaceKgPerMonth != null
+    ? prefills.seasonalPaceKgPerMonth
+    : prefills.currentPaceKgPerMonth;
+  return {
+    ...base,
+    paceMode: prefills.preferSeasonal ? 'SEASONAL' : 'CURRENT',
+    monthlyKg: pace > 0 ? Number(pace.toFixed(2)) : base.monthlyKg,
+    productId: topProduct?.productId ?? null,
+    productName: topProduct?.productName ?? null,
+    bagSizeG: topProduct?.bagSizeG ?? base.bagSizeG,
+    costPerBagFromUs: topProduct ? Number(topProduct.avgPricePerBag.toFixed(2)) : null,
+  };
+}
+
+export default function ClientMyNumbers() {
+  const { authUser } = useAuth();
+  const { previewAccountId } = usePreview();
+  const accountId = previewAccountId ?? authUser?.accountId ?? null;
+  const [searchParams, setSearchParams] = useSearchParams();
+  const qc = useQueryClient();
+
+  const { data: scenarios = [], isLoading: loadingScenarios } = useClientScenarios(accountId);
+  const { data: prefills } = useClientPrefills(accountId);
+
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [inputs, setInputs] = useState<ClientUnitEconomicsInputs>(DEFAULT_CLIENT_INPUTS);
+  const [accountName, setAccountName] = useState<string>('');
+  const [renameOpen, setRenameOpen] = useState(false);
+  const [renameValue, setRenameValue] = useState('');
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const baselineLoaded = useRef(false);
+  const autoCreated = useRef(false);
+
+  useEffect(() => {
+    if (!accountId) return;
+    supabase.from('accounts').select('account_name').eq('id', accountId).maybeSingle()
+      .then(({ data }) => setAccountName(data?.account_name ?? ''));
+  }, [accountId]);
+
+  // Pick initial scenario from URL query, else newest, else create one
+  useEffect(() => {
+    if (!accountId || loadingScenarios) return;
+    const fromUrl = searchParams.get('scenario');
+    if (fromUrl && scenarios.some(s => s.id === fromUrl)) {
+      setActiveId(fromUrl);
+      return;
+    }
+    if (scenarios.length > 0) {
+      setActiveId(scenarios[0].id);
+      return;
+    }
+    if (autoCreated.current) return;
+    autoCreated.current = true;
+    (async () => {
+      const seed = seedFromPrefills(DEFAULT_CLIENT_INPUTS, prefills);
+      const { data, error } = await supabase
+        .from('client_unit_economics_scenarios')
+        .insert({
+          account_id: accountId,
+          name: 'My first scenario',
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          inputs: seed as any,
+          created_by: authUser?.id ?? '',
+        })
+        .select()
+        .single();
+      if (!error && data) {
+        qc.invalidateQueries({ queryKey: ['client-ue-scenarios'] });
+        setActiveId(data.id);
+      }
+    })();
+  }, [accountId, loadingScenarios, scenarios, searchParams, prefills, authUser, qc]);
+
+  // Load active scenario inputs
+  useEffect(() => {
+    if (!activeId) return;
+    const s = scenarios.find(x => x.id === activeId);
+    if (s) {
+      setInputs({ ...DEFAULT_CLIENT_INPUTS, ...s.inputs });
+      baselineLoaded.current = true;
+      if (searchParams.get('scenario') !== activeId) {
+        const next = new URLSearchParams(searchParams);
+        next.set('scenario', activeId);
+        setSearchParams(next, { replace: true });
+      }
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeId, scenarios]);
+
+  const saveStatus = useClientScenarioAutoSave(activeId, inputs, baselineLoaded.current);
+
+  const activeScenario = useMemo<ClientScenarioRow | undefined>(
+    () => scenarios.find(s => s.id === activeId),
+    [scenarios, activeId],
+  );
+
+  const calc = useMemo(() => calculateClientUnitEconomics(inputs), [inputs]);
+
+  // ----- Scenario actions -----
+
+  const newScenario = async () => {
+    if (!accountId) return;
+    const seed = seedFromPrefills(DEFAULT_CLIENT_INPUTS, prefills);
+    const { data, error } = await supabase
+      .from('client_unit_economics_scenarios')
+      .insert({
+        account_id: accountId,
+        name: `Scenario ${scenarios.length + 1}`,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        inputs: seed as any,
+        created_by: authUser?.id ?? '',
+      })
+      .select().single();
+    if (error) { toast.error('Could not create scenario'); return; }
+    qc.invalidateQueries({ queryKey: ['client-ue-scenarios'] });
+    setActiveId(data.id);
+    toast.success('New scenario created');
+  };
+
+  const duplicateScenario = async () => {
+    if (!activeScenario || !accountId) return;
+    const { data, error } = await supabase
+      .from('client_unit_economics_scenarios')
+      .insert({
+        account_id: accountId,
+        name: `${activeScenario.name} (copy)`,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        inputs: inputs as any,
+        created_by: authUser?.id ?? '',
+      })
+      .select().single();
+    if (error) { toast.error('Could not duplicate'); return; }
+    qc.invalidateQueries({ queryKey: ['client-ue-scenarios'] });
+    setActiveId(data.id);
+    toast.success('Scenario duplicated');
+  };
+
+  const renameScenario = async () => {
+    if (!activeScenario || !renameValue.trim()) return;
+    const { error } = await supabase
+      .from('client_unit_economics_scenarios')
+      .update({ name: renameValue.trim() })
+      .eq('id', activeScenario.id);
+    if (error) { toast.error('Could not rename'); return; }
+    qc.invalidateQueries({ queryKey: ['client-ue-scenarios'] });
+    setRenameOpen(false);
+    toast.success('Renamed');
+  };
+
+  const deleteScenario = async () => {
+    if (!activeScenario) return;
+    const { error } = await supabase
+      .from('client_unit_economics_scenarios')
+      .delete().eq('id', activeScenario.id);
+    if (error) { toast.error('Could not delete'); return; }
+    qc.invalidateQueries({ queryKey: ['client-ue-scenarios'] });
+    setActiveId(null);
+    setDeleteOpen(false);
+    toast.success('Scenario deleted');
+  };
+
+  // ----- Print -----
+
+  const printRef = useRef<HTMLDivElement>(null);
+  const handlePrint = useReactToPrint({
+    contentRef: printRef,
+    documentTitle: `${accountName || 'My Numbers'} — ${activeScenario?.name ?? 'Scenario'}`,
+  });
+
+  if (!accountId) {
+    return (
+      <div className="p-6">
+        <Card><CardContent className="p-6 text-sm text-muted-foreground">
+          You need to be linked to an account to use My Numbers.
+        </CardContent></Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 sm:p-6 space-y-4 max-w-7xl mx-auto">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-end justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold">My Numbers</h1>
+          <p className="text-sm text-muted-foreground">
+            Model your unit economics on the coffee you buy from Home Island.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Select value={activeId ?? ''} onValueChange={setActiveId}>
+            <SelectTrigger className="w-[220px]">
+              <SelectValue placeholder="Select scenario" />
+            </SelectTrigger>
+            <SelectContent>
+              {scenarios.map(s => (
+                <SelectItem key={s.id} value={s.id}>{s.name}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button variant="outline" size="sm" onClick={newScenario}>
+            <Plus className="h-4 w-4 mr-1" /> New
+          </Button>
+          <Button variant="outline" size="sm" onClick={duplicateScenario} disabled={!activeScenario}>
+            <Copy className="h-4 w-4 mr-1" /> Duplicate
+          </Button>
+          <Button
+            variant="outline" size="sm"
+            onClick={() => { setRenameValue(activeScenario?.name ?? ''); setRenameOpen(true); }}
+            disabled={!activeScenario}
+          >
+            <Pencil className="h-4 w-4 mr-1" /> Rename
+          </Button>
+          <Button variant="outline" size="sm" onClick={() => setDeleteOpen(true)} disabled={!activeScenario}>
+            <Trash2 className="h-4 w-4 mr-1" /> Delete
+          </Button>
+          <Button
+            size="sm"
+            onClick={() => handlePrint()}
+            style={{ backgroundColor: '#1B5E8C' }}
+            className="text-white hover:opacity-90"
+          >
+            <Printer className="h-4 w-4 mr-1" /> Export PDF / Print
+          </Button>
+        </div>
+      </div>
+
+      {/* Save status */}
+      <div className="text-xs text-muted-foreground h-4">
+        {saveStatus === 'saving' && (
+          <span className="inline-flex items-center gap-1"><Loader2 className="h-3 w-3 animate-spin" /> Saving…</span>
+        )}
+        {saveStatus === 'saved' && (
+          <span className="inline-flex items-center gap-1 text-success"><Check className="h-3 w-3" /> Saved</span>
+        )}
+        {saveStatus === 'error' && <span className="text-destructive">Couldn't save — try again</span>}
+      </div>
+
+      {/* Two columns */}
+      <div className="grid grid-cols-1 lg:grid-cols-5 gap-4">
+        <div className="lg:col-span-2">
+          <ClientInputsPanel inputs={inputs} onChange={setInputs} prefills={prefills} />
+        </div>
+        <div className="lg:col-span-3 space-y-4">
+          <MSRPCard
+            inputs={inputs}
+            suggestedRetailPrice={calc.suggestedRetailPrice}
+            totalCost={calc.perUnit.total}
+            onTargetMarginChange={(v) => setInputs({ ...inputs, targetRetailMarginPct: v })}
+            onApply={() => setInputs({ ...inputs, retailPrice: Number(calc.suggestedRetailPrice.toFixed(2)) })}
+          />
+          <OutputsPanel
+            inputs={calc.engineInputs}
+            onChannelSplitChange={(v) => setInputs({ ...inputs, wholesalePct: v })}
+          />
+        </div>
+      </div>
+
+      {/* Hidden print container */}
+      <div style={{ display: 'none' }}>
+        <div ref={printRef}>
+          <ClientPrintLayout
+            accountName={accountName}
+            scenarioName={activeScenario?.name ?? ''}
+            inputs={inputs}
+          />
+        </div>
+      </div>
+
+      {/* Rename dialog */}
+      <AlertDialog open={renameOpen} onOpenChange={setRenameOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Rename scenario</AlertDialogTitle>
+          </AlertDialogHeader>
+          <Input value={renameValue} onChange={(e) => setRenameValue(e.target.value)} autoFocus />
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={renameScenario}>Save</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Delete confirm */}
+      <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this scenario?</AlertDialogTitle>
+            <AlertDialogDescription>
+              "{activeScenario?.name}" will be permanently removed. This can't be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={deleteScenario} className="bg-destructive hover:bg-destructive/90">
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+function ClientPrintLayout({
+  accountName, scenarioName, inputs,
+}: {
+  accountName: string;
+  scenarioName: string;
+  inputs: ClientUnitEconomicsInputs;
+}) {
+  const calc = calculateClientUnitEconomics(inputs);
+  const today = new Date().toLocaleDateString('en-CA', { year: 'numeric', month: 'long', day: 'numeric' });
+
+  const fmt = (n: number) => formatCurrency(n);
+  const fmtBig = (n: number) => `$${n.toLocaleString('en-CA', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+  const Row = ({ k, v }: { k: string; v: string }) => (
+    <div className="flex justify-between border-b border-dashed py-1 text-xs">
+      <span className="text-muted-foreground">{k}</span>
+      <span className="font-medium tabular-nums">{v}</span>
+    </div>
+  );
+
+  return (
+    <div className="p-8 bg-background text-foreground" style={{ width: '8.5in' }}>
+      <header className="border-b pb-3 mb-4">
+        <h1 className="text-2xl font-bold">{accountName || 'My Numbers'}</h1>
+        <p className="text-sm text-muted-foreground">
+          {scenarioName} · Generated {today}
+        </p>
+      </header>
+
+      <section className="mb-4">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-2">Assumptions</h2>
+        <div className="grid grid-cols-2 gap-x-6">
+          <div>
+            <Row k="Display unit" v={inputs.displayUnit === 'BAG' ? `Bag (${inputs.bagSizeG}g)` : inputs.displayUnit} />
+            <Row k="Product" v={inputs.productName ?? '—'} />
+            <Row k="Cost per bag from us" v={inputs.costPerBagFromUs != null ? fmt(inputs.costPerBagFromUs) : '—'} />
+            <Row k="Extra packaging /bag" v={inputs.extraPackagingPerBag != null ? fmt(inputs.extraPackagingPerBag) : '—'} />
+            <Row k="Pace assumption" v={inputs.paceMode === 'SEASONAL' ? 'Same quarter last year' : 'Last 3 months'} />
+          </div>
+          <div>
+            <Row k="Labour" v={inputs.includeLabour ? `${inputs.labourHoursPerBatch}h × $${inputs.labourRatePerHr}/h` : 'Excluded'} />
+            <Row k="Monthly overhead" v={inputs.overheadMonthly != null ? fmtBig(inputs.overheadMonthly) : '—'} />
+            <Row k="Monthly volume" v={inputs.monthlyKg != null ? `${inputs.monthlyKg} kg` : '—'} />
+            <Row k="Wholesale price" v={inputs.wholesalePrice != null ? fmt(inputs.wholesalePrice) : '—'} />
+            <Row k="Retail price" v={inputs.retailPrice != null ? fmt(inputs.retailPrice) : '—'} />
+          </div>
+        </div>
+      </section>
+
+      <section className="mb-4">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-2">Cost breakdown</h2>
+        <CostBreakdownChart inputs={calc.engineInputs} perUnit={calc.perUnit} />
+      </section>
+
+      <section className="mb-4">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+          Suggested MSRP
+        </h2>
+        <div className="rounded border p-3 flex items-baseline justify-between">
+          <span className="text-2xl font-bold tabular-nums">
+            {calc.suggestedRetailPrice > 0 && Number.isFinite(calc.suggestedRetailPrice) ? fmt(calc.suggestedRetailPrice) : '—'}
+          </span>
+          <span className="text-xs text-muted-foreground">
+            at {inputs.targetRetailMarginPct}% target retail margin
+          </span>
+        </div>
+      </section>
+
+      <section className="mb-4">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+          Per-{unitLabel(inputs.displayUnit)} results
+        </h2>
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="border-b text-muted-foreground">
+              <th className="text-left py-1 font-medium">Metric</th>
+              <th className="text-right py-1 font-medium">Wholesale</th>
+              <th className="text-right py-1 font-medium">Retail</th>
+            </tr>
+          </thead>
+          <tbody className="tabular-nums">
+            <tr className="border-b"><td className="py-1">Selling price</td><td className="text-right">{fmt(calc.wholesaleMargin.price)}</td><td className="text-right">{fmt(calc.retailMargin.price)}</td></tr>
+            <tr className="border-b"><td className="py-1">Cost per {unitLabel(inputs.displayUnit)}</td><td className="text-right">{fmt(calc.perUnit.total)}</td><td className="text-right">{fmt(calc.perUnit.total)}</td></tr>
+            <tr className="border-b"><td className="py-1">Gross margin</td><td className="text-right">{fmt(calc.wholesaleMargin.margin)}</td><td className="text-right">{fmt(calc.retailMargin.margin)}</td></tr>
+            <tr><td className="py-1">Margin %</td><td className="text-right">{calc.wholesaleMargin.marginPct.toFixed(1)}%</td><td className="text-right">{calc.retailMargin.marginPct.toFixed(1)}%</td></tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section className="mb-4">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-2">Monthly view</h2>
+        <div className="grid grid-cols-3 gap-3 text-xs">
+          <div className="border rounded p-2"><p className="text-muted-foreground">Production cost</p><p className="font-semibold tabular-nums">{fmtBig(calc.monthly.productionCost)}</p></div>
+          <div className="border rounded p-2"><p className="text-muted-foreground">Revenue ({inputs.wholesalePct}/{100 - inputs.wholesalePct})</p><p className="font-semibold tabular-nums">{fmtBig(calc.monthly.revenue)}</p></div>
+          <div className="border rounded p-2"><p className="text-muted-foreground">Gross profit</p><p className="font-semibold tabular-nums">{fmtBig(calc.monthly.grossProfit)}</p></div>
+        </div>
+        {calc.monthly.breakEvenUnits != null && calc.monthly.breakEvenUnits > 0 && (
+          <p className="mt-2 text-xs">
+            Break-even: <span className="font-semibold">{Math.ceil(calc.monthly.breakEvenUnits).toLocaleString('en-CA')}</span>{' '}
+            {unitLabelPlural(inputs.displayUnit)}/month at this price mix.
+          </p>
+        )}
+      </section>
+
+      <footer className="border-t pt-2 mt-4 text-[10px] text-muted-foreground text-center">
+        Prepared with Home Island Coffee Partners — homeislandcoffee.com
+      </footer>
+    </div>
+  );
+}

--- a/src/pages/client/Portal.tsx
+++ b/src/pages/client/Portal.tsx
@@ -8,7 +8,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { usePreview } from '@/contexts/PreviewContext';
 import { format } from 'date-fns';
 import { parseDateOnly } from '@/lib/dateOnly';
-import { PlusCircle, Package, Truck, Clock, CheckCircle2 } from 'lucide-react';
+import { PlusCircle, Package, Truck, Clock, CheckCircle2, Calculator } from 'lucide-react';
 import { LocationCodeDisplay } from '@/components/orders/LocationSelect';
 
 interface Order {
@@ -27,6 +27,7 @@ export default function Portal() {
   const navigate = useNavigate();
   const { authUser } = useAuth();
   const { previewAccountId } = usePreview();
+  const showNumbers = !!authUser?.canPlaceOrders && !authUser?.canBookRoaster;
 
   const { data: orders, isLoading } = useQuery({
     queryKey: ['client-portal-orders', previewAccountId],
@@ -81,6 +82,33 @@ export default function Portal() {
       </div>
 
       <div className="grid gap-6">
+        {showNumbers && (
+          <Card
+            className="cursor-pointer transition-colors hover:bg-muted/50"
+            onClick={() => navigate('/client/numbers')}
+          >
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Calculator className="h-5 w-5" style={{ color: '#1B5E8C' }} />
+                My Numbers
+              </CardTitle>
+              <CardDescription>
+                Model your unit economics on the coffee you buy from us. We'll pre-fill your latest
+                volume and cost — adjust pricing to see margins, break-even, and a suggested MSRP.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button
+                onClick={(e) => { e.stopPropagation(); navigate('/client/numbers'); }}
+                style={{ backgroundColor: '#1B5E8C' }}
+                className="text-white hover:opacity-90"
+              >
+                Open My Numbers
+              </Button>
+            </CardContent>
+          </Card>
+        )}
+
         {/* Open Orders */}
         <Card>
           <CardHeader>


### PR DESCRIPTION
## Summary

- Adds a second entry point to the unit-economics calculator for **manufacturing/wholesale clients** at `/client/numbers` (and `/portal/numbers` alias).
- Reuses the existing `src/lib/unitEconomics.ts` math engine without modification — client inputs (per-bag cost from us, no roasting tier) are adapted into the engine's input shape.
- Co-roasting `/member-portal/numbers` is untouched.

## What's new

- **Pre-fill from actual JIM data:**
  - Trailing 3-month shipped volume (kg/mo)
  - Same-quarter-last-year for seasonal pace (toggle if data exists)
  - Average per-bag price paid per product, last 90 days
  - Product selector if multiple products shipped
- **Suggested MSRP card:** target retail margin slider (30–70%, default 50%), with "use this" apply button.
- **Scenario management:** save, rename, duplicate, delete + 1.5s debounced autosave against the new `client_unit_economics_scenarios` table.
- **Print/PDF:** uses `display:none` (avoids `visibility:hidden` blank-page bug).
- **Gating:** nav item + portal home card only render for `can_place_orders && !can_book_roaster` so co-roasters keep seeing only `/member-portal/numbers`.

## Files

New
- `src/lib/clientUnitEconomics.ts` — input shape + `calculateClientUnitEconomics()` adapter
- `src/lib/clientUnitEconomicsPrefill.ts` — `useClientPrefills` hook
- `src/hooks/useClientUnitEconomicsScenarios.ts` — CRUD + autosave
- `src/components/client/numbers/ClientInputsPanel.tsx`
- `src/components/client/numbers/MSRPCard.tsx`
- `src/pages/client/MyNumbers.tsx`

Modified
- `src/App.tsx` — routes `/client/numbers` + `/portal/numbers`
- `src/components/layout/ClientLayout.tsx` — gated nav item
- `src/pages/client/Portal.tsx` — gated home card
- `src/integrations/supabase/types.ts` — `client_unit_economics_scenarios` Row/Insert/Update added manually (no `node_modules` in worktree to run `supabase gen`)

## Math adapter

Engine reuse trick: stash the client's per-bag cost into the engine's `greenPrice` slot as `(costPerBag * 1000 / bagSizeG)` $/kg with `yieldLossPct=0` and `tier=null`. `costPerUnit()`, `marginAt()`, `monthlyView()` produce correct numbers without any engine changes.

## Reviewer notes

- The `client_unit_economics_scenarios` table was created via Lovable SQL editor (per the task brief) — RLS policies and `updated_at` trigger already in place. The types entry here was hand-written to match. Recommend running `supabase gen types typescript --project-id cgdzjkryygwlyygeznrb` locally to confirm exact parity.
- Volume pre-fill uses `status = 'SHIPPED'` only (actuals), per spec.
- Print stylesheet uses `display:none` per the documented bug pattern in this codebase.

## Test plan

- [ ] Log in as a manufacturing client (`can_place_orders=true`, `can_book_roaster` false): "My Numbers" appears in sidebar and on portal home.
- [ ] Opening `/client/numbers` auto-creates first scenario pre-filled with T3M kg and most-shipped product's avg price.
- [ ] Pace toggle switches monthly kg between current and seasonal (when year-ago data exists).
- [ ] Product selector swaps product/bag-size/cost-per-bag.
- [ ] MSRP card updates as target-margin slider moves; "Use this as my retail price" copies it to the retail input.
- [ ] Scenario save/rename/duplicate/delete + autosave indicator behave correctly.
- [ ] Print → PDF renders one clean page with assumptions, breakdown, MSRP, monthly view; no blank pages.
- [ ] Log in as a co-roasting member (`can_book_roaster=true`): nav item and home card are hidden; `/member-portal/numbers` still works identically.
- [ ] `can_place_orders=false` user: nav item and card hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)