### PR TITLE
Auto-complete past co-roast bookings; no-show as exception

### DIFF
--- a/src/components/bookings/BookingDetailModal.tsx
+++ b/src/components/bookings/BookingDetailModal.tsx
@@ -65,6 +65,13 @@ export function BookingDetailModal({ open, onOpenChange, booking, members, allBo
   const cancellationFee = cancellationTier === '50pct' ? fullFee * 0.5 : fullFee;
   const isPast = bookingStart < new Date();
   const isConfirmed = booking?.status === 'CONFIRMED';
+  const isCompleted = booking?.status === 'COMPLETED';
+  const isNoShow = booking?.status === 'NO_SHOW';
+  // Past CONFIRMED rows are auto-swept to COMPLETED by the hourly
+  // sweep_past_bookings_to_completed() cron job, but treat them as
+  // completed in the UI immediately so users don't see a stale CONFIRMED
+  // state between the booking ending and the next sweep.
+  const treatAsCompleted = isCompleted || (isConfirmed && isPast);
 
   const hoursType = useMemo(() => {
     if (!booking) return 'Included';
@@ -194,8 +201,22 @@ export function BookingDetailModal({ open, onOpenChange, booking, members, allBo
     onError: () => toast.error('Failed to mark no-show'),
   });
 
+  const revertToCompletedMutation = useMutation({
+    mutationFn: async () => {
+      if (!booking) return;
+      const { error } = await supabase.from('coroast_bookings').update({
+        status: 'COMPLETED' as any,
+        cancellation_fee_amt: 0,
+      }).eq('id', booking.id);
+      if (error) throw error;
+    },
+    onSuccess: () => { toast.success('Reverted to completed'); invalidateAll(); onOpenChange(false); },
+    onError: () => toast.error('Failed to revert booking'),
+  });
+
   const isPending = cancelFreeMutation.isPending || cancel50PctMutation.isPending || deleteMutation.isPending ||
-    cancelChargeMutation.isPending || cancelWaiveMutation.isPending || noShowMutation.isPending;
+    cancelChargeMutation.isPending || cancelWaiveMutation.isPending || noShowMutation.isPending ||
+    revertToCompletedMutation.isPending;
 
   if (!booking) return null;
 
@@ -269,7 +290,7 @@ export function BookingDetailModal({ open, onOpenChange, booking, members, allBo
             </div>
           )}
 
-          {isConfirmed && !cancelMode && (
+          {isConfirmed && !isPast && !cancelMode && (
             <div className="space-y-2 pt-2 border-t">
               {cancellationTier === 'free' && (
                 <Button size="sm" className="w-full bg-emerald-600 hover:bg-emerald-700 text-white"
@@ -301,14 +322,31 @@ export function BookingDetailModal({ open, onOpenChange, booking, members, allBo
                   </Button>
                 </>
               )}
+            </div>
+          )}
 
-              {isPast && (
-                <Button variant="outline" size="sm"
-                  className="w-full text-destructive border-destructive/30 hover:bg-destructive/10"
-                  onClick={() => noShowMutation.mutate()} disabled={isPending}>
-                  <AlertTriangle className="h-3.5 w-3.5 mr-1" /> Mark as No-Show (100% fee — {formatCurrency(fullFee, { decimals: 0 })})
-                </Button>
-              )}
+          {treatAsCompleted && !cancelMode && (
+            <div className="space-y-2 pt-2 border-t">
+              <p className="text-xs text-muted-foreground">
+                Booking complete. If the member did not show, mark as no-show to charge the 100% fee.
+              </p>
+              <Button variant="outline" size="sm"
+                className="w-full text-destructive border-destructive/30 hover:bg-destructive/10"
+                onClick={() => noShowMutation.mutate()} disabled={isPending}>
+                <AlertTriangle className="h-3.5 w-3.5 mr-1" /> Mark as No-Show (100% fee — {formatCurrency(fullFee, { decimals: 0 })})
+              </Button>
+            </div>
+          )}
+
+          {isNoShow && !cancelMode && (
+            <div className="space-y-2 pt-2 border-t">
+              <p className="text-xs text-muted-foreground">
+                Marked as no-show. Revert if the member actually attended.
+              </p>
+              <Button variant="outline" size="sm" className="w-full"
+                onClick={() => revertToCompletedMutation.mutate()} disabled={isPending}>
+                Revert to Completed
+              </Button>
             </div>
           )}
 

--- a/src/components/bookings/BookingWeekView.tsx
+++ b/src/components/bookings/BookingWeekView.tsx
@@ -64,6 +64,7 @@ type CalendarEvent = {
   recurring: boolean;
   urgency: UrgencyTier;
   isNoShow: boolean;
+  isCompleted: boolean;
 };
 
 export function BookingWeekView({ blocks, bookings, members, windows = [], onSlotClick, onBookingClick }: BookingWeekViewProps) {
@@ -119,16 +120,20 @@ export function BookingWeekView({ blocks, bookings, members, windows = [], onSlo
         tooltip: `Unavailable: ${formatTime12(b.start_time)} – ${formatTime12(b.end_time)}${b.notes ? ' — ' + b.notes : ''}`,
         bgColor: 'hsl(25 45% 25%)',
         textColor: 'hsl(40 30% 96%)',
-        isBlock: true, isOverage: false, recurring: false, urgency: 'none' as UrgencyTier, isNoShow: false,
+        isBlock: true, isOverage: false, recurring: false, urgency: 'none' as UrgencyTier, isNoShow: false, isCompleted: false,
       });
     }
 
     for (const bk of bookings) {
       if (CANCELLED_STATUSES.includes(bk.status)) continue;
       const isNoShow = bk.status === 'NO_SHOW';
+      const isCompleted = bk.status === 'COMPLETED';
+      const baseColor = getMemberColor(bk.member_id, allMemberIds);
       const color = isNoShow
         ? { bg: NO_SHOW_BG, text: '#fff' }
-        : getMemberColor(bk.member_id, allMemberIds);
+        : isCompleted
+          ? { bg: baseColor.bg, text: baseColor.text }
+          : baseColor;
       const isOverage = bookingOverageSet.has(bk.id);
       const bkStart = parseISO(`${bk.booking_date}T${bk.start_time}`);
       const hrsUntil = differenceInHours(bkStart, now);
@@ -141,11 +146,11 @@ export function BookingWeekView({ blocks, bookings, members, windows = [], onSlo
         startMin: timeToMinutes(bk.start_time),
         endMin: timeToMinutes(bk.end_time),
         label: bk.accounts?.account_name ?? 'Booking',
-        tooltip: `${bk.accounts?.account_name ?? 'Member'}: ${formatTime12(bk.start_time)} – ${formatTime12(bk.end_time)}${bk.duration_hours ? ` (${Number(bk.duration_hours).toFixed(1)}h)` : ''}${isNoShow ? ' [NO SHOW]' : ''}`,
+        tooltip: `${bk.accounts?.account_name ?? 'Member'}: ${formatTime12(bk.start_time)} – ${formatTime12(bk.end_time)}${bk.duration_hours ? ` (${Number(bk.duration_hours).toFixed(1)}h)` : ''}${isNoShow ? ' [NO SHOW]' : isCompleted ? ' [COMPLETED]' : ''}`,
         bgColor: color.bg,
         textColor: color.text,
         isBlock: false, isOverage, recurring: !!bk.recurring_block_id,
-        urgency, isNoShow,
+        urgency: isCompleted || isNoShow ? 'none' : urgency, isNoShow, isCompleted,
       });
     }
 
@@ -288,6 +293,7 @@ export function BookingWeekView({ blocks, bookings, members, windows = [], onSlo
                         className={cn(
                           'absolute left-0.5 right-0.5 rounded px-1 text-[10px] leading-tight overflow-hidden z-20',
                           ev.isBlock ? 'cursor-not-allowed opacity-90' : 'cursor-pointer',
+                          ev.isCompleted && 'opacity-60',
                           ev.isOverage && 'ring-1 ring-inset ring-white/40',
                           !ev.isBlock && ev.urgency === 'amber' && 'ring-2 ring-amber-400',
                           !ev.isBlock && ev.urgency === 'red' && 'ring-2 ring-destructive',
@@ -344,6 +350,10 @@ export function BookingWeekView({ blocks, bookings, members, windows = [], onSlo
         <div className="flex items-center gap-1.5">
           <div className="w-3 h-3 rounded" style={{ backgroundColor: NO_SHOW_BG }} />
           <span>No-Show</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-3 rounded bg-muted-foreground/40" />
+          <span>Completed</span>
         </div>
         <div className="flex items-center gap-1.5">
           <div className="w-3 h-3 rounded border" style={{ backgroundImage: 'repeating-linear-gradient(135deg, transparent, transparent 2px, rgba(0,0,0,0.15) 2px, rgba(0,0,0,0.15) 4px)' }} />

--- a/supabase/migrations/20260522000000_b1bfd2ae-6458-4a60-8b50-9f4fe8142921.sql
+++ b/supabase/migrations/20260522000000_b1bfd2ae-6458-4a60-8b50-9f4fe8142921.sql
@@ -1,0 +1,53 @@
+-- Auto-complete past confirmed co-roast bookings.
+--
+-- Rationale: previously, a past CONFIRMED booking sat indefinitely with
+-- "Mark as No-Show" as the only resolution action — backwards for the common
+-- case where the member actually showed up. We now assume a past booking was
+-- completed, and NO_SHOW becomes the explicit exception (already supported by
+-- BookingDetailModal.noShowMutation).
+--
+-- This migration:
+--   1. Defines public.sweep_past_bookings_to_completed() — flips CONFIRMED
+--      bookings whose (booking_date + end_time) is in the past (interpreted
+--      in the business timezone, America/Vancouver) to COMPLETED.
+--   2. Runs it once as a backfill.
+--   3. Schedules it hourly via pg_cron.
+
+CREATE OR REPLACE FUNCTION public.sweep_past_bookings_to_completed()
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_updated integer;
+BEGIN
+  UPDATE public.coroast_bookings
+     SET status = 'COMPLETED'
+   WHERE status = 'CONFIRMED'
+     AND ((booking_date::text || ' ' || end_time::text)::timestamp
+            AT TIME ZONE 'America/Vancouver') < now();
+  GET DIAGNOSTICS v_updated = ROW_COUNT;
+  RETURN v_updated;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.sweep_past_bookings_to_completed() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.sweep_past_bookings_to_completed() TO service_role;
+
+-- One-time backfill so existing past CONFIRMED bookings flip immediately.
+SELECT public.sweep_past_bookings_to_completed();
+
+-- Hourly sweep. Idempotent — unschedule any prior job of the same name first.
+DO $$
+BEGIN
+  PERFORM cron.unschedule('sweep-past-bookings-to-completed');
+EXCEPTION WHEN OTHERS THEN
+  NULL;
+END $$;
+
+SELECT cron.schedule(
+  'sweep-past-bookings-to-completed',
+  '0 * * * *',
+  $cron$SELECT public.sweep_past_bookings_to_completed();$cron$
+);


### PR DESCRIPTION
## Summary
- Adds pg_cron job `sweep-past-bookings-to-completed` (hourly) + one-time backfill that flips past `CONFIRMED` co-roast bookings to `COMPLETED`, comparing `booking_date + end_time` in `America/Vancouver`.
- BookingDetailModal: cancellation actions only show for **future** CONFIRMED bookings. Past bookings (CONFIRMED or COMPLETED) expose **Mark as No-Show** as the explicit exception. NO_SHOW rows get a **Revert to Completed** button.
- BookingWeekView: COMPLETED events render at 60% opacity, no urgency ring, legend entry added.

## Why
Past CONFIRMED bookings previously sat indefinitely with "Mark as No-Show" as the only resolution action — backwards for the common case where the member actually showed up. The default is now "assume completed"; no-show is the override.

## Test plan
- [ ] After running the migration, existing past CONFIRMED bookings should show as `COMPLETED` and dimmed on the calendar.
- [ ] Past booking → modal shows "Mark as No-Show" only. No cancel actions.
- [ ] Future booking → modal shows cancellation actions (Free / 50% / 100% tiers); no no-show button.
- [ ] No-show booking → modal shows "Revert to Completed".
- [ ] Verify pg_cron job is present: `SELECT * FROM cron.job WHERE jobname = 'sweep-past-bookings-to-completed';`

🤖 Generated with [Claude Code](https://claude.com/claude-code)