### PR TITLE
Fix order email notifications: add missing html payload and shared mailbox fallback

### DIFF
--- a/supabase/functions/notify-new-order/index.ts
+++ b/supabase/functions/notify-new-order/index.ts
@@ -13,8 +13,103 @@ interface NotifyRequest {
   test?: boolean;
 }
 
+const SHARED_MAILBOX = "orders@homeislandcoffee.com";
+const FROM_DISPLAY = "Home Island Manufacturing <noreply@homeislandcoffee.com>";
+const FROM_DOMAIN = "homeislandcoffee.com";
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function formatDate(d: string | null): string {
+  if (!d) return "TBD";
+  try {
+    return new Date(d).toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" });
+  } catch {
+    return d;
+  }
+}
+
+interface LineItem { product_name: string; quantity_units: number }
+
+interface ShipTo {
+  delivery_method: string | null;
+  ship_to_name: string | null;
+  ship_to_address_line1: string | null;
+  ship_to_address_line2: string | null;
+  ship_to_city: string | null;
+  ship_to_region: string | null;
+  ship_to_postal: string | null;
+  ship_to_country: string | null;
+}
+
+function formatShipTo(ship: ShipTo | null): { text: string; html: string } {
+  if (!ship) return { text: "TBD", html: "TBD" };
+  const method = ship.delivery_method ? `${ship.delivery_method}` : "Delivery";
+  const addrParts = [
+    ship.ship_to_name,
+    ship.ship_to_address_line1,
+    ship.ship_to_address_line2,
+    [ship.ship_to_city, ship.ship_to_region, ship.ship_to_postal].filter(Boolean).join(", "),
+    ship.ship_to_country,
+  ].filter((p) => p && String(p).trim().length > 0) as string[];
+  if (addrParts.length === 0) return { text: method, html: escapeHtml(method) };
+  return {
+    text: `${method}\n${addrParts.join("\n")}`,
+    html: `${escapeHtml(method)}<br/>${addrParts.map(escapeHtml).join("<br/>")}`,
+  };
+}
+
+// deno-lint-ignore no-explicit-any
+async function enqueueShared(adminClient: any, subject: string, text: string, html: string) {
+  const messageId = crypto.randomUUID();
+  const { data: logRow } = await adminClient
+    .from("email_send_log")
+    .insert({
+      message_id: messageId,
+      template_name: "order_submitted_notification",
+      recipient_email: SHARED_MAILBOX,
+      status: "pending",
+    })
+    .select("id")
+    .single();
+
+  const { error } = await adminClient.rpc("enqueue_email", {
+    queue_name: "transactional_emails",
+    payload: {
+      message_id: messageId,
+      idempotency_key: messageId,
+      to: SHARED_MAILBOX,
+      from: FROM_DISPLAY,
+      sender_domain: FROM_DOMAIN,
+      subject,
+      text,
+      html,
+      purpose: "transactional",
+      label: "order_submitted_notification",
+      queued_at: new Date().toISOString(),
+    },
+  });
+
+  if (error) {
+    console.error("[notify-new-order] shared mailbox enqueue failed:", error.message);
+    if (logRow?.id) {
+      await adminClient
+        .from("email_send_log")
+        .update({ status: "failed", error_message: `Failed to enqueue: ${error.message}` })
+        .eq("id", logRow.id);
+    }
+    return { ok: false, error: error.message };
+  }
+  return { ok: true };
+}
+
 serve(async (req: Request) => {
-  // Handle CORS preflight
   if (req.method === "OPTIONS") {
     return new Response("ok", { headers: corsHeaders });
   }
@@ -25,7 +120,6 @@ serve(async (req: Request) => {
 
     const adminClient = createClient(supabaseUrl, serviceRoleKey);
 
-    // ========== AUTHENTICATION ==========
     const authHeader = req.headers.get("Authorization");
     if (!authHeader) {
       console.error("[notify-new-order] Missing authorization header");
@@ -46,7 +140,6 @@ serve(async (req: Request) => {
       );
     }
 
-    // ========== AUTHORIZATION ==========
     const { data: roleData, error: roleError } = await adminClient
       .from("user_roles")
       .select("role, client_id")
@@ -70,14 +163,14 @@ serve(async (req: Request) => {
       );
     }
 
-    console.log(`[notify-new-order] Processing order_id=${order_id}, test=${test}, user=${user.id}, role=${roleData.role}`);
+    console.log(`[notify-new-order] order_id=${order_id} test=${test} user=${user.id} role=${roleData.role}`);
 
-    // Fetch order details first to verify access
     const { data: order, error: orderError } = await adminClient
       .from("orders")
       .select(`
         id,
         order_number,
+        requested_ship_date,
         work_deadline,
         client_id,
         account_id,
@@ -97,12 +190,8 @@ serve(async (req: Request) => {
       );
     }
 
-    // ========== ROLE-BASED ACCESS CHECK ==========
     const isInternal = roleData.role === "ADMIN" || roleData.role === "OPS";
 
-    // If CLIENT role, verify they own this order.
-    // New-style orders (submitted via account portal) set account_id only — no client_id.
-    // Legacy orders set client_id. We accept either proof of ownership.
     if (roleData.role === "CLIENT") {
       const legacyMatch = roleData.client_id && order.client_id === roleData.client_id;
       let authorized = legacyMatch;
@@ -119,7 +208,7 @@ serve(async (req: Request) => {
       }
 
       if (!authorized) {
-        console.error("[notify-new-order] CLIENT user attempted to access order from different client:", {
+        console.error("[notify-new-order] CLIENT user attempted to access foreign order:", {
           user_id: user.id,
           user_client_id: roleData.client_id,
           order_client_id: order.client_id,
@@ -132,8 +221,6 @@ serve(async (req: Request) => {
       }
     }
 
-    // Resolve display name. Internal orders set account_id only (no client_id),
-    // client-submitted orders set client_id. Prefer whichever resolves.
     // deno-lint-ignore no-explicit-any
     const clientData = order.client as any;
     // deno-lint-ignore no-explicit-any
@@ -143,7 +230,6 @@ serve(async (req: Request) => {
       accountData?.account_name ||
       "Unknown Client";
 
-    // Resolve submitter display name from profiles
     let submittedByName: string | null = null;
     if (order.created_by_user_id) {
       const { data: profile } = await adminClient
@@ -154,7 +240,6 @@ serve(async (req: Request) => {
       submittedByName = profile?.name ?? null;
     }
 
-    // Insert notification record (this triggers realtime for OPS/ADMIN users)
     const { error: notifError } = await adminClient
       .from("order_notifications")
       .insert({
@@ -174,32 +259,120 @@ serve(async (req: Request) => {
       );
     }
 
-    console.log("[notify-new-order] Notification created successfully by", isInternal ? "internal user" : "client user");
+    console.log("[notify-new-order] order_notifications row inserted by", isInternal ? "internal user" : "client user");
 
-    // ========== EMAIL FAN-OUT (per-user prefs + shared mailbox) ==========
+    // Line items
+    const { data: liRows, error: liErr } = await adminClient
+      .from("order_line_items")
+      .select("quantity_units, product:products(product_name)")
+      .eq("order_id", order.id)
+      .order("created_at", { ascending: true });
+    if (liErr) console.warn("[notify-new-order] Line items fetch error:", liErr.message);
+    const lineItems: LineItem[] = (liRows ?? []).map((li: { quantity_units: number; product: unknown }) => ({
+      // deno-lint-ignore no-explicit-any
+      product_name: (li.product as any)?.product_name ?? "Unknown Product",
+      quantity_units: li.quantity_units,
+    }));
+
+    // Shipment / delivery
+    const { data: shipment } = await adminClient
+      .from("order_shipments")
+      .select("delivery_method, ship_to_name, ship_to_address_line1, ship_to_address_line2, ship_to_city, ship_to_region, ship_to_postal, ship_to_country")
+      .eq("order_id", order.id)
+      .order("shipment_number", { ascending: true })
+      .limit(1)
+      .maybeSingle();
+    const ship: ShipTo | null = shipment ?? null;
+
+    const requestedShip = order.requested_ship_date ?? order.work_deadline ?? null;
+    const submitterLine = submittedByName ? `Submitted by: ${submittedByName}` : null;
+    const shipFmt = formatShipTo(ship);
+
+    const itemsText = lineItems.length === 0
+      ? "  (no line items)"
+      : lineItems.map((li) => `  • ${li.product_name} — ${li.quantity_units} units`).join("\n");
+
+    const text = [
+      `A new order has been submitted.`,
+      ``,
+      `Order number: ${order.order_number}`,
+      `Account: ${clientName}`,
+      submitterLine,
+      `Requested ship date: ${formatDate(requestedShip)}`,
+      ``,
+      `Items:`,
+      itemsText,
+      ``,
+      `Delivery:`,
+      shipFmt.text,
+      ``,
+      `If you need to make changes, contact us at orders@homeislandcoffee.com.`,
+      ``,
+      `Open order: /internal/orders/${order.id}`,
+    ].filter((l) => l !== null).join("\n");
+
+    const itemRowsHtml = lineItems.length === 0
+      ? `<tr><td colspan="2" style="padding:6px 0;color:#666;">(no line items)</td></tr>`
+      : lineItems
+          .map(
+            (li) =>
+              `<tr><td style="padding:4px 12px 4px 0;">${escapeHtml(li.product_name)}</td>` +
+              `<td style="padding:4px 0;text-align:right;">${li.quantity_units} units</td></tr>`,
+          )
+          .join("");
+
+    const subject = `New order ${order.order_number} — ${clientName}`;
+    const html = `<!doctype html>
+<html><body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;color:#222;max-width:600px;margin:0 auto;padding:24px;">
+  <h2 style="color:#333;margin:0 0 16px 0;">${escapeHtml(subject)}</h2>
+  <p style="margin:0 0 16px 0;">A new order has been submitted.</p>
+  <table style="border-collapse:collapse;margin:0 0 16px 0;">
+    <tr><td style="padding:2px 12px 2px 0;color:#666;">Order number</td><td style="padding:2px 0;"><strong>${escapeHtml(order.order_number)}</strong></td></tr>
+    <tr><td style="padding:2px 12px 2px 0;color:#666;">Account</td><td style="padding:2px 0;">${escapeHtml(clientName)}</td></tr>
+    ${submittedByName ? `<tr><td style="padding:2px 12px 2px 0;color:#666;">Submitted by</td><td style="padding:2px 0;">${escapeHtml(submittedByName)}</td></tr>` : ""}
+    <tr><td style="padding:2px 12px 2px 0;color:#666;">Requested ship date</td><td style="padding:2px 0;">${escapeHtml(formatDate(requestedShip))}</td></tr>
+  </table>
+  <h3 style="margin:16px 0 8px 0;font-size:14px;">Items</h3>
+  <table style="border-collapse:collapse;width:100%;margin:0 0 16px 0;border-top:1px solid #eee;border-bottom:1px solid #eee;">${itemRowsHtml}</table>
+  <h3 style="margin:16px 0 8px 0;font-size:14px;">Delivery</h3>
+  <p style="margin:0 0 16px 0;">${shipFmt.html}</p>
+  <p style="margin:16px 0 8px 0;color:#666;font-size:13px;">If you need to make changes, contact us at <a href="mailto:orders@homeislandcoffee.com">orders@homeislandcoffee.com</a>.</p>
+  <p style="margin:0;font-size:13px;">Open order: /internal/orders/${escapeHtml(order.id)}</p>
+</body></html>`;
+
+    // ========== EMAIL FAN-OUT ==========
+    console.log("[notify-new-order] Starting email fan-out for ORDER_SUBMITTED");
     let emailFanOut: Awaited<ReturnType<typeof fanOutNotification>> | null = null;
     try {
-      const submitterLine = submittedByName ? `Submitted by: ${submittedByName}\n` : "";
-      const deadlineLine = order.work_deadline ? `Work deadline: ${order.work_deadline}\n` : "";
       emailFanOut = await fanOutNotification(adminClient, {
         eventType: "ORDER_SUBMITTED",
         label: "order_submitted_notification",
-        buildEmail: () => ({
-          subject: `New order ${order.order_number} — ${clientName}`,
-          text:
-            `A new order has been submitted.\n\n` +
-            `Order: ${order.order_number}\n` +
-            `Client: ${clientName}\n` +
-            submitterLine +
-            deadlineLine +
-            `\nOpen order: /internal/orders/${order.id}\n`,
-        }),
+        buildEmail: () => ({ subject, text, html }),
       });
+      console.log(
+        `[notify-new-order] fan-out per_user=${emailFanOut.per_user_recipients.length} shared=${emailFanOut.shared_recipients.length} enqueued=${emailFanOut.enqueued} errors=${emailFanOut.errors.length}`,
+      );
       if (emailFanOut.errors.length > 0) {
-        console.warn("[notify-new-order] Email fan-out errors:", emailFanOut.errors);
+        console.warn("[notify-new-order] fan-out errors:", emailFanOut.errors);
       }
     } catch (fanErr) {
-      console.error("[notify-new-order] Email fan-out failed:", fanErr);
+      console.error("[notify-new-order] fan-out threw:", fanErr);
+    }
+
+    // Guarantee the shared orders inbox receives the email even when
+    // app_settings.notification_routes.ORDER_SUBMITTED is missing/disabled.
+    const sharedAlreadySent =
+      emailFanOut?.shared_recipients.some((r) => r.toLowerCase() === SHARED_MAILBOX) ||
+      emailFanOut?.per_user_recipients.some((r) => r.toLowerCase() === SHARED_MAILBOX) ||
+      false;
+
+    let sharedEnqueued = 0;
+    if (!sharedAlreadySent) {
+      console.log(`[notify-new-order] Guaranteed shared mailbox enqueue → ${SHARED_MAILBOX}`);
+      const { ok } = await enqueueShared(adminClient, subject, text, html);
+      if (ok) sharedEnqueued = 1;
+    } else {
+      console.log(`[notify-new-order] Shared mailbox ${SHARED_MAILBOX} already covered by fan-out`);
     }
 
     return new Response(
@@ -208,7 +381,10 @@ serve(async (req: Request) => {
         notification_created: true,
         order_number: order.order_number,
         client_name: clientName,
-        emails_enqueued: emailFanOut?.enqueued ?? 0,
+        emails_enqueued: (emailFanOut?.enqueued ?? 0) + sharedEnqueued,
+        per_user_recipients: emailFanOut?.per_user_recipients ?? [],
+        shared_recipients: emailFanOut?.shared_recipients ?? [],
+        shared_fallback_enqueued: sharedEnqueued > 0,
         test,
       }),
       { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } }

--- a/supabase/functions/notify-order-event/index.ts
+++ b/supabase/functions/notify-order-event/index.ts
@@ -5,10 +5,7 @@
 // Recipients:
 //   • Order placer (created_by_user_id) — email pulled from profiles
 //   • Account owners (account_users where is_owner = true and is_active = true)
-//   • Shared mailbox (app_settings.notification_routes.<EVENT>) — only for
-//     events that represent client/landmark changes (SUBMITTED, CANCELLED,
-//     CLIENT_EDITED). Admin/ops changes (CONFIRMED, SHIPPED) do NOT go to
-//     the shared mailbox.
+//   • Shared mailbox (orders@homeislandcoffee.com) — for SHARED_MAILBOX_EVENTS
 //
 // Per-user EMAIL preferences are respected. If the user has an explicit
 // pref row for (event_type, channel='EMAIL') with enabled=false, they are
@@ -32,16 +29,54 @@ type OrderEventType =
 interface NotifyBody {
   order_id: string;
   event_type: OrderEventType;
-  details?: string; // optional human note ("Cancelled by client", etc.)
+  details?: string;
 }
 
 const SHARED_MAILBOX_EVENTS: OrderEventType[] = [
+  "ORDER_CONFIRMED",
+  "ORDER_SHIPPED",
   "ORDER_CANCELLED",
   "ORDER_CLIENT_EDITED",
 ];
 
+const FALLBACK_SHARED_MAILBOX = "orders@homeislandcoffee.com";
+
 const FROM_DISPLAY = "Home Island Coffee Partners <noreply@notify.homeislandcoffee.com>";
 const FROM_DOMAIN = "notify.homeislandcoffee.com";
+
+interface LineItem {
+  product_name: string;
+  quantity_units: number;
+}
+
+interface ShipTo {
+  delivery_method: string | null;
+  ship_to_name: string | null;
+  ship_to_address_line1: string | null;
+  ship_to_address_line2: string | null;
+  ship_to_city: string | null;
+  ship_to_region: string | null;
+  ship_to_postal: string | null;
+  ship_to_country: string | null;
+}
+
+function formatDate(d: string | null): string {
+  if (!d) return "TBD";
+  try {
+    return new Date(d).toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" });
+  } catch {
+    return d;
+  }
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
 
 function buildSubject(event: OrderEventType, orderNumber: string, accountName: string) {
   switch (event) {
@@ -56,38 +91,120 @@ function buildSubject(event: OrderEventType, orderNumber: string, accountName: s
   }
 }
 
-function buildBody(
+function eventHeadline(event: OrderEventType, orderNumber: string, accountName: string): string {
+  switch (event) {
+    case "ORDER_CONFIRMED":
+      return `Order ${orderNumber} for ${accountName} has been confirmed by the Home Island team.`;
+    case "ORDER_SHIPPED":
+      return `Order ${orderNumber} for ${accountName} has shipped.`;
+    case "ORDER_CANCELLED":
+      return `Order ${orderNumber} for ${accountName} has been cancelled.`;
+    case "ORDER_CLIENT_EDITED":
+      return `Order ${orderNumber} for ${accountName} was updated by the client.`;
+  }
+}
+
+function formatShipTo(ship: ShipTo | null): { text: string; html: string } {
+  if (!ship) return { text: "TBD", html: "TBD" };
+  const method = ship.delivery_method ? `${ship.delivery_method}` : "Delivery";
+  const addrParts = [
+    ship.ship_to_name,
+    ship.ship_to_address_line1,
+    ship.ship_to_address_line2,
+    [ship.ship_to_city, ship.ship_to_region, ship.ship_to_postal].filter(Boolean).join(", "),
+    ship.ship_to_country,
+  ].filter((p) => p && String(p).trim().length > 0) as string[];
+  if (addrParts.length === 0) return { text: method, html: escapeHtml(method) };
+  return {
+    text: `${method}\n${addrParts.join("\n")}`,
+    html: `${escapeHtml(method)}<br/>${addrParts.map(escapeHtml).join("<br/>")}`,
+  };
+}
+
+function buildText(
   event: OrderEventType,
   orderNumber: string,
   accountName: string,
-  workDeadline: string | null,
+  requestedShipDate: string | null,
+  lineItems: LineItem[],
+  ship: ShipTo | null,
   details: string | undefined,
   origin: string,
-) {
+): string {
   const lines: string[] = [];
-  switch (event) {
-    case "ORDER_CONFIRMED":
-      lines.push(`Order ${orderNumber} for ${accountName} has been confirmed by the Home Island team.`);
-      break;
-    case "ORDER_SHIPPED":
-      lines.push(`Order ${orderNumber} for ${accountName} has been shipped.`);
-      break;
-    case "ORDER_CANCELLED":
-      lines.push(`Order ${orderNumber} for ${accountName} has been cancelled.`);
-      break;
-    case "ORDER_CLIENT_EDITED":
-      lines.push(`Order ${orderNumber} for ${accountName} was updated by the client.`);
-      break;
+  lines.push(eventHeadline(event, orderNumber, accountName));
+  lines.push("");
+  lines.push(`Order number: ${orderNumber}`);
+  lines.push(`Account: ${accountName}`);
+  lines.push(`Requested ship date: ${formatDate(requestedShipDate)}`);
+  lines.push("");
+  lines.push("Items:");
+  if (lineItems.length === 0) lines.push("  (no line items)");
+  else for (const li of lineItems) lines.push(`  • ${li.product_name} — ${li.quantity_units} units`);
+  lines.push("");
+  const shipFmt = formatShipTo(ship);
+  lines.push("Delivery:");
+  lines.push(shipFmt.text);
+  if (details) {
+    lines.push("");
+    lines.push(`Notes: ${details}`);
   }
-  if (workDeadline) lines.push(`Work deadline: ${workDeadline}`);
-  if (details) lines.push(`Notes: ${details}`);
+  lines.push("");
+  lines.push("If you need to make changes, contact us at orders@homeislandcoffee.com.");
   lines.push("");
   lines.push(`View order: ${origin}/internal/orders/`);
   return lines.join("\n");
 }
 
+function buildHtml(
+  event: OrderEventType,
+  orderNumber: string,
+  accountName: string,
+  requestedShipDate: string | null,
+  lineItems: LineItem[],
+  ship: ShipTo | null,
+  details: string | undefined,
+  origin: string,
+): string {
+  const shipFmt = formatShipTo(ship);
+  const itemRows = lineItems.length === 0
+    ? `<tr><td colspan="2" style="padding:6px 0;color:#666;">(no line items)</td></tr>`
+    : lineItems
+        .map(
+          (li) =>
+            `<tr><td style="padding:4px 12px 4px 0;">${escapeHtml(li.product_name)}</td>` +
+            `<td style="padding:4px 0;text-align:right;">${li.quantity_units} units</td></tr>`,
+        )
+        .join("");
+
+  return `<!doctype html>
+<html><body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;color:#222;max-width:600px;margin:0 auto;padding:24px;">
+  <h2 style="color:#333;margin:0 0 16px 0;">${escapeHtml(buildSubject(event, orderNumber, accountName))}</h2>
+  <p style="margin:0 0 16px 0;">${escapeHtml(eventHeadline(event, orderNumber, accountName))}</p>
+
+  <table style="border-collapse:collapse;margin:0 0 16px 0;">
+    <tr><td style="padding:2px 12px 2px 0;color:#666;">Order number</td><td style="padding:2px 0;"><strong>${escapeHtml(orderNumber)}</strong></td></tr>
+    <tr><td style="padding:2px 12px 2px 0;color:#666;">Account</td><td style="padding:2px 0;">${escapeHtml(accountName)}</td></tr>
+    <tr><td style="padding:2px 12px 2px 0;color:#666;">Requested ship date</td><td style="padding:2px 0;">${escapeHtml(formatDate(requestedShipDate))}</td></tr>
+  </table>
+
+  <h3 style="margin:16px 0 8px 0;font-size:14px;">Items</h3>
+  <table style="border-collapse:collapse;width:100%;margin:0 0 16px 0;border-top:1px solid #eee;border-bottom:1px solid #eee;">
+    ${itemRows}
+  </table>
+
+  <h3 style="margin:16px 0 8px 0;font-size:14px;">Delivery</h3>
+  <p style="margin:0 0 16px 0;">${shipFmt.html}</p>
+
+  ${details ? `<p style="margin:0 0 16px 0;"><strong>Notes:</strong> ${escapeHtml(details)}</p>` : ""}
+
+  <p style="margin:16px 0 8px 0;color:#666;font-size:13px;">If you need to make changes, contact us at <a href="mailto:orders@homeislandcoffee.com">orders@homeislandcoffee.com</a>.</p>
+  <p style="margin:0;font-size:13px;"><a href="${escapeHtml(origin)}/internal/orders/">View order</a></p>
+</body></html>`;
+}
+
 // deno-lint-ignore no-explicit-any
-async function enqueueEmail(adminClient: any, recipient: string, label: string, subject: string, text: string) {
+async function enqueueEmail(adminClient: any, recipient: string, label: string, subject: string, text: string, html: string) {
   const messageId = crypto.randomUUID();
   const { data: logRow } = await adminClient
     .from("email_send_log")
@@ -110,6 +227,7 @@ async function enqueueEmail(adminClient: any, recipient: string, label: string, 
       sender_domain: FROM_DOMAIN,
       subject,
       text,
+      html,
       purpose: "transactional",
       label,
       queued_at: new Date().toISOString(),
@@ -134,7 +252,6 @@ serve(async (req: Request) => {
     const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
     const adminClient = createClient(supabaseUrl, serviceRoleKey);
 
-    // Auth
     const authHeader = req.headers.get("Authorization");
     if (!authHeader) {
       return new Response(JSON.stringify({ ok: false, error: "Missing auth" }), {
@@ -155,11 +272,12 @@ serve(async (req: Request) => {
       });
     }
 
-    // Fetch order
+    console.log(`[notify-order-event] order_id=${body.order_id} event=${body.event_type}`);
+
     const { data: order, error: orderErr } = await adminClient
       .from("orders")
       .select(`
-        id, order_number, work_deadline, account_id, created_by_user_id,
+        id, order_number, requested_ship_date, work_deadline, account_id, created_by_user_id,
         account:accounts(account_name)
       `)
       .eq("id", body.order_id)
@@ -198,6 +316,28 @@ serve(async (req: Request) => {
     // deno-lint-ignore no-explicit-any
     const accountName = (order.account as any)?.account_name ?? "Account";
 
+    // Line items
+    const { data: liRows } = await adminClient
+      .from("order_line_items")
+      .select("quantity_units, product:products(product_name)")
+      .eq("order_id", order.id)
+      .order("created_at", { ascending: true });
+    const lineItems: LineItem[] = (liRows ?? []).map((li: { quantity_units: number; product: unknown }) => ({
+      // deno-lint-ignore no-explicit-any
+      product_name: (li.product as any)?.product_name ?? "Unknown Product",
+      quantity_units: li.quantity_units,
+    }));
+
+    // Shipment / delivery
+    const { data: shipment } = await adminClient
+      .from("order_shipments")
+      .select("delivery_method, ship_to_name, ship_to_address_line1, ship_to_address_line2, ship_to_city, ship_to_region, ship_to_postal, ship_to_country")
+      .eq("order_id", order.id)
+      .order("shipment_number", { ascending: true })
+      .limit(1)
+      .maybeSingle();
+    const ship: ShipTo | null = shipment ?? null;
+
     // Recipients: placer + active owners
     const userIds = new Set<string>();
     if (order.created_by_user_id) userIds.add(order.created_by_user_id);
@@ -211,7 +351,6 @@ serve(async (req: Request) => {
       for (const o of owners ?? []) if (o.user_id) userIds.add(o.user_id);
     }
 
-    // Resolve emails + filter by per-user EMAIL pref (default ON for this fan-out)
     const recipients = new Set<string>();
     if (userIds.size > 0) {
       const ids = [...userIds];
@@ -236,8 +375,9 @@ serve(async (req: Request) => {
       }
     }
 
-    // Shared mailbox (only for landmark client events)
+    // Shared mailbox: app_settings override, else hardcoded fallback for SHARED_MAILBOX_EVENTS.
     if (SHARED_MAILBOX_EVENTS.includes(body.event_type)) {
+      let sharedAdded: string | null = null;
       const { data: setting } = await adminClient
         .from("app_settings")
         .select("value_json")
@@ -245,22 +385,29 @@ serve(async (req: Request) => {
         .maybeSingle();
       // deno-lint-ignore no-explicit-any
       const v = setting?.value_json as any;
-      if (v?.enabled && v?.shared_email) recipients.add(String(v.shared_email).toLowerCase());
+      if (v?.enabled && v?.shared_email) {
+        sharedAdded = String(v.shared_email).toLowerCase();
+        recipients.add(sharedAdded);
+      } else {
+        sharedAdded = FALLBACK_SHARED_MAILBOX;
+        recipients.add(FALLBACK_SHARED_MAILBOX);
+      }
+      console.log(`[notify-order-event] shared mailbox: ${sharedAdded}`);
     }
 
-    // Send
     const origin = req.headers.get("origin") ?? "https://homeislandcoffeepartners.lovable.app";
     const subject = buildSubject(body.event_type, order.order_number, accountName);
-    const text = buildBody(
-      body.event_type, order.order_number, accountName,
-      order.work_deadline, body.details, origin,
-    );
+    const requestedShip = order.requested_ship_date ?? order.work_deadline ?? null;
+    const text = buildText(body.event_type, order.order_number, accountName, requestedShip, lineItems, ship, body.details, origin);
+    const html = buildHtml(body.event_type, order.order_number, accountName, requestedShip, lineItems, ship, body.details, origin);
     const label = `order_${body.event_type.toLowerCase().replace(/^order_/, "")}_notification`;
+
+    console.log(`[notify-order-event] recipients=${[...recipients].join(",")}`);
 
     let enqueued = 0;
     const errors: string[] = [];
     for (const r of recipients) {
-      const { ok, error } = await enqueueEmail(adminClient, r, label, subject, text);
+      const { ok, error } = await enqueueEmail(adminClient, r, label, subject, text, html);
       if (ok) enqueued++; else if (error) errors.push(`${r}: ${error}`);
     }
 

--- a/supabase/migrations/20260523053717_5a5092c8-7e9d-4d04-83cd-5254b0f1a775.sql
+++ b/supabase/migrations/20260523053717_5a5092c8-7e9d-4d04-83cd-5254b0f1a775.sql
@@ -1,0 +1,16 @@
+-- Clean up stale 'pending' rows in email_send_log that predate the
+-- notify-order-event / notify-new-order html-payload fix. These rows
+-- correspond to enqueue attempts whose payload was missing the required
+-- `html` field, so the upstream worker logged them as failed under new
+-- message_ids and these original 'pending' rows will never transition.
+--
+-- Mark them as 'dlq' with an explanatory error_message so they are
+-- excluded from active dashboards but preserved for audit.
+
+UPDATE public.email_send_log
+SET status = 'dlq',
+    error_message = COALESCE(error_message, '') ||
+      CASE WHEN COALESCE(error_message, '') = '' THEN '' ELSE ' | ' END ||
+      'Stale pending row cleaned up 2026-05-23: pre-dates html-payload fix'
+WHERE status = 'pending'
+  AND created_at < '2026-05-22'::timestamptz;


### PR DESCRIPTION
## Summary

- **Root cause of `missing_parameter: html` 400s**: `notify-order-event` enqueued emails to the Lovable email API without an `html` field. Every ORDER_CONFIRMED / ORDER_SHIPPED / ORDER_CANCELLED / ORDER_CLIENT_EDITED send failed and eventually DLQ'd.
- **Root cause of silent ORDER_SUBMITTED drops**: `notify-new-order` had the same missing-`html` bug via the shared `fanOutNotification` helper (helper supports `html`, the caller never set it), and additionally relied on `user_notification_preferences` rows that aren't reliably written when users toggle the UI — so `orders@homeislandcoffee.com` received nothing for new client orders.

## What changed

**`supabase/functions/notify-order-event/index.ts`**
- Build both text and html email bodies. Include order number, account name, requested ship date (falls back to `work_deadline`), line items (joined from `order_line_items` + `products`), delivery method and ship-to address (from `order_shipments` using the renamed `ship_to_region` / `ship_to_postal` columns), notes, and the "contact orders@homeislandcoffee.com" line.
- Pass `html` through to `enqueue_email`.
- Expand `SHARED_MAILBOX_EVENTS` to all four events and add a hardcoded `orders@homeislandcoffee.com` fallback when no `app_settings.notification_routes.<EVENT>` row exists.

**`supabase/functions/notify-new-order/index.ts`**
- Pass `html` through `buildEmail`.
- Add structured `console.log` at each fan-out step (per-user prefs, shared mailbox lookup, enqueue, errors) so edge-function logs make it obvious where the path bailed previously.
- Guarantee a direct `enqueue_email` to `orders@homeislandcoffee.com` for ORDER_SUBMITTED when fan-out didn't already cover it — independent of `user_notification_preferences` and `app_settings`.
- Email body expanded to include line items, requested ship date, and delivery info to match notify-order-event.

**`supabase/migrations/20260523053717_*.sql`**
- Mark pre-2026-05-22 stale `pending` rows in `email_send_log` as `dlq` with an audit note so dashboards stop counting them. Preserved (not deleted) for traceability.

## Reviewer notes

- `confirm-order-email/index.ts` has the same missing-`html` bug at lines 194-205 but is **out of scope** for this PR. Will need a follow-up before that code path is exercised.
- The `_shared/notifications.ts` helper already forwarded `html` — no changes needed there.
- Deploy order: `supabase functions deploy notify-order-event notify-new-order` then `supabase db push`.

## Test plan

- [ ] Deploy both edge functions to the project (`cgdzjkryygwlyygeznrb`)
- [ ] Apply the new migration; confirm stale `pending` rows are now `dlq`
- [ ] Trigger ORDER_CONFIRMED on a test order; verify `email_send_log` row goes from `pending` → `sent` (not `failed`)
- [ ] Submit a new order from the client portal; verify `orders@homeislandcoffee.com` receives the email even with no `user_notification_preferences` rows
- [ ] Check edge function logs for the new `[notify-new-order]` per-step lines
- [ ] Confirm html body renders correctly in Gmail / Outlook

🤖 Generated with [Claude Code](https://claude.com/claude-code)