### PR TITLE
Wire unsubscribe_token through transactional email enqueue paths

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -23,3 +23,5 @@ project_id = "cgdzjkryygwlyygeznrb"
     verify_jwt = false
   [functions.update-user]
     verify_jwt = false
+  [functions.unsubscribe]
+    verify_jwt = false

--- a/supabase/functions/_shared/notifications.ts
+++ b/supabase/functions/_shared/notifications.ts
@@ -3,6 +3,12 @@
 //   1. per-user EMAIL preferences (user_notification_preferences + enabled=true)
 //   2. shared mailbox (app_settings.notification_routes.<EVENT>, when enabled)
 //
+// All transactional email enqueues MUST include an `unsubscribe_token` — the
+// Lovable email API rejects payloads without one ("missing_unsubscribe" 400).
+// This helper resolves a per-recipient token from public.email_unsubscribe_tokens
+// (creating one on first send) and appends a "click here to unsubscribe" line
+// to the text and html bodies.
+//
 // In-app delivery is intentionally NOT handled here — callers continue to
 // insert their domain-specific notification rows (order_notifications,
 // booking notifications, etc.) which drive realtime UI toasts.
@@ -26,7 +32,7 @@ export interface EmailContent {
 
 export interface FanOutOptions {
   eventType: NotificationEventType;
-  label: string; // template label for email_send_log
+  label: string;
   buildEmail: (recipient: string) => EmailContent;
   /** When true, also enqueue email to ADMIN/OPS users whose EMAIL pref is on. */
   includePerUserEmails?: boolean;
@@ -41,12 +47,113 @@ interface FanOutResult {
   errors: string[];
 }
 
+// ---------------------------------------------------------------------------
+// Unsubscribe token helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Look up an unsubscribe token for the recipient email; create one if missing.
+ * Email is the unique key in email_unsubscribe_tokens, so this is idempotent.
+ */
+export async function ensureUnsubscribeToken(
+  adminClient: any,
+  email: string,
+): Promise<string> {
+  const normalized = email.toLowerCase().trim();
+
+  const { data: existing, error: selectErr } = await adminClient
+    .from('email_unsubscribe_tokens')
+    .select('token')
+    .eq('email', normalized)
+    .maybeSingle();
+
+  if (selectErr) {
+    console.error('[notifications] token lookup failed:', selectErr.message);
+  }
+  if (existing?.token) return existing.token;
+
+  const newToken = crypto.randomUUID();
+  const { error: insertErr } = await adminClient
+    .from('email_unsubscribe_tokens')
+    .insert({ token: newToken, email: normalized });
+
+  if (insertErr) {
+    // Likely a race: another concurrent enqueue inserted the row. Re-select.
+    const { data: raced } = await adminClient
+      .from('email_unsubscribe_tokens')
+      .select('token')
+      .eq('email', normalized)
+      .maybeSingle();
+    if (raced?.token) return raced.token;
+    throw new Error(`Failed to create unsubscribe token: ${insertErr.message}`);
+  }
+  return newToken;
+}
+
+export function buildUnsubscribeUrl(token: string): string {
+  const base =
+    Deno.env.get('APP_PUBLIC_URL') ||
+    Deno.env.get('SUPABASE_URL') ||
+    'https://homeislandcoffeepartners.lovable.app';
+  // If APP_PUBLIC_URL points at the app rather than Supabase, route through
+  // the supabase functions URL directly to avoid needing a frontend handler.
+  if (base.includes('supabase.co') || base.includes('supabase.in')) {
+    return `${base.replace(/\/$/, '')}/functions/v1/unsubscribe?token=${encodeURIComponent(token)}`;
+  }
+  const supabaseUrl = Deno.env.get('SUPABASE_URL');
+  if (supabaseUrl) {
+    return `${supabaseUrl.replace(/\/$/, '')}/functions/v1/unsubscribe?token=${encodeURIComponent(token)}`;
+  }
+  return `${base.replace(/\/$/, '')}/functions/v1/unsubscribe?token=${encodeURIComponent(token)}`;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/** Inline-able footer lines to append at the end of a transactional email body. */
+export function unsubscribeFooter(token: string): { text: string; html: string } {
+  const url = buildUnsubscribeUrl(token);
+  return {
+    text: `\n\nTo unsubscribe from these notifications, click here: ${url}`,
+    html: `<p style="margin:24px 0 0 0;color:#999;font-size:12px;border-top:1px solid #eee;padding-top:12px;">To unsubscribe from these notifications, <a href="${escapeHtml(url)}" style="color:#999;">click here</a>.</p>`,
+  };
+}
+
+/** Append the unsubscribe footer to an existing EmailContent. */
+export function withUnsubscribe(content: EmailContent, token: string): EmailContent {
+  const footer = unsubscribeFooter(token);
+  return {
+    subject: content.subject,
+    text: `${content.text}${footer.text}`,
+    html: content.html ? content.html.replace(/<\/body>/i, `${footer.html}</body>`) : undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Enqueue + fan-out
+// ---------------------------------------------------------------------------
+
 async function enqueueOne(
   adminClient: any,
   recipient: string,
   label: string,
   content: EmailContent,
 ): Promise<{ ok: boolean; error?: string }> {
+  let unsubscribeToken: string;
+  try {
+    unsubscribeToken = await ensureUnsubscribeToken(adminClient, recipient);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: `unsubscribe token: ${msg}` };
+  }
+
+  const final = withUnsubscribe(content, unsubscribeToken);
   const messageId = crypto.randomUUID();
 
   const { data: logRow } = await adminClient
@@ -68,11 +175,12 @@ async function enqueueOne(
       to: recipient,
       from: FROM_DISPLAY,
       sender_domain: FROM_DOMAIN,
-      subject: content.subject,
-      text: content.text,
-      html: content.html,
+      subject: final.subject,
+      text: final.text,
+      html: final.html,
       purpose: 'transactional',
       label,
+      unsubscribe_token: unsubscribeToken,
       queued_at: new Date().toISOString(),
     },
   });
@@ -115,8 +223,6 @@ export async function fanOutNotification(
       result.errors.push(`prefs query failed: ${prefsError.message}`);
     } else if (prefs && prefs.length > 0) {
       const userIds = prefs.map((p: any) => p.user_id);
-      // Resolve emails via auth.users (service-role only has access via RPC or admin API).
-      // Profiles table also stores email for app users; prefer it for simplicity.
       const { data: profiles } = await adminClient
         .from('profiles')
         .select('user_id, email')
@@ -151,8 +257,23 @@ export async function fanOutNotification(
     }
   }
 
+  // ---- suppression filter ----
+  let active = [...recipients];
+  if (active.length > 0) {
+    const { data: suppressed, error: suppErr } = await adminClient
+      .from('suppressed_emails')
+      .select('email')
+      .in('email', active);
+    if (suppErr) {
+      result.errors.push(`suppression check failed: ${suppErr.message}`);
+    } else if (suppressed && suppressed.length > 0) {
+      const blocked = new Set(suppressed.map((s: any) => String(s.email).toLowerCase()));
+      active = active.filter((r) => !blocked.has(r));
+    }
+  }
+
   // ---- enqueue ----
-  for (const recipient of recipients) {
+  for (const recipient of active) {
     const content = opts.buildEmail(recipient);
     const { ok, error } = await enqueueOne(adminClient, recipient, opts.label, content);
     if (ok) result.enqueued += 1;

--- a/supabase/functions/confirm-order-email/index.ts
+++ b/supabase/functions/confirm-order-email/index.ts
@@ -1,8 +1,6 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.91.0";
-
-// TODO: Deploy this function via `supabase functions deploy confirm-order-email`
-// before the email trigger in OrderEditModal.tsx goes live.
+import { ensureUnsubscribeToken, unsubscribeFooter } from "../_shared/notifications.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -14,18 +12,53 @@ const FROM_ADDRESS = "noreply@homeislandcoffee.com";
 const FROM_DISPLAY = "Home Island Manufacturing <noreply@homeislandcoffee.com>";
 const CC_ADDRESS = "orders@homeislandcoffee.com";
 
-// TODO: Confirm that the enqueue_email RPC payload supports a `cc` field.
-// If the RPC / process-email-queue function does not forward `cc` to Resend,
-// either extend the RPC payload schema or send a second enqueue call to CC_ADDRESS.
-
 interface ConfirmRequest {
   order_id: string;
+}
+
+interface LineItem { product_name: string; quantity_units: number }
+
+interface ShipTo {
+  delivery_method: string | null;
+  ship_to_name: string | null;
+  ship_to_address_line1: string | null;
+  ship_to_address_line2: string | null;
+  ship_to_city: string | null;
+  ship_to_region: string | null;
+  ship_to_postal: string | null;
+  ship_to_country: string | null;
 }
 
 function formatDate(dateStr: string | null): string {
   if (!dateStr) return "TBD";
   const d = new Date(dateStr);
   return d.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" });
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function formatShipTo(ship: ShipTo | null): { text: string; html: string } {
+  if (!ship) return { text: "TBD", html: "TBD" };
+  const method = ship.delivery_method ? `${ship.delivery_method}` : "Delivery";
+  const addrParts = [
+    ship.ship_to_name,
+    ship.ship_to_address_line1,
+    ship.ship_to_address_line2,
+    [ship.ship_to_city, ship.ship_to_region, ship.ship_to_postal].filter(Boolean).join(", "),
+    ship.ship_to_country,
+  ].filter((p) => p && String(p).trim().length > 0) as string[];
+  if (addrParts.length === 0) return { text: method, html: escapeHtml(method) };
+  return {
+    text: `${method}\n${addrParts.join("\n")}`,
+    html: `${escapeHtml(method)}<br/>${addrParts.map(escapeHtml).join("<br/>")}`,
+  };
 }
 
 serve(async (req: Request) => {
@@ -38,9 +71,6 @@ serve(async (req: Request) => {
     const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
     const adminClient = createClient(supabaseUrl, serviceRoleKey);
 
-    // ========== AUTHENTICATION ==========
-    // Only ADMIN/OPS users can change order status to CONFIRMED, so we verify
-    // the caller is authenticated with an internal role.
     const authHeader = req.headers.get("Authorization");
     if (!authHeader) {
       return new Response(
@@ -82,10 +112,9 @@ serve(async (req: Request) => {
 
     console.log(`[confirm-order-email] Processing order_id=${order_id}`);
 
-    // ========== FETCH ORDER ==========
     const { data: order, error: orderError } = await adminClient
       .from("orders")
-      .select("id, order_number, requested_ship_date, work_deadline_at, account_id, status")
+      .select("id, order_number, requested_ship_date, work_deadline, work_deadline_at, account_id, status")
       .eq("id", order_id)
       .maybeSingle();
 
@@ -105,9 +134,6 @@ serve(async (req: Request) => {
       );
     }
 
-    // ========== FETCH ACCOUNT ==========
-    // TODO: Verify the accounts table has `billing_email` and `account_name` populated
-    // for this account before going live. If billing_email is null, the email will be skipped.
     const { data: account, error: accountError } = await adminClient
       .from("accounts")
       .select("account_name, billing_email")
@@ -130,8 +156,7 @@ serve(async (req: Request) => {
       );
     }
 
-    // ========== FETCH LINE ITEMS ==========
-    const { data: lineItems, error: lineError } = await adminClient
+    const { data: liRows, error: lineError } = await adminClient
       .from("order_line_items")
       .select("quantity_units, product:products(product_name)")
       .eq("order_id", order_id)
@@ -140,78 +165,132 @@ serve(async (req: Request) => {
     if (lineError) {
       console.error("[confirm-order-email] Failed to fetch line items:", lineError.message);
     }
+    const lineItems: LineItem[] = (liRows ?? []).map((li: { quantity_units: number; product: unknown }) => ({
+      // deno-lint-ignore no-explicit-any
+      product_name: (li.product as any)?.product_name ?? "Unknown Product",
+      quantity_units: li.quantity_units,
+    }));
 
-    // ========== BUILD EMAIL BODY ==========
+    const { data: shipment } = await adminClient
+      .from("order_shipments")
+      .select("delivery_method, ship_to_name, ship_to_address_line1, ship_to_address_line2, ship_to_city, ship_to_region, ship_to_postal, ship_to_country")
+      .eq("order_id", order_id)
+      .order("shipment_number", { ascending: true })
+      .limit(1)
+      .maybeSingle();
+    const ship: ShipTo | null = shipment ?? null;
+
     const accountName = account.account_name;
     const orderNumber = order.order_number;
-    const roastDay = formatDate(order.work_deadline_at);
+    const roastDay = formatDate(order.work_deadline_at ?? order.work_deadline ?? null);
     const shipDate = formatDate(order.requested_ship_date);
+    const shipFmt = formatShipTo(ship);
 
-    const itemLines = (lineItems ?? [])
-      .map((li) => {
-        // deno-lint-ignore no-explicit-any
-        const productName = (li.product as any)?.product_name ?? "Unknown Product";
-        return `  * ${productName} — ${li.quantity_units} units`;
-      })
-      .join("\n");
+    const itemsText = lineItems.length === 0
+      ? "  (no line items)"
+      : lineItems.map((li) => `  • ${li.product_name} — ${li.quantity_units} units`).join("\n");
+
+    const subject = `Order Confirmed — ${orderNumber} — ${accountName}`;
 
     const emailText = `Hi ${accountName},
 
 Your order has been confirmed. Here are the details:
 
-Order Number: ${orderNumber}
-Planned Roast Day: ${roastDay}
-Requested Ship Date: ${shipDate}
+Order number: ${orderNumber}
+Account: ${accountName}
+Planned roast day: ${roastDay}
+Requested ship date: ${shipDate}
 
 Items:
-${itemLines || "  (No items)"}
+${itemsText}
 
-If you have any questions, reply to this email or contact us at orders@homeislandcoffee.com.
+Delivery:
+${shipFmt.text}
+
+If you need to make changes, contact us at orders@homeislandcoffee.com.
 
 Thank you,
 Home Island Manufacturing`;
 
-    const subject = `Order Confirmed — ${orderNumber} — ${accountName}`;
+    const itemRowsHtml = lineItems.length === 0
+      ? `<tr><td colspan="2" style="padding:6px 0;color:#666;">(no line items)</td></tr>`
+      : lineItems
+          .map(
+            (li) =>
+              `<tr><td style="padding:4px 12px 4px 0;">${escapeHtml(li.product_name)}</td>` +
+              `<td style="padding:4px 0;text-align:right;">${li.quantity_units} units</td></tr>`,
+          )
+          .join("");
 
-    // ========== ENQUEUE EMAIL ==========
-    // CC strategy: the shared process-email-queue / sendLovableEmail pipeline
-    // does NOT forward a `cc` field, so instead of relying on `cc` we enqueue a
-    // SECOND message addressed directly to the orders inbox with the same body
-    // and a distinct message_id. (Option B from the spec.)
+    const emailHtml = `<!doctype html>
+<html><body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;color:#222;max-width:600px;margin:0 auto;padding:24px;">
+  <h2 style="color:#333;margin:0 0 16px 0;">${escapeHtml(subject)}</h2>
+  <p style="margin:0 0 16px 0;">Hi ${escapeHtml(accountName)}, your order has been confirmed.</p>
+  <table style="border-collapse:collapse;margin:0 0 16px 0;">
+    <tr><td style="padding:2px 12px 2px 0;color:#666;">Order number</td><td style="padding:2px 0;"><strong>${escapeHtml(orderNumber)}</strong></td></tr>
+    <tr><td style="padding:2px 12px 2px 0;color:#666;">Account</td><td style="padding:2px 0;">${escapeHtml(accountName)}</td></tr>
+    <tr><td style="padding:2px 12px 2px 0;color:#666;">Planned roast day</td><td style="padding:2px 0;">${escapeHtml(roastDay)}</td></tr>
+    <tr><td style="padding:2px 12px 2px 0;color:#666;">Requested ship date</td><td style="padding:2px 0;">${escapeHtml(shipDate)}</td></tr>
+  </table>
+  <h3 style="margin:16px 0 8px 0;font-size:14px;">Items</h3>
+  <table style="border-collapse:collapse;width:100%;margin:0 0 16px 0;border-top:1px solid #eee;border-bottom:1px solid #eee;">${itemRowsHtml}</table>
+  <h3 style="margin:16px 0 8px 0;font-size:14px;">Delivery</h3>
+  <p style="margin:0 0 16px 0;">${shipFmt.html}</p>
+  <p style="margin:16px 0 8px 0;color:#666;font-size:13px;">If you need to make changes, contact us at <a href="mailto:orders@homeislandcoffee.com">orders@homeislandcoffee.com</a>.</p>
+  <p style="margin:0;color:#666;font-size:13px;">Thank you,<br/>Home Island Manufacturing</p>
+</body></html>`;
+
     const senderDomain = FROM_ADDRESS.split("@")[1];
 
     async function enqueueOne(recipient: string): Promise<{ ok: boolean; message_id: string; error?: string }> {
+      let unsubscribeToken: string;
+      try {
+        unsubscribeToken = await ensureUnsubscribeToken(adminClient, recipient);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return { ok: false, message_id: "", error: `unsubscribe token: ${msg}` };
+      }
+      const footer = unsubscribeFooter(unsubscribeToken);
+      const finalText = `${emailText}${footer.text}`;
+      const finalHtml = emailHtml.replace(/<\/body>/i, `${footer.html}</body>`);
+
       const messageId = crypto.randomUUID();
-      await adminClient.from("email_send_log").insert({
-        message_id: messageId,
-        template_name: "order_confirmation",
-        recipient_email: recipient,
-        status: "pending",
-      });
+      const { data: logRow } = await adminClient
+        .from("email_send_log")
+        .insert({
+          message_id: messageId,
+          template_name: "order_confirmation",
+          recipient_email: recipient,
+          status: "pending",
+        })
+        .select("id")
+        .single();
 
       const { error: enqueueError } = await adminClient.rpc("enqueue_email", {
         queue_name: "transactional_emails",
         payload: {
           message_id: messageId,
+          idempotency_key: messageId,
           to: recipient,
           from: FROM_DISPLAY,
           sender_domain: senderDomain,
           subject,
-          text: emailText,
+          text: finalText,
+          html: finalHtml,
           purpose: "transactional",
           label: "order_confirmation",
+          unsubscribe_token: unsubscribeToken,
           queued_at: new Date().toISOString(),
         },
       });
 
       if (enqueueError) {
-        await adminClient.from("email_send_log").insert({
-          message_id: messageId,
-          template_name: "order_confirmation",
-          recipient_email: recipient,
-          status: "failed",
-          error_message: "Failed to enqueue",
-        });
+        if (logRow?.id) {
+          await adminClient
+            .from("email_send_log")
+            .update({ status: "failed", error_message: `Failed to enqueue: ${enqueueError.message}` })
+            .eq("id", logRow.id);
+        }
         return { ok: false, message_id: messageId, error: enqueueError.message };
       }
       return { ok: true, message_id: messageId };

--- a/supabase/functions/notify-new-order/index.ts
+++ b/supabase/functions/notify-new-order/index.ts
@@ -1,6 +1,6 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.91.0";
-import { fanOutNotification } from "../_shared/notifications.ts";
+import { ensureUnsubscribeToken, fanOutNotification, unsubscribeFooter } from "../_shared/notifications.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -67,6 +67,18 @@ function formatShipTo(ship: ShipTo | null): { text: string; html: string } {
 
 // deno-lint-ignore no-explicit-any
 async function enqueueShared(adminClient: any, subject: string, text: string, html: string) {
+  let unsubscribeToken: string;
+  try {
+    unsubscribeToken = await ensureUnsubscribeToken(adminClient, SHARED_MAILBOX);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error("[notify-new-order] shared mailbox token failed:", msg);
+    return { ok: false, error: `unsubscribe token: ${msg}` };
+  }
+  const footer = unsubscribeFooter(unsubscribeToken);
+  const finalText = `${text}${footer.text}`;
+  const finalHtml = html.replace(/<\/body>/i, `${footer.html}</body>`);
+
   const messageId = crypto.randomUUID();
   const { data: logRow } = await adminClient
     .from("email_send_log")
@@ -88,10 +100,11 @@ async function enqueueShared(adminClient: any, subject: string, text: string, ht
       from: FROM_DISPLAY,
       sender_domain: FROM_DOMAIN,
       subject,
-      text,
-      html,
+      text: finalText,
+      html: finalHtml,
       purpose: "transactional",
       label: "order_submitted_notification",
+      unsubscribe_token: unsubscribeToken,
       queued_at: new Date().toISOString(),
     },
   });

--- a/supabase/functions/notify-order-event/index.ts
+++ b/supabase/functions/notify-order-event/index.ts
@@ -13,6 +13,7 @@
 
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.91.0";
+import { ensureUnsubscribeToken, unsubscribeFooter } from "../_shared/notifications.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -205,6 +206,17 @@ function buildHtml(
 
 // deno-lint-ignore no-explicit-any
 async function enqueueEmail(adminClient: any, recipient: string, label: string, subject: string, text: string, html: string) {
+  let unsubscribeToken: string;
+  try {
+    unsubscribeToken = await ensureUnsubscribeToken(adminClient, recipient);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: `unsubscribe token: ${msg}` };
+  }
+  const footer = unsubscribeFooter(unsubscribeToken);
+  const finalText = `${text}${footer.text}`;
+  const finalHtml = html.replace(/<\/body>/i, `${footer.html}</body>`);
+
   const messageId = crypto.randomUUID();
   const { data: logRow } = await adminClient
     .from("email_send_log")
@@ -226,10 +238,11 @@ async function enqueueEmail(adminClient: any, recipient: string, label: string, 
       from: FROM_DISPLAY,
       sender_domain: FROM_DOMAIN,
       subject,
-      text,
-      html,
+      text: finalText,
+      html: finalHtml,
       purpose: "transactional",
       label,
+      unsubscribe_token: unsubscribeToken,
       queued_at: new Date().toISOString(),
     },
   });

--- a/supabase/functions/unsubscribe/index.ts
+++ b/supabase/functions/unsubscribe/index.ts
@@ -1,0 +1,129 @@
+// Public unsubscribe handler. Reached from the link in transactional emails.
+// GET /functions/v1/unsubscribe?token=<uuid>
+//
+// - Resolves the token in public.email_unsubscribe_tokens.
+// - Inserts the associated email into public.suppressed_emails (idempotent).
+// - Marks the token row's used_at timestamp.
+// - Returns a simple confirmation HTML page.
+//
+// No auth header is required — this URL has to work from a click in an email.
+
+import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.91.0";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "content-type",
+};
+
+const HTML_HEAD = `<!doctype html>
+<html><head><meta charset="utf-8"><title>Home Island Coffee Partners</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; color: #222; background: #fafafa; margin: 0; padding: 40px 16px; }
+  .card { max-width: 520px; margin: 0 auto; background: #fff; border: 1px solid #eee; border-radius: 8px; padding: 32px; }
+  h1 { margin: 0 0 12px 0; font-size: 20px; }
+  p { margin: 0 0 12px 0; line-height: 1.5; }
+  .muted { color: #666; font-size: 13px; }
+  .ok { color: #1a7f37; }
+  .err { color: #b42318; }
+</style></head><body><div class="card">`;
+const HTML_FOOT = `</div></body></html>`;
+
+function htmlResponse(status: number, body: string): Response {
+  return new Response(HTML_HEAD + body + HTML_FOOT, {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "text/html; charset=utf-8" },
+  });
+}
+
+serve(async (req: Request) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  if (req.method !== "GET" && req.method !== "POST") {
+    return htmlResponse(
+      405,
+      `<h1>Method not allowed</h1><p class="muted">Use the unsubscribe link from your email.</p>`,
+    );
+  }
+
+  try {
+    const url = new URL(req.url);
+    const token = url.searchParams.get("token");
+
+    if (!token) {
+      return htmlResponse(
+        400,
+        `<h1 class="err">Missing token</h1><p class="muted">This link is incomplete. If you received this from a Home Island Coffee Partners email, please reply to that email asking to be unsubscribed.</p>`,
+      );
+    }
+
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+    const adminClient = createClient(supabaseUrl, serviceRoleKey);
+
+    const { data: tokenRow, error: lookupErr } = await adminClient
+      .from("email_unsubscribe_tokens")
+      .select("id, email, used_at")
+      .eq("token", token)
+      .maybeSingle();
+
+    if (lookupErr) {
+      console.error("[unsubscribe] token lookup failed:", lookupErr.message);
+      return htmlResponse(
+        500,
+        `<h1 class="err">Something went wrong</h1><p class="muted">Please try again later or reply to the email you received.</p>`,
+      );
+    }
+
+    if (!tokenRow) {
+      return htmlResponse(
+        404,
+        `<h1 class="err">Link not recognized</h1><p class="muted">This unsubscribe link is invalid or has expired. If you keep receiving emails you don't want, reply to one of them and we'll remove you manually.</p>`,
+      );
+    }
+
+    const email = tokenRow.email;
+
+    const { error: suppressErr } = await adminClient
+      .from("suppressed_emails")
+      .insert({
+        email,
+        reason: "unsubscribe",
+        metadata: { source: "email_link", token_id: tokenRow.id },
+      });
+
+    // 23505 = unique violation: already suppressed. Treat as success.
+    if (suppressErr && suppressErr.code !== "23505") {
+      console.error("[unsubscribe] suppression insert failed:", suppressErr.message);
+      return htmlResponse(
+        500,
+        `<h1 class="err">Something went wrong</h1><p class="muted">We couldn't complete the unsubscribe. Please reply to the email you received and we'll remove you manually.</p>`,
+      );
+    }
+
+    if (!tokenRow.used_at) {
+      await adminClient
+        .from("email_unsubscribe_tokens")
+        .update({ used_at: new Date().toISOString() })
+        .eq("id", tokenRow.id);
+    }
+
+    console.log(`[unsubscribe] suppressed email=${email} token_id=${tokenRow.id}`);
+
+    return htmlResponse(
+      200,
+      `<h1 class="ok">You've been unsubscribed</h1>
+       <p>You've been unsubscribed from Home Island Coffee Partners notifications. We won't send any further transactional emails to <strong>${email}</strong>.</p>
+       <p class="muted">If this was a mistake, reply to any prior email from us and we'll re-enable your notifications.</p>`,
+    );
+  } catch (err) {
+    console.error("[unsubscribe] unhandled error:", err);
+    return htmlResponse(
+      500,
+      `<h1 class="err">Something went wrong</h1><p class="muted">Please try again later.</p>`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

- **Root cause:** Lovable email API rejected every transactional send with `missing_unsubscribe: Transactional emails must include an unsubscribe_token`. None of the enqueue paths included a token in the payload.
- All four enqueue sites now resolve (or create) a per-recipient token from `public.email_unsubscribe_tokens`, include it in the `enqueue_email` RPC payload, and append a visible unsubscribe link to the text and html bodies.
- New public edge function honors the link: looks up the token, inserts the email into `public.suppressed_emails` (idempotent), stamps `used_at`, and renders a confirmation page.

## What changed

**`supabase/functions/_shared/notifications.ts`**
- Adds `ensureUnsubscribeToken(client, email)` — idempotent against the email-unique constraint with a race-safe re-select.
- Adds `buildUnsubscribeUrl(token)` (uses `SUPABASE_URL` / `APP_PUBLIC_URL`) and `unsubscribeFooter(token)` (returns `{ text, html }`).
- `fanOutNotification` now threads token resolution through `enqueueOne`, sets `unsubscribe_token` in the payload, and appends the footer to text/html.
- `fanOutNotification` also filters recipients against `public.suppressed_emails` before enqueue so previously unsubscribed addresses are skipped.

**`supabase/functions/notify-order-event/index.ts`**
- Inline `enqueueEmail` resolves token via helper, appends footer, includes `unsubscribe_token` in payload.

**`supabase/functions/notify-new-order/index.ts`**
- The fan-out path is covered automatically by the shared helper.
- The guaranteed `orders@homeislandcoffee.com` shared-mailbox fallback `enqueueShared` is updated the same way.

**`supabase/functions/confirm-order-email/index.ts`**
- Reinstates the `html` payload + line items + ship-to fields (the prior fix in #62 was reverted on main).
- `enqueueOne` resolves token + appends footer + sets `unsubscribe_token`.

**`supabase/functions/unsubscribe/index.ts` (new)**
- Public GET handler. Resolves `?token=`, inserts into `suppressed_emails` (treats `23505` as success), stamps `used_at`, returns styled HTML confirmation.
- Surfaces friendly messages for missing/invalid token and internal errors.

**`supabase/config.toml`**
- Registers `[functions.unsubscribe]` with `verify_jwt = false` so the click-through link works without an auth header.

## Reviewer notes

- No schema migration needed — `email_unsubscribe_tokens` and `suppressed_emails` tables already exist (`20260425044550_email_infra.sql`).
- Token row's `used_at` is stamped but the row is **not** deleted, so a future re-subscribe flow could repurpose it. Suppression is the authoritative state.
- `buildUnsubscribeUrl` prefers `APP_PUBLIC_URL` if it points at Supabase, otherwise falls back to `${SUPABASE_URL}/functions/v1/unsubscribe?token=...`. If you want links to go through a frontend route instead, set `APP_PUBLIC_URL` to the app domain and add a frontend handler that calls this function — but the direct Supabase URL works out of the box.
- Race condition on first-send to a fresh recipient is handled: if the unique-on-email insert collides with a concurrent enqueue, we re-select and use the existing row's token.

## Deploy

```
supabase functions deploy unsubscribe notify-order-event notify-new-order confirm-order-email
```

No `db push` required.

## Test plan

- [ ] Deploy all four functions
- [ ] Trigger ORDER_SUBMITTED, ORDER_CONFIRMED, ORDER_SHIPPED, ORDER_CANCELLED, and ORDER_CLIENT_EDITED on a test order
- [ ] Verify `email_send_log` rows go `pending` → `sent` (no `missing_unsubscribe` 400s)
- [ ] Confirm `email_unsubscribe_tokens` has one row per unique recipient email
- [ ] Click the unsubscribe link in a received email; verify the confirmation page renders and a `suppressed_emails` row is created
- [ ] Re-trigger a notification to that same email; verify it's filtered out by `fanOutNotification`
- [ ] Verify direct enqueue paths (notify-order-event, confirm-order-email) also skip / handle suppression appropriately (current PR only filters in fan-out — direct paths still enqueue, see follow-up note below)

## Follow-up

- Direct enqueue paths in `notify-order-event` and `confirm-order-email` do not yet check `suppressed_emails` before enqueueing. They will still create a token + send the email. Worth a follow-up to extract a single shared `enqueueTransactional` that owns suppression + token + footer in one place. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)