### PR TITLE
Fix ORDER_CONFIRMED recipients & unify order email body format

### DIFF
--- a/supabase/functions/_shared/notifications.ts
+++ b/supabase/functions/_shared/notifications.ts
@@ -107,13 +107,64 @@ export function buildUnsubscribeUrl(token: string): string {
   return `${base.replace(/\/$/, '')}/functions/v1/unsubscribe?token=${encodeURIComponent(token)}`;
 }
 
-function escapeHtml(s: string): string {
+export function escapeHtml(s: string): string {
   return s
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#39;');
+}
+
+// ---------------------------------------------------------------------------
+// Order line item rendering (shared across order email functions)
+// ---------------------------------------------------------------------------
+
+export interface OrderLineItemRow {
+  product_name: string;
+  bag_size_g: number | null;
+  quantity_units: number;
+}
+
+export function formatBagSize(grams: number | null | undefined): string {
+  if (grams == null) return '—';
+  return grams >= 1000 ? `${grams / 1000}kg` : `${grams}g`;
+}
+
+export function renderOrderItemsText(items: OrderLineItemRow[]): string {
+  if (items.length === 0) return '  (no line items)';
+  const header = ['Item', 'Bag Size', 'Quantity'];
+  const rows = items.map((li) => [
+    li.product_name,
+    formatBagSize(li.bag_size_g),
+    String(li.quantity_units),
+  ]);
+  const all = [header, ...rows];
+  const widths = [0, 1, 2].map((c) => Math.max(...all.map((r) => r[c].length)));
+  return all.map((r) => r.map((c, i) => c.padEnd(widths[i])).join('  ')).join('\n');
+}
+
+export function renderOrderItemsHtml(items: OrderLineItemRow[]): string {
+  if (items.length === 0) {
+    return `<tr><td colspan="3" style="padding:6px 0;color:#666;">(no line items)</td></tr>`;
+  }
+  const headerRow =
+    `<tr>` +
+    `<th align="left" style="padding:4px 12px 4px 0;border-bottom:1px solid #ddd;font-size:13px;">Item</th>` +
+    `<th align="left" style="padding:4px 12px 4px 0;border-bottom:1px solid #ddd;font-size:13px;">Bag Size</th>` +
+    `<th align="right" style="padding:4px 0;border-bottom:1px solid #ddd;font-size:13px;">Quantity</th>` +
+    `</tr>`;
+  const bodyRows = items
+    .map(
+      (li) =>
+        `<tr>` +
+        `<td style="padding:4px 12px 4px 0;">${escapeHtml(li.product_name)}</td>` +
+        `<td style="padding:4px 12px 4px 0;">${escapeHtml(formatBagSize(li.bag_size_g))}</td>` +
+        `<td style="padding:4px 0;text-align:right;">${li.quantity_units}</td>` +
+        `</tr>`,
+    )
+    .join('');
+  return headerRow + bodyRows;
 }
 
 /** Inline-able footer lines to append at the end of a transactional email body. */

--- a/supabase/functions/confirm-order-email/index.ts
+++ b/supabase/functions/confirm-order-email/index.ts
@@ -1,6 +1,25 @@
+// Sends the customer-facing ORDER_CONFIRMED email.
+//
+// Recipients are resolved the same way as notify-order-event for
+// ORDER_CONFIRMED:
+//   • Order placer (orders.created_by_user_id)
+//   • Active owners on the order's account (account_users.is_owner=true AND is_active=true)
+// All recipients are filtered through user_notification_preferences for
+// (event_type=ORDER_CONFIRMED, channel=EMAIL). A user with enabled=false is
+// skipped; everyone else (default) receives the email.
+//
+// Notably we do NOT fall back to accounts.billing_email or any other
+// account-level address. Shared mailbox CCs are also gone — orders@homeislandcoffee.com
+// is reserved for ORDER_SUBMITTED.
+
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.91.0";
-import { ensureUnsubscribeToken, unsubscribeFooter } from "../_shared/notifications.ts";
+import {
+  ensureUnsubscribeToken,
+  renderOrderItemsHtml,
+  renderOrderItemsText,
+  unsubscribeFooter,
+} from "../_shared/notifications.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -10,13 +29,16 @@ const corsHeaders = {
 
 const FROM_ADDRESS = "noreply@homeislandcoffee.com";
 const FROM_DISPLAY = "Home Island Manufacturing <noreply@homeislandcoffee.com>";
-const CC_ADDRESS = "orders@homeislandcoffee.com";
 
 interface ConfirmRequest {
   order_id: string;
 }
 
-interface LineItem { product_name: string; quantity_units: number }
+interface LineItem {
+  product_name: string;
+  bag_size_g: number | null;
+  quantity_units: number;
+}
 
 interface ShipTo {
   delivery_method: string | null;
@@ -114,7 +136,7 @@ serve(async (req: Request) => {
 
     const { data: order, error: orderError } = await adminClient
       .from("orders")
-      .select("id, order_number, requested_ship_date, work_deadline, work_deadline_at, account_id, status")
+      .select("id, order_number, requested_ship_date, work_deadline, work_deadline_at, account_id, created_by_user_id, status")
       .eq("id", order_id)
       .maybeSingle();
 
@@ -136,7 +158,7 @@ serve(async (req: Request) => {
 
     const { data: account, error: accountError } = await adminClient
       .from("accounts")
-      .select("account_name, billing_email")
+      .select("account_name")
       .eq("id", order.account_id)
       .maybeSingle();
 
@@ -148,17 +170,9 @@ serve(async (req: Request) => {
       );
     }
 
-    if (!account.billing_email) {
-      console.warn(`[confirm-order-email] Account ${order.account_id} has no billing_email — cannot send`);
-      return new Response(
-        JSON.stringify({ ok: false, error: "Account has no billing email" }),
-        { status: 422, headers: { ...corsHeaders, "Content-Type": "application/json" } }
-      );
-    }
-
     const { data: liRows, error: lineError } = await adminClient
       .from("order_line_items")
-      .select("quantity_units, product:products(product_name)")
+      .select("quantity_units, product:products(product_name, bag_size_g)")
       .eq("order_id", order_id)
       .order("created_at", { ascending: true });
 
@@ -168,6 +182,8 @@ serve(async (req: Request) => {
     const lineItems: LineItem[] = (liRows ?? []).map((li: { quantity_units: number; product: unknown }) => ({
       // deno-lint-ignore no-explicit-any
       product_name: (li.product as any)?.product_name ?? "Unknown Product",
+      // deno-lint-ignore no-explicit-any
+      bag_size_g: (li.product as any)?.bag_size_g ?? null,
       quantity_units: li.quantity_units,
     }));
 
@@ -180,15 +196,62 @@ serve(async (req: Request) => {
       .maybeSingle();
     const ship: ShipTo | null = shipment ?? null;
 
+    // ---- Resolve recipients: placer + active owners, filtered by per-user EMAIL prefs ----
+    const userIds = new Set<string>();
+    if (order.created_by_user_id) userIds.add(order.created_by_user_id);
+    if (order.account_id) {
+      const { data: owners } = await adminClient
+        .from("account_users")
+        .select("user_id")
+        .eq("account_id", order.account_id)
+        .eq("is_owner", true)
+        .eq("is_active", true);
+      // deno-lint-ignore no-explicit-any
+      for (const o of (owners ?? []) as any[]) {
+        if (o?.user_id) userIds.add(o.user_id);
+      }
+    }
+
+    const recipients = new Set<string>();
+    if (userIds.size > 0) {
+      const ids = [...userIds];
+      const [{ data: profiles }, { data: prefs }] = await Promise.all([
+        adminClient.from("profiles").select("user_id, email").in("user_id", ids),
+        adminClient
+          .from("user_notification_preferences")
+          .select("user_id, enabled")
+          .in("user_id", ids)
+          .eq("event_type", "ORDER_CONFIRMED")
+          .eq("channel", "EMAIL"),
+      ]);
+      const disabled = new Set(
+        // deno-lint-ignore no-explicit-any
+        (prefs ?? []).filter((p: any) => p.enabled === false).map((p: any) => p.user_id),
+      );
+      // deno-lint-ignore no-explicit-any
+      for (const p of (profiles ?? []) as any[]) {
+        if (!p?.email) continue;
+        if (disabled.has(p.user_id)) continue;
+        recipients.add(String(p.email).toLowerCase());
+      }
+    }
+
+    if (recipients.size === 0) {
+      console.warn(`[confirm-order-email] No eligible recipients for order ${order_id} — nothing to send`);
+      return new Response(
+        JSON.stringify({ ok: true, enqueued: 0, recipients: [], message: "No eligible recipients" }),
+        { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
     const accountName = account.account_name;
     const orderNumber = order.order_number;
     const roastDay = formatDate(order.work_deadline_at ?? order.work_deadline ?? null);
     const shipDate = formatDate(order.requested_ship_date);
     const shipFmt = formatShipTo(ship);
 
-    const itemsText = lineItems.length === 0
-      ? "  (no line items)"
-      : lineItems.map((li) => `  • ${li.product_name} — ${li.quantity_units} units`).join("\n");
+    const itemsText = renderOrderItemsText(lineItems);
+    const itemRowsHtml = renderOrderItemsHtml(lineItems);
 
     const subject = `Order Confirmed — ${orderNumber} — ${accountName}`;
 
@@ -211,16 +274,6 @@ If you need to make changes, contact us at orders@homeislandcoffee.com.
 
 Thank you,
 Home Island Manufacturing`;
-
-    const itemRowsHtml = lineItems.length === 0
-      ? `<tr><td colspan="2" style="padding:6px 0;color:#666;">(no line items)</td></tr>`
-      : lineItems
-          .map(
-            (li) =>
-              `<tr><td style="padding:4px 12px 4px 0;">${escapeHtml(li.product_name)}</td>` +
-              `<td style="padding:4px 0;text-align:right;">${li.quantity_units} units</td></tr>`,
-          )
-          .join("");
 
     const emailHtml = `<!doctype html>
 <html><body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;color:#222;max-width:600px;margin:0 auto;padding:24px;">
@@ -296,24 +349,29 @@ Home Island Manufacturing`;
       return { ok: true, message_id: messageId };
     }
 
-    const primary = await enqueueOne(account.billing_email);
-    if (!primary.ok) {
-      console.error("[confirm-order-email] Failed to enqueue primary:", primary.error);
-      return new Response(
-        JSON.stringify({ ok: false, error: "Failed to enqueue email" }),
-        { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
-      );
+    const results: { recipient: string; ok: boolean; message_id: string; error?: string }[] = [];
+    for (const r of recipients) {
+      const result = await enqueueOne(r);
+      results.push({ recipient: r, ...result });
     }
 
-    const ccCopy = await enqueueOne(CC_ADDRESS);
-    if (!ccCopy.ok) {
-      console.warn("[confirm-order-email] Failed to enqueue CC copy (non-fatal):", ccCopy.error);
-    }
+    const enqueued = results.filter((r) => r.ok).length;
+    const errors = results.filter((r) => !r.ok).map((r) => `${r.recipient}: ${r.error}`);
 
-    console.log(`[confirm-order-email] Enqueued confirmation for order ${orderNumber} → ${account.billing_email} (cc copy: ${CC_ADDRESS})`);
+    console.log(
+      `[confirm-order-email] order ${orderNumber} → enqueued=${enqueued}/${recipients.size} recipients=[${[...recipients].join(",")}]`,
+    );
+    if (errors.length > 0) {
+      console.warn(`[confirm-order-email] errors:`, errors);
+    }
 
     return new Response(
-      JSON.stringify({ ok: true, message_id: primary.message_id, cc_message_id: ccCopy.message_id }),
+      JSON.stringify({
+        ok: true,
+        enqueued,
+        recipients: [...recipients],
+        errors,
+      }),
       { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } }
     );
   } catch (err) {

--- a/supabase/functions/notify-new-order/index.ts
+++ b/supabase/functions/notify-new-order/index.ts
@@ -1,6 +1,12 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.91.0";
-import { ensureUnsubscribeToken, fanOutNotification, unsubscribeFooter } from "../_shared/notifications.ts";
+import {
+  ensureUnsubscribeToken,
+  fanOutNotification,
+  renderOrderItemsHtml,
+  renderOrderItemsText,
+  unsubscribeFooter,
+} from "../_shared/notifications.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -35,7 +41,7 @@ function formatDate(d: string | null): string {
   }
 }
 
-interface LineItem { product_name: string; quantity_units: number }
+interface LineItem { product_name: string; bag_size_g: number | null; quantity_units: number }
 
 interface ShipTo {
   delivery_method: string | null;
@@ -277,13 +283,15 @@ serve(async (req: Request) => {
     // Line items
     const { data: liRows, error: liErr } = await adminClient
       .from("order_line_items")
-      .select("quantity_units, product:products(product_name)")
+      .select("quantity_units, product:products(product_name, bag_size_g)")
       .eq("order_id", order.id)
       .order("created_at", { ascending: true });
     if (liErr) console.warn("[notify-new-order] Line items fetch error:", liErr.message);
     const lineItems: LineItem[] = (liRows ?? []).map((li: { quantity_units: number; product: unknown }) => ({
       // deno-lint-ignore no-explicit-any
       product_name: (li.product as any)?.product_name ?? "Unknown Product",
+      // deno-lint-ignore no-explicit-any
+      bag_size_g: (li.product as any)?.bag_size_g ?? null,
       quantity_units: li.quantity_units,
     }));
 
@@ -301,9 +309,7 @@ serve(async (req: Request) => {
     const submitterLine = submittedByName ? `Submitted by: ${submittedByName}` : null;
     const shipFmt = formatShipTo(ship);
 
-    const itemsText = lineItems.length === 0
-      ? "  (no line items)"
-      : lineItems.map((li) => `  • ${li.product_name} — ${li.quantity_units} units`).join("\n");
+    const itemsText = renderOrderItemsText(lineItems);
 
     const text = [
       `A new order has been submitted.`,
@@ -320,19 +326,9 @@ serve(async (req: Request) => {
       shipFmt.text,
       ``,
       `If you need to make changes, contact us at orders@homeislandcoffee.com.`,
-      ``,
-      `Open order: /internal/orders/${order.id}`,
     ].filter((l) => l !== null).join("\n");
 
-    const itemRowsHtml = lineItems.length === 0
-      ? `<tr><td colspan="2" style="padding:6px 0;color:#666;">(no line items)</td></tr>`
-      : lineItems
-          .map(
-            (li) =>
-              `<tr><td style="padding:4px 12px 4px 0;">${escapeHtml(li.product_name)}</td>` +
-              `<td style="padding:4px 0;text-align:right;">${li.quantity_units} units</td></tr>`,
-          )
-          .join("");
+    const itemRowsHtml = renderOrderItemsHtml(lineItems);
 
     const subject = `New order ${order.order_number} — ${clientName}`;
     const html = `<!doctype html>
@@ -350,7 +346,6 @@ serve(async (req: Request) => {
   <h3 style="margin:16px 0 8px 0;font-size:14px;">Delivery</h3>
   <p style="margin:0 0 16px 0;">${shipFmt.html}</p>
   <p style="margin:16px 0 8px 0;color:#666;font-size:13px;">If you need to make changes, contact us at <a href="mailto:orders@homeislandcoffee.com">orders@homeislandcoffee.com</a>.</p>
-  <p style="margin:0;font-size:13px;">Open order: /internal/orders/${escapeHtml(order.id)}</p>
 </body></html>`;
 
     // ========== EMAIL FAN-OUT ==========

--- a/supabase/functions/notify-order-event/index.ts
+++ b/supabase/functions/notify-order-event/index.ts
@@ -5,7 +5,8 @@
 // Recipients:
 //   • Order placer (created_by_user_id) — email pulled from profiles
 //   • Account owners (account_users where is_owner = true and is_active = true)
-//   • Shared mailbox (orders@homeislandcoffee.com) — for SHARED_MAILBOX_EVENTS
+//   • Shared mailbox: ONLY when an admin has wired one in via
+//     app_settings.notification_routes.<EVENT>. No hardcoded fallback.
 //
 // Per-user EMAIL preferences are respected. If the user has an explicit
 // pref row for (event_type, channel='EMAIL') with enabled=false, they are
@@ -13,7 +14,12 @@
 
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.91.0";
-import { ensureUnsubscribeToken, unsubscribeFooter } from "../_shared/notifications.ts";
+import {
+  ensureUnsubscribeToken,
+  renderOrderItemsHtml,
+  renderOrderItemsText,
+  unsubscribeFooter,
+} from "../_shared/notifications.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -33,20 +39,18 @@ interface NotifyBody {
   details?: string;
 }
 
-const SHARED_MAILBOX_EVENTS: OrderEventType[] = [
-  "ORDER_CONFIRMED",
-  "ORDER_SHIPPED",
-  "ORDER_CANCELLED",
-  "ORDER_CLIENT_EDITED",
-];
-
-const FALLBACK_SHARED_MAILBOX = "orders@homeislandcoffee.com";
+// orders@homeislandcoffee.com is ONLY a hardcoded recipient for ORDER_SUBMITTED
+// (handled by notify-new-order). It must NOT be added for any of the events
+// this function handles. Per-user EMAIL preferences are the sole recipient
+// source here; the only exception is an explicit app_settings override row
+// keyed `notification_routes.<EVENT>`.
 
 const FROM_DISPLAY = "Home Island Coffee Partners <noreply@notify.homeislandcoffee.com>";
 const FROM_DOMAIN = "notify.homeislandcoffee.com";
 
 interface LineItem {
   product_name: string;
+  bag_size_g: number | null;
   quantity_units: number;
 }
 
@@ -130,7 +134,6 @@ function buildText(
   lineItems: LineItem[],
   ship: ShipTo | null,
   details: string | undefined,
-  origin: string,
 ): string {
   const lines: string[] = [];
   lines.push(eventHeadline(event, orderNumber, accountName));
@@ -140,8 +143,7 @@ function buildText(
   lines.push(`Requested ship date: ${formatDate(requestedShipDate)}`);
   lines.push("");
   lines.push("Items:");
-  if (lineItems.length === 0) lines.push("  (no line items)");
-  else for (const li of lineItems) lines.push(`  • ${li.product_name} — ${li.quantity_units} units`);
+  lines.push(renderOrderItemsText(lineItems));
   lines.push("");
   const shipFmt = formatShipTo(ship);
   lines.push("Delivery:");
@@ -152,8 +154,6 @@ function buildText(
   }
   lines.push("");
   lines.push("If you need to make changes, contact us at orders@homeislandcoffee.com.");
-  lines.push("");
-  lines.push(`View order: ${origin}/internal/orders/`);
   return lines.join("\n");
 }
 
@@ -165,18 +165,9 @@ function buildHtml(
   lineItems: LineItem[],
   ship: ShipTo | null,
   details: string | undefined,
-  origin: string,
 ): string {
   const shipFmt = formatShipTo(ship);
-  const itemRows = lineItems.length === 0
-    ? `<tr><td colspan="2" style="padding:6px 0;color:#666;">(no line items)</td></tr>`
-    : lineItems
-        .map(
-          (li) =>
-            `<tr><td style="padding:4px 12px 4px 0;">${escapeHtml(li.product_name)}</td>` +
-            `<td style="padding:4px 0;text-align:right;">${li.quantity_units} units</td></tr>`,
-        )
-        .join("");
+  const itemRows = renderOrderItemsHtml(lineItems);
 
   return `<!doctype html>
 <html><body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;color:#222;max-width:600px;margin:0 auto;padding:24px;">
@@ -200,7 +191,6 @@ function buildHtml(
   ${details ? `<p style="margin:0 0 16px 0;"><strong>Notes:</strong> ${escapeHtml(details)}</p>` : ""}
 
   <p style="margin:16px 0 8px 0;color:#666;font-size:13px;">If you need to make changes, contact us at <a href="mailto:orders@homeislandcoffee.com">orders@homeislandcoffee.com</a>.</p>
-  <p style="margin:0;font-size:13px;"><a href="${escapeHtml(origin)}/internal/orders/">View order</a></p>
 </body></html>`;
 }
 
@@ -332,12 +322,14 @@ serve(async (req: Request) => {
     // Line items
     const { data: liRows } = await adminClient
       .from("order_line_items")
-      .select("quantity_units, product:products(product_name)")
+      .select("quantity_units, product:products(product_name, bag_size_g)")
       .eq("order_id", order.id)
       .order("created_at", { ascending: true });
     const lineItems: LineItem[] = (liRows ?? []).map((li: { quantity_units: number; product: unknown }) => ({
       // deno-lint-ignore no-explicit-any
       product_name: (li.product as any)?.product_name ?? "Unknown Product",
+      // deno-lint-ignore no-explicit-any
+      bag_size_g: (li.product as any)?.bag_size_g ?? null,
       quantity_units: li.quantity_units,
     }));
 
@@ -388,9 +380,11 @@ serve(async (req: Request) => {
       }
     }
 
-    // Shared mailbox: app_settings override, else hardcoded fallback for SHARED_MAILBOX_EVENTS.
-    if (SHARED_MAILBOX_EVENTS.includes(body.event_type)) {
-      let sharedAdded: string | null = null;
+    // Shared mailbox: only honor an explicit app_settings override row. No
+    // hardcoded fallback. orders@homeislandcoffee.com is reserved for
+    // ORDER_SUBMITTED (notify-new-order) and must not appear on other events
+    // unless an admin has wired it in via notification_routes.<EVENT>.
+    {
       const { data: setting } = await adminClient
         .from("app_settings")
         .select("value_json")
@@ -399,20 +393,16 @@ serve(async (req: Request) => {
       // deno-lint-ignore no-explicit-any
       const v = setting?.value_json as any;
       if (v?.enabled && v?.shared_email) {
-        sharedAdded = String(v.shared_email).toLowerCase();
-        recipients.add(sharedAdded);
-      } else {
-        sharedAdded = FALLBACK_SHARED_MAILBOX;
-        recipients.add(FALLBACK_SHARED_MAILBOX);
+        const shared = String(v.shared_email).toLowerCase();
+        recipients.add(shared);
+        console.log(`[notify-order-event] shared mailbox override: ${shared}`);
       }
-      console.log(`[notify-order-event] shared mailbox: ${sharedAdded}`);
     }
 
-    const origin = req.headers.get("origin") ?? "https://homeislandcoffeepartners.lovable.app";
     const subject = buildSubject(body.event_type, order.order_number, accountName);
     const requestedShip = order.requested_ship_date ?? order.work_deadline ?? null;
-    const text = buildText(body.event_type, order.order_number, accountName, requestedShip, lineItems, ship, body.details, origin);
-    const html = buildHtml(body.event_type, order.order_number, accountName, requestedShip, lineItems, ship, body.details, origin);
+    const text = buildText(body.event_type, order.order_number, accountName, requestedShip, lineItems, ship, body.details);
+    const html = buildHtml(body.event_type, order.order_number, accountName, requestedShip, lineItems, ship, body.details);
     const label = `order_${body.event_type.toLowerCase().replace(/^order_/, "")}_notification`;
 
     console.log(`[notify-order-event] recipients=${[...recipients].join(",")}`);


### PR DESCRIPTION
## Summary
- **Recipient bug**: ORDER_CONFIRMED emails were leaking to `orders@homeislandcoffee.com` and to `accounts.billing_email` (e.g. `info@oldhandcoffee.com`). Two culprits:
  - `notify-order-event` unconditionally added the shared mailbox as a fallback for all four order events.
  - `confirm-order-email` sent directly to `accounts.billing_email` and CC'd `orders@homeislandcoffee.com`, ignoring per-user prefs entirely.
- **Body bug**: line items rendered as a flat `Dopamine — 13 units` list with a `View order` link.

## Changes
- `notify-order-event`: remove `SHARED_MAILBOX_EVENTS` list + `FALLBACK_SHARED_MAILBOX`. Only an explicit `app_settings.notification_routes.<EVENT>` override can add a shared recipient. `orders@…` is now reserved for `ORDER_SUBMITTED` (handled by `notify-new-order`).
- `confirm-order-email`: resolve recipients the same way `notify-order-event` does for `ORDER_CONFIRMED` — placer (`orders.created_by_user_id`) + active owners (`account_users.is_owner=true AND is_active=true`), then filter through `user_notification_preferences (ORDER_CONFIRMED, EMAIL, enabled != false)`. Drops `billing_email` send and CC to shared mailbox entirely.
- Body unified across `notify-order-event`, `notify-new-order`, `confirm-order-email`:
  - Items now a proper three-column table: **Item | Bag Size | Quantity** (bag size from `products.bag_size_g`, formatted as `Ng` or `Nkg`).
  - "View order" / "Open order" link removed.
  - Renderers (`renderOrderItemsText`, `renderOrderItemsHtml`, `formatBagSize`) live in `_shared/notifications.ts` so the three functions stay in sync.

## Test plan
- [ ] Deploy edge functions (`notify-order-event`, `notify-new-order`, `confirm-order-email`, `_shared`).
- [ ] Submit a test order as a CLIENT user → confirm `orders@homeislandcoffee.com` still receives `ORDER_SUBMITTED`.
- [ ] Confirm a test order (both via OrderDetail confirm button and via OrderEditModal status change). Verify:
  - `orders@homeislandcoffee.com` does **not** receive a copy.
  - `info@oldhandcoffee.com` (or any other `accounts.billing_email`) does **not** receive a copy unless that address is a real user on the account with `ORDER_CONFIRMED`/EMAIL pref enabled.
  - The placing user and active account owners do receive it.
- [ ] Verify all three emails now show the three-column items table with bag size and no "View order" link.
- [ ] Verify shipping an order still emails the correct people, no shared mailbox copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)