### PR TITLE
feat(last-mile): manual order click-through, inventory views, drop grind from ordering

### DIFF
--- a/src/components/internal/OrderEditModal.tsx
+++ b/src/components/internal/OrderEditModal.tsx
@@ -85,7 +85,6 @@ export function OrderEditModal({
   const [editedShipments, setEditedShipments] = useState<ShipmentDraft[]>([]);
   const [newLineProductId, setNewLineProductId] = useState<string>('');
   const [newLineQuantity, setNewLineQuantity] = useState<number>(1);
-  const [newLineGrind, setNewLineGrind] = useState<GrindOption>('WHOLE_BEAN');
 
   // Load existing shipments when the modal opens.
   const { data: existingShipments } = useQuery({
@@ -249,7 +248,7 @@ export function OrderEditModal({
             order_id: order.id,
             product_id: li.product_id,
             quantity_units: li.quantity_units,
-            grind: li.grind,
+            grind: null,
             unit_price_locked: li.unit_price_locked,
             shipment_id: resolveShipmentId(li.shipment_id),
           });
@@ -259,7 +258,6 @@ export function OrderEditModal({
             .from('order_line_items')
             .update({
               quantity_units: li.quantity_units,
-              grind: li.grind,
               shipment_id: resolveShipmentId(li.shipment_id),
             })
             .eq('id', li.id);
@@ -358,7 +356,7 @@ export function OrderEditModal({
         product_id: newLineProductId,
         product_name: product.product_name,
         quantity_units: newLineQuantity,
-        grind: newLineGrind,
+        grind: null,
         unit_price_locked: price,
         shipment_id: defaultShipmentId,
         isNew: true,
@@ -367,7 +365,6 @@ export function OrderEditModal({
     ]);
     setNewLineProductId('');
     setNewLineQuantity(1);
-    setNewLineGrind('WHOLE_BEAN');
   };
 
   const handleRemoveLineItem = (itemId: string) => {
@@ -379,12 +376,6 @@ export function OrderEditModal({
   const handleQuantityChange = (itemId: string, quantity: number) => {
     setEditedLineItems((items) =>
       items.map((li) => (li.id === itemId ? { ...li, quantity_units: Math.max(1, quantity) } : li)),
-    );
-  };
-
-  const handleGrindChange = (itemId: string, grind: GrindOption | null) => {
-    setEditedLineItems((items) =>
-      items.map((li) => (li.id === itemId ? { ...li, grind } : li)),
     );
   };
 
@@ -588,20 +579,6 @@ export function OrderEditModal({
                       className="w-20 h-8"
                     />
 
-                    <Select
-                      value={li.grind ?? 'WHOLE_BEAN'}
-                      onValueChange={(v) => handleGrindChange(li.id, v as GrindOption)}
-                    >
-                      <SelectTrigger className="w-28 h-8">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="WHOLE_BEAN">Whole Bean</SelectItem>
-                        <SelectItem value="ESPRESSO">Espresso</SelectItem>
-                        <SelectItem value="FILTER">Filter</SelectItem>
-                      </SelectContent>
-                    </Select>
-
                     {activeShipments.length > 0 && (
                       <Select
                         value={li.shipment_id ?? activeShipments[0]?.id ?? ''}
@@ -665,22 +642,6 @@ export function OrderEditModal({
                 />
               </div>
 
-              <div className="w-28 space-y-1">
-                <Label className="text-xs">Grind</Label>
-                <Select
-                  value={newLineGrind}
-                  onValueChange={(v) => setNewLineGrind(v as GrindOption)}
-                >
-                  <SelectTrigger className="h-8">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="WHOLE_BEAN">Whole Bean</SelectItem>
-                    <SelectItem value="ESPRESSO">Espresso</SelectItem>
-                    <SelectItem value="FILTER">Filter</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
 
               <Button
                 size="sm"

--- a/src/components/production/ShipTab.tsx
+++ b/src/components/production/ShipTab.tsx
@@ -27,7 +27,6 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { PackagingBadge, type PackagingVariant } from '@/components/PackagingBadge';
 import { SortableShipCard } from './SortableShipCard';
 import { format, addDays, parseISO } from 'date-fns';
-import type { Database } from '@/integrations/supabase/types';
 import type { DateFilterConfig } from './types';
 // Use AUTHORITATIVE inventory hooks - computed from source-of-truth tables
 import { useAuthoritativeFg, useAuthoritativeShortList } from '@/hooks/useAuthoritativeInventory';
@@ -35,7 +34,6 @@ import { AuthoritativeSummaryPanel } from './AuthoritativeTotals';
 import { filterOrderByWorkStart } from '@/lib/productionScheduling';
 
 type ShipPriority = 'NORMAL' | 'TIME_SENSITIVE';
-type OrderStatus = Database['public']['Enums']['order_status'];
 
 interface ShipTabProps {
   dateFilterConfig: DateFilterConfig;
@@ -544,19 +542,26 @@ export function ShipTab({ dateFilterConfig, today }: ShipTabProps) {
     },
   });
 
+  // Route through the update_order_status RPC (validates transition, writes the
+  // audit log, sets shipped_or_ready atomically) so this matches the OrderDetail
+  // path instead of a raw orders.update that bypassed all of that.
   const markOrderShippedMutation = useMutation({
     mutationFn: async (orderId: string) => {
-      const { error } = await supabase
-        .from('orders')
-        .update({ status: 'SHIPPED' as OrderStatus, shipped_or_ready: true })
-        .eq('id', orderId);
+      const { error } = await supabase.rpc('update_order_status' as any, {
+        p_order_id: orderId,
+        p_target_status: 'SHIPPED',
+      });
       if (error) throw error;
+      return orderId;
     },
-    onSuccess: () => {
+    onSuccess: (orderId) => {
       toast.success('Order marked as shipped');
       queryClient.invalidateQueries({ queryKey: ['shippable-orders'] });
       queryClient.invalidateQueries({ queryKey: ['shipped-awaiting-invoice'] });
       queryClient.invalidateQueries({ queryKey: ['orders'] });
+      supabase.functions.invoke('notify-order-event', {
+        body: { order_id: orderId, event_type: 'ORDER_SHIPPED' },
+      }).catch((e) => console.warn('[notify-order-event] SHIPPED failed:', e));
     },
     onError: (err) => {
       console.error(err);

--- a/src/pages/client/NewOrder.tsx
+++ b/src/pages/client/NewOrder.tsx
@@ -24,15 +24,13 @@ import { useClientOrderingConstraints, validateCaseQuantity } from '@/hooks/useC
 import { usePricingVisibility } from '@/hooks/usePricingVisibility';
 import { blockNonIntegerKeys } from '@/lib/numericInput';
 import { DatePicker } from '@/components/ui/date-picker';
-import type { GrindOption, DeliveryMethod } from '@/types/database';
+import type { DeliveryMethod } from '@/types/database';
 
 interface LineItem {
   productId: string;
   productName: string;
   displayName: string;
   quantity: number;
-  grind: GrindOption | null;
-  grindOptions: GrindOption[];
   price: number | null;
   packagingTypeName: string | null;
   gramsPerUnit: number | null;
@@ -84,7 +82,6 @@ interface Product {
   bag_size_g: number;
   grams_per_unit: number | null;
   format: string;
-  grind_options: GrindOption[];
   is_perennial: boolean;
   packaging_type_id: string | null;
   packaging_types: { name: string } | null;
@@ -142,7 +139,7 @@ export default function NewOrder() {
     queryFn: async () => {
       let query = supabase
         .from('products')
-        .select('id, product_name, sku, bag_size_g, grams_per_unit, format, grind_options, is_perennial, packaging_type_id, packaging_types(name)')
+        .select('id, product_name, sku, bag_size_g, grams_per_unit, format, is_perennial, packaging_type_id, packaging_types(name)')
         .eq('is_active', true)
         .order('product_name', { ascending: true });
 
@@ -205,17 +202,14 @@ export default function NewOrder() {
   const getLineItem = (productId: string) => lineItems.find((li) => li.productId === productId);
 
   const createLineItem = (product: Product, qty: number): LineItem => {
-    const grindOpts = (product.grind_options ?? []) as GrindOption[];
     const packagingTypeName = product.packaging_types?.name ?? null;
     const gramsPerUnit = product.grams_per_unit;
-    
+
     return {
       productId: product.id,
       productName: product.product_name,
       displayName: buildDisplayName(product.product_name, packagingTypeName, gramsPerUnit),
       quantity: qty,
-      grind: grindOpts.length > 0 ? grindOpts[0] : null,
-      grindOptions: grindOpts,
       price: prices?.[product.id] ?? null,
       packagingTypeName,
       gramsPerUnit,
@@ -245,12 +239,6 @@ export default function NewOrder() {
     }
     setLineItems((prev) =>
       prev.map((li) => (li.productId === productId ? { ...li, quantity: qty } : li))
-    );
-  };
-
-  const updateGrind = (productId: string, grind: GrindOption) => {
-    setLineItems((prev) =>
-      prev.map((li) => (li.productId === productId ? { ...li, grind } : li))
     );
   };
 
@@ -548,7 +536,7 @@ export default function NewOrder() {
           order_id: order.id,
           product_id: li.productId,
           quantity_units: li.quantity,
-          grind: li.grind,
+          grind: null,
           unit_price_locked: li.price!,
           shipment_id: targetShipmentId,
         };

--- a/src/pages/internal/CreateOrderForClient.tsx
+++ b/src/pages/internal/CreateOrderForClient.tsx
@@ -18,7 +18,6 @@ import { GramPackagingBadge, formatGramsLabel } from '@/components/GramPackaging
 import { useClientOrderingConstraints } from '@/hooks/useClientOrderingConstraints';
 import { WorkDeadlinePicker } from '@/components/orders/WorkDeadlinePicker';
 import { DatePicker } from '@/components/ui/date-picker';
-import type { GrindOption } from '@/types/database';
 import type { Database } from '@/integrations/supabase/types';
 import { LocationSelect } from '@/components/orders/LocationSelect';
 import { OrderContextBanner } from '@/components/orders/OrderContextBanner';
@@ -31,8 +30,6 @@ interface LineItem {
   productName: string;
   displayName: string;
   quantity: number;
-  grind: GrindOption | null;
-  grindOptions: GrindOption[];
   price: number | null;
   packagingTypeName: string | null;
   gramsPerUnit: number | null;
@@ -45,7 +42,6 @@ interface Product {
   bag_size_g: number;
   grams_per_unit: number | null;
   format: string;
-  grind_options: GrindOption[];
   is_perennial: boolean;
   packaging_type_id: string | null;
   packaging_types: { name: string } | null;
@@ -149,7 +145,7 @@ export default function CreateOrderForClient() {
       if (!selectedClientId) return [];
       const { data, error } = await supabase
         .from('products')
-        .select('id, product_name, sku, bag_size_g, grams_per_unit, format, grind_options, is_perennial, packaging_type_id, packaging_types(name), client_id, account_id')
+        .select('id, product_name, sku, bag_size_g, grams_per_unit, format, is_perennial, packaging_type_id, packaging_types(name), client_id, account_id')
         .eq('account_id', selectedClientId)
         .eq('is_active', true)
         .order('product_name', { ascending: true });
@@ -239,17 +235,14 @@ export default function CreateOrderForClient() {
   const getLineItem = (productId: string) => lineItems.find((li) => li.productId === productId);
 
   const createLineItem = (product: Product, qty: number): LineItem => {
-    const grindOpts = (product.grind_options ?? []) as GrindOption[];
     const packagingTypeName = product.packaging_types?.name ?? null;
     const gramsPerUnit = product.grams_per_unit;
-    
+
     return {
       productId: product.id,
       productName: product.product_name,
       displayName: buildDisplayName(product.product_name, packagingTypeName, gramsPerUnit),
       quantity: qty,
-      grind: grindOpts.length > 0 ? grindOpts[0] : null,
-      grindOptions: grindOpts,
       price: effectivePrice(product.id).price,
       packagingTypeName,
       gramsPerUnit,
@@ -276,12 +269,6 @@ export default function CreateOrderForClient() {
     }
     setLineItems((prev) =>
       prev.map((li) => (li.productId === productId ? { ...li, quantity: qty } : li))
-    );
-  };
-
-  const updateGrind = (productId: string, grind: GrindOption) => {
-    setLineItems((prev) =>
-      prev.map((li) => (li.productId === productId ? { ...li, grind } : li))
     );
   };
 
@@ -399,7 +386,7 @@ export default function CreateOrderForClient() {
         order_id: order.id,
         product_id: li.productId,
         quantity_units: li.quantity,
-        grind: li.grind,
+        grind: null,
         unit_price_locked: li.price!,
         shipment_id: defaultShipment?.id ?? null,
       }));
@@ -705,18 +692,6 @@ export default function CreateOrderForClient() {
                           />
                         </div>
                         <div className="flex items-center gap-2 shrink-0">
-                          {li.grindOptions.length > 0 && (
-                            <Select value={li.grind ?? ''} onValueChange={(v) => updateGrind(li.productId, v as GrindOption)}>
-                              <SelectTrigger className="h-7 w-24 text-xs">
-                                <SelectValue />
-                              </SelectTrigger>
-                              <SelectContent>
-                                {li.grindOptions.map((g) => (
-                                  <SelectItem key={g} value={g}>{g}</SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
-                          )}
                           <span className="w-8 text-center">{li.quantity}</span>
                           <span className="w-16 text-right">${((li.price ?? 0) * li.quantity).toFixed(2)}</span>
                           <Button

--- a/src/pages/internal/Inventory.tsx
+++ b/src/pages/internal/Inventory.tsx
@@ -85,6 +85,10 @@ export default function Inventory() {
   // WIP Floor Count modal
   const [floorCountOpen, setFloorCountOpen] = useState(false);
 
+  // "Available only" view filters: roasted-not-packed (WIP) and finished-not-picked (FG)
+  const [wipAvailableOnly, setWipAvailableOnly] = useState(true);
+  const [fgAvailableOnly, setFgAvailableOnly] = useState(true);
+
   // ===== WIP Tab Queries =====
   
   // Fetch roast groups to identify blends
@@ -443,6 +447,28 @@ export default function Inventory() {
     setAbsoluteAdjustOpen(true);
   };
 
+  // Roasted-not-packed view: roast groups with positive net WIP awaiting packing.
+  const wipAvailableRows = useMemo(
+    () => wipByRoastGroup.filter((r) => r.net_wip_kg > 0),
+    [wipByRoastGroup],
+  );
+  const wipDisplayRows = wipAvailableOnly ? wipAvailableRows : wipByRoastGroup;
+  const wipAvailableTotalKg = useMemo(
+    () => wipAvailableRows.reduce((sum, r) => sum + r.net_wip_kg, 0),
+    [wipAvailableRows],
+  );
+
+  // Finished-not-picked view: products with packed units on hand not yet shipped.
+  const fgAvailableRows = useMemo(
+    () => (fgInventory ?? []).filter((r) => r.units_on_hand > 0),
+    [fgInventory],
+  );
+  const fgDisplayRows = fgAvailableOnly ? fgAvailableRows : (fgInventory ?? []);
+  const fgAvailableUnits = useMemo(
+    () => fgAvailableRows.reduce((sum, r) => sum + r.units_on_hand, 0),
+    [fgAvailableRows],
+  );
+
   return (
     <div className="p-6 space-y-6">
       <GreenCoffeeAlerts />
@@ -491,37 +517,52 @@ export default function Inventory() {
                   <p className="text-xs text-muted-foreground">
                     For post-roast blends, WIP is created when components are blended, not when components are roasted.
                   </p>
+                  <p className="mt-2 text-sm font-medium">
+                    {wipAvailableTotalKg.toFixed(1)} kg roasted awaiting packing across {wipAvailableRows.length}{' '}
+                    {wipAvailableRows.length === 1 ? 'group' : 'groups'}
+                  </p>
                 </div>
-                {isAdminOrOps && (
-                  <div className="flex gap-2 shrink-0">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => {
-                        setPickerGroup('');
-                        setPickerOpen(true);
-                      }}
-                    >
-                      <Plus className="h-4 w-4" />
-                      Add WIP for roast group
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => setFloorCountOpen(true)}
-                    >
-                      <Scale className="h-4 w-4" />
-                      Floor Count
-                    </Button>
-                  </div>
-                )}
+                <div className="flex items-center gap-2 shrink-0">
+                  <Button
+                    variant={wipAvailableOnly ? 'default' : 'outline'}
+                    size="sm"
+                    onClick={() => setWipAvailableOnly((v) => !v)}
+                  >
+                    {wipAvailableOnly ? 'Showing available' : 'Show all'}
+                  </Button>
+                  {isAdminOrOps && (
+                    <>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => {
+                          setPickerGroup('');
+                          setPickerOpen(true);
+                        }}
+                      >
+                        <Plus className="h-4 w-4" />
+                        Add WIP for roast group
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setFloorCountOpen(true)}
+                      >
+                        <Scale className="h-4 w-4" />
+                        Floor Count
+                      </Button>
+                    </>
+                  )}
+                </div>
               </div>
             </CardHeader>
             <CardContent>
-              {wipByRoastGroup.length === 0 ? (
+              {wipDisplayRows.length === 0 ? (
                 <div className="py-6">
                   <p className="text-muted-foreground">
-                    No WIP data available. Use “Add WIP for roast group” above to enter an opening balance.
+                    {wipAvailableOnly && wipByRoastGroup.length > 0
+                      ? 'No roasted coffee is currently awaiting packing. Toggle “Show all” to see fully-consumed groups.'
+                      : 'No WIP data available. Use “Add WIP for roast group” above to enter an opening balance.'}
                   </p>
                 </div>
               ) : (
@@ -537,7 +578,7 @@ export default function Inventory() {
                     </tr>
                   </thead>
                   <tbody>
-                    {wipByRoastGroup.map((row) => (
+                    {wipDisplayRows.map((row) => (
                       <tr key={row.roast_group} className="border-b">
                         <td className="py-3 font-medium">{row.roast_group}</td>
                         <td className="py-3 text-right">{row.roasted_kg.toFixed(1)} kg</td>
@@ -594,13 +635,33 @@ export default function Inventory() {
         <TabsContent value="fg" className="mt-4">
           <Card>
             <CardHeader>
-              <CardTitle className="text-lg">Finished Goods Inventory</CardTitle>
-              <p className="text-sm text-muted-foreground">
-                Packed units on hand by product
-              </p>
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <CardTitle className="text-lg">Finished Goods Inventory</CardTitle>
+                  <p className="text-sm text-muted-foreground">
+                    Packed units on hand by product
+                  </p>
+                  <p className="mt-2 text-sm font-medium">
+                    {fgAvailableUnits} {fgAvailableUnits === 1 ? 'unit' : 'units'} finished awaiting pick across{' '}
+                    {fgAvailableRows.length} {fgAvailableRows.length === 1 ? 'product' : 'products'}
+                  </p>
+                </div>
+                <Button
+                  variant={fgAvailableOnly ? 'default' : 'outline'}
+                  size="sm"
+                  className="shrink-0"
+                  onClick={() => setFgAvailableOnly((v) => !v)}
+                >
+                  {fgAvailableOnly ? 'Showing available' : 'Show all'}
+                </Button>
+              </div>
             </CardHeader>
             <CardContent>
-              {fgInventory?.length === 0 && allProducts?.length === 0 ? (
+              {fgAvailableOnly && fgDisplayRows.length === 0 ? (
+                <p className="text-muted-foreground py-4">
+                  No finished goods are currently awaiting pick. Toggle “Show all” to see every product.
+                </p>
+              ) : !fgAvailableOnly && fgInventory?.length === 0 && allProducts?.length === 0 ? (
                 <p className="text-muted-foreground py-4">No products configured.</p>
               ) : (
                 <table className="w-full text-sm">
@@ -615,7 +676,7 @@ export default function Inventory() {
                   </thead>
                   <tbody>
                     {/* Show products that have FG inventory */}
-                    {fgInventory?.map((row) => (
+                    {fgDisplayRows.map((row) => (
                       <FgInventoryRow
                         key={row.id}
                         row={row}
@@ -623,8 +684,8 @@ export default function Inventory() {
                         onSet={(value) => handleFgSet(row.product_id, row.units_on_hand, value)}
                       />
                     ))}
-                    {/* Show products without FG inventory (units = 0) */}
-                    {allProducts
+                    {/* Show products without FG inventory (units = 0) — only in the "show all" view */}
+                    {!fgAvailableOnly && allProducts
                       ?.filter(p => !fgInventory?.some(fg => fg.product_id === p.id))
                       .map((product) => (
                         <tr key={product.id} className="border-b text-muted-foreground">

--- a/src/pages/internal/OrderDetail.tsx
+++ b/src/pages/internal/OrderDetail.tsx
@@ -25,9 +25,30 @@ import { OrderEditModal } from '@/components/internal/OrderEditModal';
 import { OrderDateAuditHistory } from '@/components/internal/OrderDateAuditHistory';
 import { WorkDeadlinePicker } from '@/components/orders/WorkDeadlinePicker';
 import { OrderDeleteModal } from '@/components/internal/OrderDeleteModal';
+import { ALLOWED_ORDER_TRANSITIONS } from '@/lib/orderTransitions';
 import type { Database } from '@/integrations/supabase/types';
 
 type OrderStatus = Database['public']['Enums']['order_status'];
+
+// Linear fulfillment ladder for the status stepper (CANCELLED is off-ladder).
+const PRODUCTION_LADDER: OrderStatus[] = [
+  'DRAFT',
+  'SUBMITTED',
+  'CONFIRMED',
+  'IN_PRODUCTION',
+  'READY',
+  'SHIPPED',
+];
+
+const STATUS_LABEL: Record<OrderStatus, string> = {
+  DRAFT: 'Draft',
+  SUBMITTED: 'Submitted',
+  CONFIRMED: 'Confirmed',
+  IN_PRODUCTION: 'In Production',
+  READY: 'Ready',
+  SHIPPED: 'Shipped',
+  CANCELLED: 'Cancelled',
+};
 
 interface PackingRun {
   product_id: string;
@@ -228,9 +249,11 @@ export default function OrderDetail() {
     invoiced?: boolean;
   } | null>(null);
 
-  // Incomplete fulfillment modal state
+  // Incomplete fulfillment modal state. `incompleteIntent` records which
+  // advancement the soft-warning is gating so the modal's confirm can dispatch it.
   const [showIncompleteModal, setShowIncompleteModal] = useState(false);
   const [incompleteSteps, setIncompleteSteps] = useState<string[]>([]);
+  const [incompleteIntent, setIncompleteIntent] = useState<'SHIP' | 'READY'>('SHIP');
 
   // Status change modal state (for undoing shipped status)
   const [showStatusChangeModal, setShowStatusChangeModal] = useState(false);
@@ -279,10 +302,11 @@ export default function OrderDetail() {
   // Uses derived pack complete status - no longer checks invoiced as a blocker
   const handleMarkAsShipped = useCallback(() => {
     if (!order) return;
-    
+
     // Only check pack completion - invoiced is tracked separately
     if (!isDerivedPackComplete) {
       setIncompleteSteps(['Packed (per run sheet)']);
+      setIncompleteIntent('SHIP');
       setShowIncompleteModal(true);
     } else {
       markAsShippedMutation.mutate();
@@ -505,6 +529,58 @@ export default function OrderDetail() {
 
   const lineTotal = lineItemsWithPackedStatus.reduce((sum, li) => sum + li.quantity_units * li.unit_price_locked, 0);
 
+  // Advancement is always a deliberate click. SHIPPED keeps its pack-complete gate;
+  // READY soft-warns when not packed but still allows an override.
+  const handleAdvanceTo = (target: OrderStatus) => {
+    if (target === 'SHIPPED') {
+      handleMarkAsShipped();
+      return;
+    }
+    if (target === 'CONFIRMED' && order.status === 'SUBMITTED') {
+      confirmMutation.mutate();
+      return;
+    }
+    if (target === 'READY' && !isDerivedPackComplete) {
+      setIncompleteSteps(['Packed (per run sheet)']);
+      setIncompleteIntent('READY');
+      setShowIncompleteModal(true);
+      return;
+    }
+    handleStatusChange(target);
+  };
+
+  // Primary recommended next action for the current status.
+  const primaryNext: { target: OrderStatus; label: string; pending: boolean } | null = (() => {
+    switch (order.status) {
+      case 'SUBMITTED':
+        return { target: 'CONFIRMED', label: 'Confirm Order', pending: confirmMutation.isPending };
+      case 'CONFIRMED':
+        return { target: 'IN_PRODUCTION', label: 'Start Production', pending: changeStatusMutation.isPending };
+      case 'IN_PRODUCTION':
+        return { target: 'READY', label: 'Mark Ready', pending: changeStatusMutation.isPending };
+      case 'READY':
+        return { target: 'SHIPPED', label: 'Mark as Shipped', pending: markAsShippedMutation.isPending };
+      default:
+        return null;
+    }
+  })();
+
+  // Human label for a transition target, phrased as revert when moving backward.
+  const currentIdx = PRODUCTION_LADDER.indexOf(order.status);
+  const transitionLabel = (target: OrderStatus): string => {
+    const targetIdx = PRODUCTION_LADDER.indexOf(target);
+    const isRevert = targetIdx !== -1 && currentIdx !== -1 && targetIdx < currentIdx;
+    if (target === 'CANCELLED') return 'Cancel Order';
+    if (isRevert) return `Revert to ${STATUS_LABEL[target]}`;
+    return STATUS_LABEL[target];
+  };
+
+  // Remaining allowed transitions for the secondary menu (excludes the primary
+  // recommendation and the rarely-needed move back to DRAFT).
+  const secondaryTransitions = (ALLOWED_ORDER_TRANSITIONS[order.status] ?? []).filter(
+    (t) => t !== primaryNext?.target && t !== 'DRAFT',
+  );
+
   return (
     <div className="page-container">
       <div className="page-header flex items-center justify-between">
@@ -568,39 +644,67 @@ export default function OrderDetail() {
             Edit Order
           </Button>
           
-          {/* Confirm button for SUBMITTED orders */}
-          {order.status === 'SUBMITTED' && (
-            <Button onClick={() => confirmMutation.mutate()} disabled={confirmMutation.isPending}>
-              {confirmMutation.isPending ? 'Confirming…' : 'Confirm Order'}
-            </Button>
-          )}
-          
-          {/* Mark as Shipped button for non-shipped, non-cancelled orders */}
-          {order.status !== 'SHIPPED' && order.status !== 'CANCELLED' && order.status !== 'DRAFT' && (
-            <Button 
-              onClick={handleMarkAsShipped} 
-              disabled={markAsShippedMutation.isPending}
+          {/* Primary next-action button — the one obvious step for this status */}
+          {primaryNext && (
+            <Button
+              onClick={() => handleAdvanceTo(primaryNext.target)}
+              disabled={primaryNext.pending}
               className="gap-2"
             >
-              <Truck className="h-4 w-4" />
-              {markAsShippedMutation.isPending ? 'Processing…' : 'Mark as Shipped'}
+              {primaryNext.target === 'SHIPPED' && <Truck className="h-4 w-4" />}
+              {primaryNext.target === 'IN_PRODUCTION' && <Flame className="h-4 w-4" />}
+              {primaryNext.pending ? 'Working…' : primaryNext.label}
             </Button>
           )}
-          
-          {/* Status change dropdown for SHIPPED orders (undo) */}
-          {order.status === 'SHIPPED' && (
-            <Select onValueChange={(value) => handleStatusChange(value as OrderStatus)}>
+
+          {/* Secondary transitions (reverts, cancel, alternate advances) */}
+          {secondaryTransitions.length > 0 && (
+            <Select
+              value=""
+              onValueChange={(value) => handleAdvanceTo(value as OrderStatus)}
+            >
               <SelectTrigger className="w-[180px]">
-                <SelectValue placeholder="Change Status" />
+                <SelectValue placeholder={primaryNext ? 'More actions' : 'Change Status'} />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="CONFIRMED">Revert to Confirmed</SelectItem>
-                <SelectItem value="READY">Revert to Ready</SelectItem>
+                {secondaryTransitions.map((t) => (
+                  <SelectItem key={t} value={t}>
+                    {transitionLabel(t)}
+                  </SelectItem>
+                ))}
               </SelectContent>
             </Select>
           )}
         </div>
       </div>
+
+      {/* Status stepper — at-a-glance position in the fulfillment ladder */}
+      {order.status !== 'CANCELLED' && (
+        <div className="mb-4 flex flex-wrap items-center gap-1 text-xs">
+          {PRODUCTION_LADDER.map((s, i) => {
+            const done = currentIdx !== -1 && i < currentIdx;
+            const current = i === currentIdx;
+            return (
+              <React.Fragment key={s}>
+                <span
+                  className={`rounded px-2 py-1 ${
+                    current
+                      ? 'bg-primary text-primary-foreground font-medium'
+                      : done
+                      ? 'bg-primary/15 text-primary'
+                      : 'bg-muted text-muted-foreground'
+                  }`}
+                >
+                  {STATUS_LABEL[s]}
+                </span>
+                {i < PRODUCTION_LADDER.length - 1 && (
+                  <span className="text-muted-foreground">→</span>
+                )}
+              </React.Fragment>
+            );
+          })}
+        </div>
+      )}
 
       <div className="grid gap-6 md:grid-cols-2">
         <Card>
@@ -882,7 +986,11 @@ export default function OrderDetail() {
         incompleteSteps={incompleteSteps}
         onConfirm={() => {
           setShowIncompleteModal(false);
-          markAsShippedMutation.mutate();
+          if (incompleteIntent === 'READY') {
+            changeStatusMutation.mutate('READY');
+          } else {
+            markAsShippedMutation.mutate();
+          }
         }}
       />
 


### PR DESCRIPTION
Last-mile sprint: clear manual fulfillment click-through, two inventory views, grind unplugged from ordering.

## A — Production click-through (manual buttons, no auto-advance)
- **OrderDetail = status hub**: one "next action" button per status (Confirm Order → Start Production → Mark Ready → Mark as Shipped) + secondary dropdown of remaining allowed transitions (reverts/cancel) from `ALLOWED_ORDER_TRANSITIONS`. Reuses existing mutations + `update_order_status` RPC.
- SHIPPED keeps pack-complete gate; READY soft-warns via `IncompleteFulfillmentModal` but allows override.
- Presentational status stepper (Draft → … → Shipped).
- **ShipTab fix**: `markOrderShipped` was a raw `orders.update` bypassing the audit log + transition validation — now routes through `update_order_status` RPC + `ORDER_SHIPPED` notify, matching OrderDetail.

## B — Inventory views
- WIP + FG tabs get a "Showing available / Show all" toggle (default available) + summary line.
- Roasted-not-packed = `net_wip_kg > 0`; finished-not-picked = `units_on_hand > 0`. Client-side filter, no new queries.

## C — Grind removed from ordering
- NewOrder, CreateOrderForClient, OrderEditModal: selectors/state stripped, write `grind: null`. Read types, product-config grind, DB columns left intact (returns later).

## Verification
- `tsc --noEmit` clean · `npm run test` 28/28 · app compiles, login renders, no console errors.
- Full browser click-through (confirm→ship + live inventory) is auth-gated — not exercised; needs login/seed data locally.

## Open calls (your decision)
1. **Shipped email dedup** — OrderDetail + ShipTab both fire `ORDER_SHIPPED`. One ship = one fire; revert+re-ship double-fires. Left as-is.
2. **FG available count** sums loaded pages only (FG list paginated) — undercounts if more pages exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)