### PR TITLE
Fix six run-sheet friction points (roast/pack/ship)

### DIFF
--- a/src/components/production/InlinePackingControl.tsx
+++ b/src/components/production/InlinePackingControl.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Minus, Plus, Loader2 } from 'lucide-react';
+import { Minus, Plus, Loader2, Check } from 'lucide-react';
 
 interface InlinePackingControlProps {
   value: number;
@@ -9,14 +9,17 @@ interface InlinePackingControlProps {
   onEditingChange?: (isEditing: boolean) => void;
   disabled?: boolean;
   isComplete?: boolean;
+  /** When set, shows an "All packed" button that fills to this value (the demand). */
+  fillValue?: number;
 }
 
-export function InlinePackingControl({ 
-  value, 
-  onCommit, 
+export function InlinePackingControl({
+  value,
+  onCommit,
   onEditingChange,
   disabled = false,
-  isComplete = false 
+  isComplete = false,
+  fillValue,
 }: InlinePackingControlProps) {
   const [localValue, setLocalValue] = useState<string>(value.toString());
   const [isSaving, setIsSaving] = useState(false);
@@ -149,6 +152,20 @@ export function InlinePackingControl({
     commitValue(newValue);
   };
 
+  const handleFill = () => {
+    if (fillValue === undefined) return;
+    setLocalValue(fillValue.toString());
+
+    notifyEditingChange(true);
+    resetIdleTimeout();
+
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
+    commitValue(fillValue);
+  };
+
   // Cleanup on unmount
   useEffect(() => {
     return () => {
@@ -209,6 +226,21 @@ export function InlinePackingControl({
       >
         <Plus className="h-3 w-3" />
       </Button>
+
+      {fillValue !== undefined && (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-7 px-2 text-xs gap-1"
+          onClick={handleFill}
+          disabled={isDisabled || (parseInt(localValue, 10) || 0) >= fillValue}
+          title="All packed"
+        >
+          <Check className="h-3 w-3" />
+          All packed
+        </Button>
+      )}
     </div>
   );
 }

--- a/src/components/production/OverdueBadge.tsx
+++ b/src/components/production/OverdueBadge.tsx
@@ -1,10 +1,32 @@
 import React, { useMemo } from 'react';
 import { Badge } from '@/components/ui/badge';
-import { AlertTriangle, Clock } from 'lucide-react';
-import { parseISO, differenceInMinutes, differenceInHours, differenceInDays } from 'date-fns';
+import { AlertTriangle, Clock, CalendarClock } from 'lucide-react';
+import { parseISO, differenceInMinutes, differenceInHours, differenceInDays, startOfDay, differenceInCalendarDays } from 'date-fns';
 import { toZonedTime } from 'date-fns-tz';
 import { TIMEZONE, getVancouverNow } from '@/lib/productionScheduling';
 import { cn } from '@/lib/utils';
+
+export type DueBucket = 'today' | 'tomorrow' | 'later';
+
+/**
+ * Bucket a work deadline into today / tomorrow / later (Vancouver time).
+ * Anything already past collapses into 'today' — it's due now, not noisy "LATE".
+ */
+export function getDueBucket(workDeadlineAt: string | null): DueBucket | null {
+  if (!workDeadlineAt) return null;
+
+  try {
+    const now = getVancouverNow();
+    const deadlineVancouver = toZonedTime(parseISO(workDeadlineAt), TIMEZONE);
+    const days = differenceInCalendarDays(startOfDay(deadlineVancouver), startOfDay(now));
+
+    if (days <= 0) return 'today';
+    if (days === 1) return 'tomorrow';
+    return 'later';
+  } catch {
+    return null;
+  }
+}
 
 interface OverdueBadgeProps {
   workDeadlineAt: string | null;
@@ -91,6 +113,42 @@ export function OverdueBadge({ workDeadlineAt, className, badgeOnly = false }: O
         </span>
       )}
     </div>
+  );
+}
+
+/**
+ * DueBadge - calm "Due today / tomorrow / later" cue.
+ *
+ * Replaces the noisy pulsing LATE badge. Today is emphasized (it needs action),
+ * tomorrow is a soft heads-up, later is muted. No pulse, no "Xd overdue" string.
+ */
+export function DueBadge({ workDeadlineAt, className }: { workDeadlineAt: string | null; className?: string }) {
+  const bucket = useMemo(() => getDueBucket(workDeadlineAt), [workDeadlineAt]);
+
+  if (!bucket) return null;
+
+  const styles: Record<DueBucket, { className: string; label: string }> = {
+    today: {
+      className: 'bg-destructive/10 text-destructive border-destructive/30',
+      label: 'Due today',
+    },
+    tomorrow: {
+      className: 'bg-amber-100 text-amber-800 border-amber-300',
+      label: 'Due tomorrow',
+    },
+    later: {
+      className: 'bg-muted text-muted-foreground border-border',
+      label: 'Due later',
+    },
+  };
+
+  const { className: badgeClass, label } = styles[bucket];
+
+  return (
+    <Badge variant="outline" className={cn('flex items-center gap-1 px-2 py-0.5 text-xs font-medium', badgeClass, className)}>
+      <CalendarClock className="h-3 w-3" />
+      {label}
+    </Badge>
   );
 }
 

--- a/src/components/production/PackTab.tsx
+++ b/src/components/production/PackTab.tsx
@@ -457,9 +457,26 @@ export function PackTab({ dateFilterConfig, today }: PackTabProps) {
   }, [sortedProducts, roastGroupsConfig, groupKeyOf]);
 
   // The active group order (manual drag wins, else the sort-control order).
+  //
+  // Frozen during a session so completing a group's last row does NOT bounce it to
+  // the bottom live (WIP-priority stays the rule). The order is only recomputed when
+  // the user explicitly changes sort mode / drags, when the SET of groups changes
+  // (add/remove), or on remount (nav away + back / refresh) — at which point WIP sort
+  // naturally sinks fully-packed groups (tier 'none') to the bottom.
+  const groupKeySig = useMemo(
+    () => groupMetas.map((m) => m.roastGroup).sort().join('|'),
+    [groupMetas],
+  );
+  const [frozenGroupOrder, setFrozenGroupOrder] = useState<string[] | null>(null);
+  useEffect(() => {
+    setFrozenGroupOrder(orderPackGroups(groupMetas, sortMode, manualGroupOrder));
+    // groupMetas intentionally omitted: live tier/completion changes must NOT re-sort.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sortMode, manualGroupOrder, groupKeySig]);
+
   const groupOrder = useMemo(
-    () => orderPackGroups(groupMetas, sortMode, manualGroupOrder),
-    [groupMetas, sortMode, manualGroupOrder],
+    () => frozenGroupOrder ?? orderPackGroups(groupMetas, sortMode, manualGroupOrder),
+    [frozenGroupOrder, groupMetas, sortMode, manualGroupOrder],
   );
 
   const metaByKey = useMemo(
@@ -521,22 +538,11 @@ export function PackTab({ dateFilterConfig, today }: PackTabProps) {
     // Calculate kg consumed/returned for the delta
     const kgDelta = bagSizeG > 0 ? (delta * bagSizeG) / 1000 : 0;
 
-    // Guard: never consume more WIP than is actually available for this roast group.
-    // Blend component kg is removed from component WIP when a blend executes, so this
-    // also blocks a sibling single-origin product from packing coffee already in a blend.
-    if (delta > 0 && roastGroup) {
-      const availableWipKg = roastedInventory[roastGroup] ?? 0;
-      const EPSILON = 0.001;
-      if (kgDelta > availableWipKg + EPSILON) {
-        toast.error(
-          `Not enough WIP for ${roastGroup}: need ${kgDelta.toFixed(2)} kg, only ${availableWipKg.toFixed(2)} kg available. ` +
-          `Coffee may already be committed to a blend.`
-        );
-        throw new Error('Insufficient WIP for pack');
-      }
-    }
-    
-    console.log('[PackTab] updatePackingUnits:', { 
+    // No upstream-material gating: a user packing a bag the system thinks doesn't
+    // exist is treated as an upstream data-entry lag, not a physical shortage. The
+    // "0 available" / amber WIP color cues are nudge enough; never block completion.
+
+    console.log('[PackTab] updatePackingUnits:', {
       productId, newUnits, previousUnits, delta, bagSizeG, kgDelta, roastGroup, target_date: today 
     });
     
@@ -612,7 +618,7 @@ export function PackTab({ dateFilterConfig, today }: PackTabProps) {
     queryClient.invalidateQueries({ queryKey: ['authoritative-packing-runs'] });
     queryClient.invalidateQueries({ queryKey: ['inventory-ledger-wip'] });
     queryClient.invalidateQueries({ queryKey: ['inventory-ledger-fg'] });
-  }, [today, user?.id, queryClient, roastedInventory]);
+  }, [today, user?.id, queryClient]);
 
   // Mutation to update pack_display_order
   const updateDisplayOrderMutation = useMutation({

--- a/src/components/production/RoastTab.tsx
+++ b/src/components/production/RoastTab.tsx
@@ -440,9 +440,13 @@ export function RoastTab({ dateFilterConfig, today }: RoastTabProps) {
       const fg_kg = inventoryLevelsByGroup[roast_group]?.fg_kg ?? 0;
       const net_demand_kg = Math.max(0, data.total_kg - wip_kg - fg_kg);
       
-      // A group is "completed" if it has no net demand but has some form of activity
+      // A group is "completed" if it has no net demand, has some form of activity,
+      // and has no PLANNED batches still queued (unroasted work must stay visible).
       const hasActivity = groupsWithActivity.has(roast_group);
-      const isCompleted = net_demand_kg === 0 && hasActivity;
+      const hasPlanned = (batches ?? []).some(
+        b => b.roast_group === roast_group && b.status === 'PLANNED'
+      );
+      const isCompleted = net_demand_kg === 0 && hasActivity && !hasPlanned;
       
       return {
         roast_group,

--- a/src/components/production/ShipPickInput.tsx
+++ b/src/components/production/ShipPickInput.tsx
@@ -6,6 +6,8 @@ import { Check } from 'lucide-react';
 interface ShipPickInputProps {
   value: number;
   maxValue: number;
+  /** Value the "Pick all" button fills to — the required quantity, not FG available. */
+  fillValue: number;
   onCommit: (newValue: number) => void;
   disabled?: boolean;
 }
@@ -13,6 +15,7 @@ interface ShipPickInputProps {
 export function ShipPickInput({
   value,
   maxValue,
+  fillValue,
   onCommit,
   disabled = false
 }: ShipPickInputProps) {
@@ -63,7 +66,7 @@ export function ShipPickInput({
   };
 
   const handlePickAll = () => {
-    commitValue(maxValue);
+    commitValue(fillValue);
   };
 
   const currentValue = parseInt(draftValue, 10) || 0;
@@ -88,7 +91,7 @@ export function ShipPickInput({
         variant="outline"
         className="h-7 px-2 text-xs gap-1"
         onClick={handlePickAll}
-        disabled={disabled || currentValue >= maxValue}
+        disabled={disabled || currentValue >= fillValue}
         title="Pick all"
       >
         <Check className="h-3 w-3" />

--- a/src/components/production/SortablePackRow.tsx
+++ b/src/components/production/SortablePackRow.tsx
@@ -195,6 +195,7 @@ export function SortablePackRow({
             onCommit={onUpdatePackedUnits}
             onEditingChange={onEditingChange}
             isComplete={isComplete}
+            fillValue={demandedUnits}
           />
         </td>
         <td className="py-3 text-right">

--- a/src/components/production/SortableShipCard.tsx
+++ b/src/components/production/SortableShipCard.tsx
@@ -8,7 +8,7 @@ import { Badge } from '@/components/ui/badge';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { ShipPickInput } from './ShipPickInput';
 import { NudgeScheduleButtons } from './NudgeScheduleButtons';
-import { OverdueBadge, isOrderOverdue } from './OverdueBadge';
+import { DueBadge, getDueBucket } from './OverdueBadge';
 import { format, parseISO } from 'date-fns';
 import { toZonedTime } from 'date-fns-tz';
 import { TIMEZONE } from '@/lib/productionScheduling';
@@ -213,8 +213,9 @@ export function SortableShipCard({
   const hasOpsNotes = !!order.internal_ops_notes;
   const isShippable = allItemsFullyPicked;
   
-  // Check if order is overdue
-  const isOverdue = useMemo(() => isOrderOverdue(order.work_deadline), [order.work_deadline]);
+  // Due-day bucket (calm cue, replaces noisy LATE)
+  const dueBucket = useMemo(() => getDueBucket(order.work_deadline), [order.work_deadline]);
+  const isDueToday = dueBucket === 'today';
   
   // Format work_deadline for display in Vancouver time
   const formattedDeadline = order.work_deadline
@@ -226,12 +227,12 @@ export function SortableShipCard({
       ref={setNodeRef}
       style={style}
       className={`border rounded-lg p-4 transition-colors ${
-        isOverdue && !isShippable
-          ? 'border-destructive bg-destructive/5 ring-2 ring-destructive/30 shadow-md' // OVERDUE - highest priority styling
-          : isShippable 
-            ? 'border-green-500 bg-green-50 ring-2 ring-green-200 shadow-sm' 
-            : isTimeSensitive 
-              ? 'border-destructive/30 bg-destructive/5' 
+        isShippable
+          ? 'border-green-500 bg-green-50 ring-2 ring-green-200 shadow-sm'
+          : isDueToday && !isShippable
+            ? 'border-destructive/40 bg-destructive/5' // Due today - calm emphasis, no pulse/ring
+            : isTimeSensitive
+              ? 'border-destructive/30 bg-destructive/5'
               : 'border-muted bg-muted/20 opacity-80'
       }`}
     >
@@ -262,11 +263,9 @@ export function SortableShipCard({
               {order.shipToLabel}
             </span>
 
-            {/* Overdue badge - highest priority, always visible */}
-            {isOverdue && (
-              <OverdueBadge workDeadlineAt={order.work_deadline} />
-            )}
-            
+            {/* Due-day cue - calm, replaces noisy LATE badge */}
+            <DueBadge workDeadlineAt={order.work_deadline} />
+
             {/* Shippable badge */}
             {isShippable && (
               <Badge className="text-xs bg-green-600 hover:bg-green-700">
@@ -274,8 +273,8 @@ export function SortableShipCard({
                 Ready
               </Badge>
             )}
-            
-            {isTimeSensitive && !isOverdue && (
+
+            {isTimeSensitive && !isDueToday && (
               <Badge variant="destructive" className="text-xs">
                 <Clock className="h-3 w-3 mr-1" />
                 Urgent
@@ -457,6 +456,7 @@ export function SortableShipCard({
                     <ShipPickInput
                       value={picked}
                       maxValue={Math.max(available + picked, li.quantity_units)} // Can pick up to what's available + already picked
+                      fillValue={li.quantity_units} // "Pick all" fills Required, not FG available
                       onCommit={(newValue) => handlePickChange(li.id, newValue, available + picked, li.product_id)}
                       disabled={upsertPickMutation.isPending}
                     />


### PR DESCRIPTION
## What

Six small, isolated usability fixes on the Production **Run Sheet** (`src/components/production/`).

| # | Tab | Fix |
|---|-----|-----|
| 1 | Roast | A roast group with `PLANNED` batches no longer counts as "completed", so its drawer stays visible instead of hiding unroasted work when "show completed" is off. |
| 2 | Pack | Group order is frozen during a session — WIP priority stays the live rule. Completed groups only sink to the bottom on remount / nav-back / sort-mode change, not live as you finish a row. |
| 3 | Pack | New **"All packed"** button fills a row to its demand value for one-click completion (mirrors ship's "Pick all"). |
| 4 | Ship | **"Pick all"** now fills the **Required** quantity instead of FG **Available**. |
| 5 | Ship | Replaced the noisy pulsing **LATE** badge with a calm **Due today / tomorrow / later** cue (bucketed off `work_deadline` in Vancouver time); softened the aggressive red card ring. |
| 6 | Pack | Removed the hard "insufficient WIP" block on packing. Upstream shortfalls are treated as data-entry lag, not a physical stop — "0 available" visual cues remain the nudge. |

## Why

Daily floor work was slowed by drawers hiding unfinished work, completed groups bouncing mid-task, missing one-click completion, "pick all" leaning on the wrong number, false "late" noise from unrealistically early internal deadlines, and upstream-material gating blocking users from clicking their own step through to done.

## Reviewer notes

- **Item 2**: WIP-priority sort already sinks fully-packed (tier `none`) groups; the new `useEffect` freezes the order keyed on sort-mode / manual-drag / group-set membership (deliberately **not** live tier), so a finished group stays put until refresh/nav. Manual drag order still wins.
- **Item 5**: Added `DueBadge` / `getDueBucket`; kept the old `OverdueBadge` / `isOrderOverdue` exports (no other consumers, nothing else broke).
- Three behavior choices were confirmed with the product owner: due cue off `work_deadline`, remove the WIP block silently (no toast), "completed" = all rows packed.

## Verification

- `npm run test` → **45/45 pass** (incl. `packGroupSort`).
- Lint: no new errors in touched files (repo-wide `no-explicit-any` errors are pre-existing).
- App boots clean (no Vite/console errors). Live interactive run-sheet flows need an authenticated session with seeded production data — worth a manual pass on the six points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)