### PR TITLE
Enforce co-roast booking rules server-side + collapse tier-rate duplication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ dist-ssr
 
 # Claude Code local state
 .claude/
+supabase/.temp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,18 +102,18 @@ AuthContext (global state) → ProtectedRoute (per-route enforcement)
 - `BOOKING_CONFIRMED` → positive
 - `BOOKING_RETURNED` → negative
 
-This is the convention used by the admin UI in `src/components/bookings/BookingFormDialog.tsx` and `BookingDetailModal.tsx`. The member-portal RPCs in `supabase/migrations/20260501195324_*.sql` currently use the **opposite sign** and need to be flipped. When changing one path, change all so they stay consistent.
+This convention is used by the admin UI (`src/components/bookings/BookingFormDialog.tsx`, `BookingDetailModal.tsx`) **and** the member-portal RPCs — both are consistent as of `supabase/migrations/20260514120000_fix_hours_delta_sign.sql` (which flipped the originally-inverted RPC signs). When changing one path, change all so they stay consistent.
 
 ## Co-Roasting: Member Writes Go Through SECURITY DEFINER RPCs
 
 Members do not have direct INSERT/UPDATE/DELETE RLS on `coroast_bookings`, `coroast_hour_ledger`, `coroast_recurring_blocks`, or `coroast_billing_periods`. All member writes go through SECURITY DEFINER RPCs (`create_member_booking`, `create_member_recurring_bookings`, `cancel_member_booking`). Do not grant members direct write access.
 
-Business rules (4-week MEMBER-tier horizon, 48-hour cancellation lock) **must** be enforced inside the RPCs — UI checks alone can be bypassed.
+Business rules (booking horizon, cancellation lock, duration bounds, recurring-allowed) **must** be enforced inside the RPCs — UI checks alone can be bypassed. As of `20260603000000_*.sql` (Stage 2) all three RPCs call `_coroast_effective_booking_rules(account_id)`, which merges the `coroast_tier_booking_rules` tier defaults with the per-account `accounts.coroast_custom_*` overrides (both seeded in `20260512230749_*.sql`). To change a rule, update the table/override rows — do **not** hardcode new limits in the RPC bodies.
 
 ## Co-Roasting: Schema Gotchas
 
 - `account_id` is the canonical FK to `accounts(id)` on `coroast_bookings`, `coroast_billing_periods`, `coroast_hour_ledger`, `coroast_invoices`, `coroast_storage_allocations`, `coroast_waiver_log`. Legacy `member_id` columns are nullable and unused for new writes.
-- **Exception**: `coroast_recurring_blocks` has only `member_id` (no `account_id` column). New writes populate `member_id` with the account UUID. `BookingFormDialog.tsx` currently writes to a non-existent `account_id` field on this table — that admin flow is broken.
+- `coroast_recurring_blocks` gained `account_id` (NOT NULL, FK → `accounts(id)`) in `20260514120000_coroast_recurring_blocks_account_id.sql`; its read RLS is now account-scoped on that column. Both the admin flow (`BookingFormDialog.tsx`) and the `create_member_recurring_bookings` RPC write `account_id` (the RPC also keeps `member_id` populated for back-compat). `member_id` is nullable and slated for removal in a follow-up migration.
 - Standard RLS read pattern for account-scoped tables:
   ```sql
   USING (EXISTS (
@@ -126,7 +126,9 @@ Business rules (4-week MEMBER-tier horizon, 48-hour cancellation lock) **must** 
 
 ## Co-Roasting: Tier Rates
 
-`TIER_RATES` are defined in `src/components/bookings/bookingUtils.ts` **and** duplicated in `supabase/migrations/20260501195324_*.sql` (`_get_or_create_billing_period`). When updating rates, update **both**. The `ACCESS` tier is legacy — kept for historical billing records, do not surface in new UI.
+Frontend tier rates have a single source of truth: `CO_ROAST_TIER_DEFAULTS` in `src/components/bookings/bookingUtils.ts`. `TIER_RATES`, `STORAGE_RATES` (same file), `DEFAULT_RATES` (`CoRoastPricing.tsx`), and `TIER_DEFAULTS` (`AccountDetail.tsx`) are all **derived** from it — do not reintroduce parallel hardcoded copies. The live runtime source is the `coroast_tier_rates` DB table (read via `useTierRates`); `CO_ROAST_TIER_DEFAULTS` mirrors its seed and is the synchronous fallback.
+
+When changing rates, update in lockstep: (1) `CO_ROAST_TIER_DEFAULTS`, (2) the `coroast_tier_rates` table seed in `supabase/migrations/20260514094701_*.sql`, and (3) the `_get_or_create_billing_period` CASE in `supabase/migrations/20260501195324_*.sql`. The `ACCESS` tier is legacy (`isLegacy: true`) — kept for historical billing, filtered out of admin UI; do not surface in new UI.
 
 ## Migration Discipline
 

--- a/src/components/bookings/bookingUtils.ts
+++ b/src/components/bookings/bookingUtils.ts
@@ -177,16 +177,43 @@ export type TierRate = {
   label: string;
 };
 
-// Fallback / synchronous source for non-booking call sites
-// (unitEconomics.ts, coroastPricing.ts) that cannot use React Query.
-// Source of truth is the `coroast_tier_rates` table; this mirrors the seed.
+// ── Single source of truth for bundled co-roast tier defaults ────────────────
+// Fallback / synchronous source for call sites that cannot use React Query
+// (unitEconomics.ts, coroastPricing.ts) and seed for the admin pages
+// (CoRoastPricing.tsx, AccountDetail.tsx). The live source of truth is the
+// `coroast_tier_rates` table (read via useTierRates); this mirrors its seed.
 // Keep in sync with migration 20260514094701_coroast_rpc_hardening.sql.
-export const TIER_RATES: Record<string, TierRate> = {
-  MEMBER:     { base: 399,   includedHours: 3,  overageRate: 160, packagingBlocksIncluded: 0, packagingBlockRate: 0, label: 'Member' },
-  GROWTH:     { base: 859,   includedHours: 7,  overageRate: 145, packagingBlocksIncluded: 0, packagingBlockRate: 0, label: 'Growth' },
-  PRODUCTION: { base: 1399,  includedHours: 12, overageRate: 130, packagingBlocksIncluded: 0, packagingBlockRate: 0, label: 'Production' },
-  ACCESS:     { base: 300,   includedHours: 3,  overageRate: 135, packagingBlocksIncluded: 0, packagingBlockRate: 0, label: 'Access (Legacy)' },
+// Every other rate/storage map in the app is DERIVED from this constant — do
+// not reintroduce parallel hardcoded copies.
+export type CoRoastTierDefault = {
+  base: number;
+  includedHours: number;
+  overageRate: number;
+  includedPallets: number;
+  storageRate: number;
+  packagingBlocksIncluded: number;
+  packagingBlockRate: number;
+  label: string;
+  isLegacy: boolean;
 };
+
+export const CO_ROAST_TIER_DEFAULTS: Record<string, CoRoastTierDefault> = {
+  MEMBER:     { base: 399,  includedHours: 3,  overageRate: 160, includedPallets: 0, storageRate: 175, packagingBlocksIncluded: 0, packagingBlockRate: 0, label: 'Member',          isLegacy: false },
+  GROWTH:     { base: 859,  includedHours: 7,  overageRate: 145, includedPallets: 1, storageRate: 175, packagingBlocksIncluded: 0, packagingBlockRate: 0, label: 'Growth',          isLegacy: false },
+  PRODUCTION: { base: 1399, includedHours: 12, overageRate: 130, includedPallets: 2, storageRate: 175, packagingBlocksIncluded: 0, packagingBlockRate: 0, label: 'Production',      isLegacy: false },
+  ACCESS:     { base: 300,  includedHours: 3,  overageRate: 135, includedPallets: 0, storageRate: 225, packagingBlocksIncluded: 0, packagingBlockRate: 0, label: 'Access (Legacy)', isLegacy: true  },
+};
+
+export const TIER_RATES: Record<string, TierRate> = Object.fromEntries(
+  Object.entries(CO_ROAST_TIER_DEFAULTS).map(([tier, d]) => [tier, {
+    base: d.base,
+    includedHours: d.includedHours,
+    overageRate: d.overageRate,
+    packagingBlocksIncluded: d.packagingBlocksIncluded,
+    packagingBlockRate: d.packagingBlockRate,
+    label: d.label,
+  }]),
+);
 
 type TierRateRow = {
   tier: CoroastTier;
@@ -234,12 +261,13 @@ export function useTierRates() {
   return { rates, isLoading: query.isLoading, error: query.error };
 }
 
-export const STORAGE_RATES: Record<string, { includedPallets: number; ratePerPallet: number }> = {
-  MEMBER:     { includedPallets: 0, ratePerPallet: 175 },
-  GROWTH:     { includedPallets: 1, ratePerPallet: 175 },
-  PRODUCTION: { includedPallets: 2, ratePerPallet: 175 },
-  ACCESS:     { includedPallets: 0, ratePerPallet: 225 }, // Legacy
-};
+export const STORAGE_RATES: Record<string, { includedPallets: number; ratePerPallet: number }> =
+  Object.fromEntries(
+    Object.entries(CO_ROAST_TIER_DEFAULTS).map(([tier, d]) => [tier, {
+      includedPallets: d.includedPallets,
+      ratePerPallet: d.storageRate,
+    }]),
+  );
 
 export const HOUR_START = 5;
 export const HOUR_END = 22;

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1350,6 +1350,7 @@ export type Database = {
       }
       coroast_recurring_blocks: {
         Row: {
+          account_id: string
           created_at: string
           created_by: string | null
           day_of_week: Database["public"]["Enums"]["coroast_recurring_day"]
@@ -1364,6 +1365,7 @@ export type Database = {
           updated_at: string
         }
         Insert: {
+          account_id: string
           created_at?: string
           created_by?: string | null
           day_of_week: Database["public"]["Enums"]["coroast_recurring_day"]
@@ -1378,6 +1380,7 @@ export type Database = {
           updated_at?: string
         }
         Update: {
+          account_id?: string
           created_at?: string
           created_by?: string | null
           day_of_week?: Database["public"]["Enums"]["coroast_recurring_day"]
@@ -1391,7 +1394,15 @@ export type Database = {
           start_time?: string
           updated_at?: string
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "coroast_recurring_blocks_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       coroast_storage_allocations: {
         Row: {

--- a/src/pages/internal/AccountDetail.tsx
+++ b/src/pages/internal/AccountDetail.tsx
@@ -30,6 +30,7 @@ import { formatPronounsSuffix } from '@/lib/pronounOptions';
 import PricingAnalysisTab from '@/components/account/PricingAnalysisTab';
 import OfferWorkspaceTab from '@/components/account/OfferWorkspaceTab';
 import { formatAuditEntry, type PricingAuditRow } from '@/lib/coroastPricing';
+import { CO_ROAST_TIER_DEFAULTS } from '@/components/bookings/bookingUtils';
 
 // PricingTierCard removed — pricing tiers are no longer in the data model.
 function PricingTierCard(_props: { accountId: string; pricingTierId: string | null }) {
@@ -1442,11 +1443,20 @@ const OVERRIDE_FIELDS = [
   { key: 'coroast_custom_packaging_block_rate', label: 'Packaging Block Rate ($/2-hr block)', tierKey: 'packagingBlockRate', isDollar: true },
 ] as const;
 
-const TIER_DEFAULTS: Record<string, Record<string, number>> = {
-  MEMBER:     { base: 399,  includedHours: 3,  overageRate: 160, includedPallets: 0, storageRate: 175, packagingBlocksIncluded: 0, packagingBlockRate: 0 },
-  GROWTH:     { base: 859,  includedHours: 7,  overageRate: 145, includedPallets: 1, storageRate: 175, packagingBlocksIncluded: 0, packagingBlockRate: 0 },
-  PRODUCTION: { base: 1399, includedHours: 12, overageRate: 130, includedPallets: 2, storageRate: 175, packagingBlocksIncluded: 0, packagingBlockRate: 0 },
-};
+// Derived from the single source of truth in bookingUtils (active tiers only).
+const TIER_DEFAULTS: Record<string, Record<string, number>> = Object.fromEntries(
+  Object.entries(CO_ROAST_TIER_DEFAULTS)
+    .filter(([, d]) => !d.isLegacy)
+    .map(([tier, d]) => [tier, {
+      base: d.base,
+      includedHours: d.includedHours,
+      overageRate: d.overageRate,
+      includedPallets: d.includedPallets,
+      storageRate: d.storageRate,
+      packagingBlocksIncluded: d.packagingBlocksIncluded,
+      packagingBlockRate: d.packagingBlockRate,
+    }]),
+);
 
 function CustomRateOverrides({ account, refetch }: { account: any; refetch: () => void }) {
   const { authUser } = useAuth();

--- a/src/pages/internal/CoRoastPricing.tsx
+++ b/src/pages/internal/CoRoastPricing.tsx
@@ -11,6 +11,7 @@ import { toast } from 'sonner';
 import { useAuth } from '@/contexts/AuthContext';
 import { formatMoney } from '@/lib/formatMoney';
 import { format } from 'date-fns';
+import { CO_ROAST_TIER_DEFAULTS } from '@/components/bookings/bookingUtils';
 
 const SETTINGS_KEY = 'coroast_tier_rates';
 
@@ -24,11 +25,19 @@ interface TierRates {
 
 type AllTierRates = Record<string, TierRates>;
 
-const DEFAULT_RATES: AllTierRates = {
-  MEMBER: { base: 399, includedHours: 3, overageRate: 160, includedPallets: 0, storageRate: 175 },
-  GROWTH: { base: 859, includedHours: 7, overageRate: 145, includedPallets: 1, storageRate: 175 },
-  PRODUCTION: { base: 1399, includedHours: 12, overageRate: 130, includedPallets: 2, storageRate: 175 },
-};
+// Derived from the single source of truth in bookingUtils. Legacy tiers are
+// excluded so they never surface in the admin pricing UI (3 active tiers only).
+const DEFAULT_RATES: AllTierRates = Object.fromEntries(
+  Object.entries(CO_ROAST_TIER_DEFAULTS)
+    .filter(([, d]) => !d.isLegacy)
+    .map(([tier, d]) => [tier, {
+      base: d.base,
+      includedHours: d.includedHours,
+      overageRate: d.overageRate,
+      includedPallets: d.includedPallets,
+      storageRate: d.storageRate,
+    }]),
+);
 
 const TIER_LABELS: Record<string, string> = {
   MEMBER: 'Member',

--- a/supabase/migrations/20260603000000_aaae9970-6944-4e9b-aafe-6904f4fd2492.sql
+++ b/supabase/migrations/20260603000000_aaae9970-6944-4e9b-aafe-6904f4fd2492.sql
@@ -1,0 +1,306 @@
+-- ============================================================
+-- Stage 2: enforce co-roast booking rules inside the SECURITY DEFINER RPCs.
+--
+-- Until now the 4-week booking horizon and the 48-hour cancellation lock were
+-- enforced ONLY in the React member portal (MemberSchedule.tsx / BookingDetailModal.tsx).
+-- A member calling supabase.rpc('create_member_booking' | 'cancel_member_booking' |
+-- 'create_member_recurring_bookings') directly could bypass them entirely.
+--
+-- This migration wires the Stage-1 tables (coroast_tier_booking_rules + the
+-- accounts.coroast_custom_* override columns from 20260512230749_*.sql) into all
+-- three member RPCs so the rules are enforced server-side.
+--
+-- Effective rule = per-account override (accounts.coroast_custom_*) when set,
+-- else the tier default (coroast_tier_booking_rules), resolved by the account's
+-- coroast_tier (defaulting to MEMBER).
+--
+-- Function signatures are unchanged. Ledger sign convention (POSITIVE = consumed)
+-- is preserved from 20260514120000_fix_hours_delta_sign.sql.
+-- ============================================================
+
+-- ── Effective-rules resolver ─────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public._coroast_effective_booking_rules(p_account_id uuid)
+RETURNS TABLE (
+  booking_horizon_days       integer,
+  cancellation_free_hours    integer,
+  min_booking_duration_hours numeric,
+  max_booking_duration_hours numeric,
+  allow_recurring_bookings   boolean,
+  allow_past_dated_bookings  boolean
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    COALESCE(a.coroast_custom_booking_horizon_days,       r.booking_horizon_days),
+    COALESCE(a.coroast_custom_cancellation_free_hours,    r.cancellation_free_hours),
+    COALESCE(a.coroast_custom_min_booking_duration_hours, r.min_booking_duration_hours),
+    COALESCE(a.coroast_custom_max_booking_duration_hours, r.max_booking_duration_hours),
+    COALESCE(a.coroast_custom_allow_recurring_bookings,   r.allow_recurring_bookings),
+    r.allow_past_dated_bookings
+  FROM public.accounts a
+  JOIN public.coroast_tier_booking_rules r
+    ON r.tier = COALESCE(a.coroast_tier, 'MEMBER'::coroast_tier)
+  WHERE a.id = p_account_id;
+$$;
+
+REVOKE ALL ON FUNCTION public._coroast_effective_booking_rules(uuid) FROM PUBLIC, anon;
+
+-- ── create_member_booking: + horizon / past-date / duration enforcement ──────
+CREATE OR REPLACE FUNCTION public.create_member_booking(
+  p_account_id uuid,
+  p_booking_date date,
+  p_start_time time,
+  p_end_time time,
+  p_notes text DEFAULT NULL,
+  p_recurring_block_id uuid DEFAULT NULL
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_booking_id uuid;
+  v_billing_period_id uuid;
+  v_hours numeric;
+  v_rules RECORD;
+BEGIN
+  PERFORM public._assert_active_coroast_member(p_account_id);
+
+  IF p_start_time >= p_end_time THEN
+    RAISE EXCEPTION 'Invalid time range';
+  END IF;
+
+  SELECT * INTO v_rules FROM public._coroast_effective_booking_rules(p_account_id);
+  IF v_rules IS NULL THEN
+    RAISE EXCEPTION 'No booking rules configured for this account';
+  END IF;
+
+  -- Past-dated bookings
+  IF NOT v_rules.allow_past_dated_bookings AND p_booking_date < CURRENT_DATE THEN
+    RAISE EXCEPTION 'Cannot book a date in the past';
+  END IF;
+
+  -- Booking horizon (e.g. MEMBER = 28 days out)
+  IF p_booking_date > CURRENT_DATE + (v_rules.booking_horizon_days || ' days')::interval THEN
+    RAISE EXCEPTION 'Booking date is beyond the % day booking horizon', v_rules.booking_horizon_days;
+  END IF;
+
+  v_hours := ROUND(EXTRACT(EPOCH FROM (p_end_time - p_start_time)) / 3600.0, 2);
+
+  -- Duration bounds
+  IF v_hours < v_rules.min_booking_duration_hours THEN
+    RAISE EXCEPTION 'Booking is shorter than the % hour minimum', v_rules.min_booking_duration_hours;
+  END IF;
+  IF v_hours > v_rules.max_booking_duration_hours THEN
+    RAISE EXCEPTION 'Booking exceeds the % hour maximum', v_rules.max_booking_duration_hours;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM public.coroast_bookings cb
+    WHERE cb.booking_date = p_booking_date
+      AND cb.status NOT IN ('CANCELLED_FREE', 'CANCELLED_CHARGED', 'CANCELLED_WAIVED', 'NO_SHOW')
+      AND cb.start_time < p_end_time
+      AND cb.end_time   > p_start_time
+  ) THEN
+    RAISE EXCEPTION 'Time slot conflicts with an existing booking';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM public.coroast_loring_blocks lb
+    WHERE lb.block_date = p_booking_date
+      AND lb.start_time < p_end_time
+      AND lb.end_time   > p_start_time
+  ) THEN
+    RAISE EXCEPTION 'Time slot conflicts with an unavailability block';
+  END IF;
+
+  v_billing_period_id := public._get_or_create_billing_period(p_account_id, p_booking_date);
+
+  INSERT INTO public.coroast_bookings (
+    account_id, billing_period_id, booking_date, start_time, end_time,
+    notes_member, recurring_block_id, status, created_by
+  ) VALUES (
+    p_account_id, v_billing_period_id, p_booking_date, p_start_time, p_end_time,
+    NULLIF(TRIM(COALESCE(p_notes, '')), ''), p_recurring_block_id,
+    'CONFIRMED'::coroast_booking_status, auth.uid()
+  )
+  RETURNING id INTO v_booking_id;
+
+  INSERT INTO public.coroast_hour_ledger (
+    account_id, billing_period_id, booking_id, entry_type, hours_delta, notes, created_by
+  ) VALUES (
+    p_account_id, v_billing_period_id, v_booking_id,
+    'BOOKING_CONFIRMED'::coroast_ledger_entry_type,
+    v_hours, -- POSITIVE: bookings consume hours
+    'Self-serve booking on ' || to_char(p_booking_date, 'YYYY-MM-DD'),
+    auth.uid()
+  );
+
+  RETURN v_booking_id;
+END;
+$$;
+
+-- ── create_member_recurring_bookings: + recurring-allowed gate ───────────────
+-- Per-date horizon/duration/conflict checks are inherited from create_member_booking,
+-- which this function calls per occurrence (failures are collected into bookings_skipped).
+CREATE OR REPLACE FUNCTION public.create_member_recurring_bookings(
+  p_account_id uuid,
+  p_pattern_start_date date,
+  p_pattern_end_date date,
+  p_day_of_week int,
+  p_start_time time,
+  p_end_time time,
+  p_notes text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_block_id uuid;
+  v_dow coroast_recurring_day;
+  v_d date;
+  v_target_dow int;
+  v_skipped jsonb := '[]'::jsonb;
+  v_created int := 0;
+  v_booking_id uuid;
+  v_err text;
+  v_rules RECORD;
+BEGIN
+  PERFORM public._assert_active_coroast_member(p_account_id);
+
+  IF p_start_time >= p_end_time THEN
+    RAISE EXCEPTION 'Invalid time range';
+  END IF;
+  IF p_day_of_week < 0 OR p_day_of_week > 6 THEN
+    RAISE EXCEPTION 'Invalid day_of_week (must be 0-6)';
+  END IF;
+  IF p_pattern_end_date < p_pattern_start_date THEN
+    RAISE EXCEPTION 'pattern_end_date must be on or after pattern_start_date';
+  END IF;
+
+  SELECT * INTO v_rules FROM public._coroast_effective_booking_rules(p_account_id);
+  IF v_rules IS NULL THEN
+    RAISE EXCEPTION 'No booking rules configured for this account';
+  END IF;
+  IF NOT v_rules.allow_recurring_bookings THEN
+    RAISE EXCEPTION 'Recurring bookings are not permitted for this account tier';
+  END IF;
+
+  v_dow := (ARRAY['SUN','MON','TUE','WED','THU','FRI','SAT']::coroast_recurring_day[])[p_day_of_week + 1];
+
+  -- account_id is NOT NULL (20260514120000_coroast_recurring_blocks_account_id.sql).
+  -- member_id is kept populated for backwards compatibility while writes migrate.
+  INSERT INTO public.coroast_recurring_blocks (
+    account_id, member_id, day_of_week, start_time, end_time,
+    effective_from, effective_until, notes, created_by
+  ) VALUES (
+    p_account_id, p_account_id, v_dow, p_start_time, p_end_time,
+    p_pattern_start_date, p_pattern_end_date,
+    NULLIF(TRIM(COALESCE(p_notes, '')), ''), auth.uid()
+  )
+  RETURNING id INTO v_block_id;
+
+  v_d := p_pattern_start_date;
+  WHILE v_d <= p_pattern_end_date LOOP
+    v_target_dow := EXTRACT(DOW FROM v_d)::int;
+    IF v_target_dow = p_day_of_week THEN
+      BEGIN
+        v_booking_id := public.create_member_booking(
+          p_account_id, v_d, p_start_time, p_end_time, p_notes, v_block_id
+        );
+        v_created := v_created + 1;
+      EXCEPTION WHEN OTHERS THEN
+        v_err := SQLERRM;
+        v_skipped := v_skipped || jsonb_build_object('date', v_d, 'reason', v_err);
+      END;
+    END IF;
+    v_d := v_d + 1;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'recurring_block_id', v_block_id,
+    'bookings_created', v_created,
+    'bookings_skipped', v_skipped
+  );
+END;
+$$;
+
+-- ── cancel_member_booking: + cancellation lock enforcement ───────────────────
+CREATE OR REPLACE FUNCTION public.cancel_member_booking(p_booking_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_account_id uuid;
+  v_billing_period_id uuid;
+  v_booking_date date;
+  v_start_time time;
+  v_status coroast_booking_status;
+  v_duration numeric;
+  v_rules RECORD;
+  v_start_ts timestamptz;
+BEGIN
+  SELECT account_id, billing_period_id, booking_date, start_time, status, duration_hours
+    INTO v_account_id, v_billing_period_id, v_booking_date, v_start_time, v_status, v_duration
+    FROM public.coroast_bookings
+   WHERE id = p_booking_id;
+
+  IF v_account_id IS NULL THEN
+    RAISE EXCEPTION 'Booking not found';
+  END IF;
+
+  PERFORM public._assert_active_coroast_member(v_account_id);
+
+  IF v_status IN ('CANCELLED_FREE','CANCELLED_CHARGED','CANCELLED_WAIVED','NO_SHOW','COMPLETED') THEN
+    RAISE EXCEPTION 'Booking is not cancellable';
+  END IF;
+
+  IF v_booking_date < CURRENT_DATE THEN
+    RAISE EXCEPTION 'Cannot cancel a past booking';
+  END IF;
+
+  -- Cancellation lock: within the free-cancellation window members cannot
+  -- self-cancel for free. Charged/waived cancellations are an admin action.
+  SELECT * INTO v_rules FROM public._coroast_effective_booking_rules(v_account_id);
+  v_start_ts := (v_booking_date + v_start_time)::timestamptz;
+  IF v_rules IS NOT NULL
+     AND now() >= v_start_ts - (v_rules.cancellation_free_hours || ' hours')::interval THEN
+    RAISE EXCEPTION 'Cannot cancel within % hours of the booking start; contact an administrator',
+      v_rules.cancellation_free_hours;
+  END IF;
+
+  UPDATE public.coroast_bookings
+     SET status = 'CANCELLED_FREE'::coroast_booking_status,
+         cancelled_at = now(),
+         cancelled_by = auth.uid(),
+         updated_at = now()
+   WHERE id = p_booking_id;
+
+  INSERT INTO public.coroast_hour_ledger (
+    account_id, billing_period_id, booking_id, entry_type, hours_delta, notes, created_by
+  ) VALUES (
+    v_account_id, v_billing_period_id, p_booking_id,
+    'BOOKING_RETURNED'::coroast_ledger_entry_type,
+    -ROUND(COALESCE(v_duration, 0), 2), -- NEGATIVE: refunds the hours
+    'Member-initiated cancellation',
+    auth.uid()
+  );
+END;
+$$;
+
+-- ── Grants (mirror prior migrations; signatures unchanged) ───────────────────
+REVOKE ALL ON FUNCTION public.create_member_booking(uuid, date, time, time, text, uuid) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.create_member_recurring_bookings(uuid, date, date, int, time, time, text) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.cancel_member_booking(uuid) FROM PUBLIC, anon;
+
+GRANT EXECUTE ON FUNCTION public.create_member_booking(uuid, date, time, time, text, uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.create_member_recurring_bookings(uuid, date, date, int, time, time, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.cancel_member_booking(uuid) TO authenticated;


### PR DESCRIPTION
## Summary
Stage 2 of the co-roast booking-rules rollout + a tier-rate dedup, found during a pre-build codebase health audit.

### Server-side rule enforcement (audit findings #1–#3)
Business rules previously lived **only** in the React member portal — a direct `supabase.rpc()` call bypassed them. Migration `20260603000000` wires the Stage-1 `coroast_tier_booking_rules` defaults + `accounts.coroast_custom_*` overrides (seeded in `20260512230749`) into the SECURITY DEFINER RPCs:

- New resolver `_coroast_effective_booking_rules(account_id)` merges tier defaults with per-account overrides.
- `create_member_booking` — enforces booking horizon, past-date block, min/max duration.
- `create_member_recurring_bookings` — gates on `allow_recurring_bookings`.
- `cancel_member_booking` — enforces the cancellation lock (no free self-cancel inside `cancellation_free_hours` of start).
- Ledger sign convention (positive = consumed) and grants preserved.

### Latent bug fixed
`create_member_recurring_bookings` inserted only `member_id`, but `coroast_recurring_blocks.account_id` is **NOT NULL** (`20260514120000`) and its read RLS is account-scoped — so every member recurring booking would have failed the constraint and been invisible. RPC now writes `account_id`.

### Tier-rate dedup (audit #4)
`CO_ROAST_TIER_DEFAULTS` in `bookingUtils.ts` is now the single source of truth. `TIER_RATES`, `STORAGE_RATES`, `CoRoastPricing.DEFAULT_RATES`, and `AccountDetail.TIER_DEFAULTS` all derive from it (legacy `ACCESS` filtered out of admin UI). Values unchanged; all consumers index by key, so no behavior change.

### Docs
`CLAUDE.md` refreshed: sign convention now consistent, `recurring_blocks.account_id` exists, RPC rule enforcement, single-source tier rates.

## Verification
- `tsc --noEmit` clean.

## ⚠️ Follow-ups before merge/deploy
- **Apply migration**: `supabase db push` (CREATE OR REPLACE + idempotent).
- **Regen types**: a full `supabase gen types` (login/token required) is still needed to capture `coroast_tier_booking_rules`, `coroast_booking_rules_audit`, and `accounts.coroast_custom_*`. This PR only hand-patched `coroast_recurring_blocks.account_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)