### PR TITLE
Fix order number generation to use accounts/account_locations

### DIFF
--- a/src/components/orders/LocationSelect.tsx
+++ b/src/components/orders/LocationSelect.tsx
@@ -191,7 +191,7 @@ export function LocationCodeDisplay({ locationId }: LocationCodeDisplayProps) {
   const { data: location } = useAccountLocationLookup(locationId);
   if (!location) return null;
   return (
-    <span className="text-xs text-muted-foreground" title={location.location_name}>
+    <span className="text-sm text-muted-foreground" title={location.location_name}>
       @ {location.location_name}
     </span>
   );

--- a/src/pages/internal/Orders.tsx
+++ b/src/pages/internal/Orders.tsx
@@ -373,7 +373,11 @@ export default function Orders() {
                       className="flex-1 flex items-center gap-2 min-w-0"
                       onClick={() => navigate(`/orders/${o.id}`)}
                     >
-                      <span className="font-medium">{o.order_number}</span>
+                      <span className="font-medium truncate">
+                        {(o as any).account?.account_name ?? o.client?.name ?? 'Unknown'}
+                      </span>
+                      <LocationCodeDisplay locationId={o.location_id} />
+                      <span className="text-sm text-muted-foreground">{o.order_number}</span>
                       {o.created_by_admin && (
                         <span className="inline-flex items-center gap-1 rounded bg-primary/10 px-1.5 py-0.5 text-xs font-medium text-primary" title="Created by Admin">
                           <UserPlus className="h-3 w-3" />
@@ -389,10 +393,6 @@ export default function Orders() {
                           Needs deadline
                         </Badge>
                       )}
-                      <span className="text-sm text-muted-foreground truncate">
-                        {(o as any).account?.account_name ?? o.client?.name ?? 'Unknown'}
-                      </span>
-                      <LocationCodeDisplay locationId={o.location_id} />
                     </div>
 
                     {/* Deadline column - show date/time or set button */}

--- a/supabase/migrations/20260608120000_b678786f-5909-46d7-96d1-caa38e0682d0.sql
+++ b/supabase/migrations/20260608120000_b678786f-5909-46d7-96d1-caa38e0682d0.sql
@@ -1,0 +1,40 @@
+-- Fix generate_order_number(): read account_code / location_code from the live
+-- accounts + account_locations tables. The previous body still queried the legacy
+-- clients / client_locations tables by NEW.client_id / NEW.location_id, but orders
+-- now insert account_id (no client_id) and a location_id that points at
+-- account_locations(id). Both lookups missed, so every new order fell back to the
+-- 'ORD' + 'XX' placeholders (e.g. ORDXX-000132) even when a location was chosen.
+-- Format is unchanged (account_code || location_code || '-' || seq); only the
+-- lookup sources are corrected. Existing order_number values are left untouched.
+
+CREATE OR REPLACE FUNCTION public.generate_order_number()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  account_code_val  TEXT;
+  location_code_val TEXT;
+BEGIN
+  IF NEW.order_number IS NULL OR NEW.order_number = '' THEN
+    SELECT account_code INTO account_code_val
+      FROM public.accounts WHERE id = NEW.account_id;
+    IF account_code_val IS NULL OR account_code_val = '' THEN
+      account_code_val := 'ORD';
+    END IF;
+
+    IF NEW.location_id IS NOT NULL THEN
+      SELECT location_code INTO location_code_val
+        FROM public.account_locations WHERE id = NEW.location_id;
+    END IF;
+    IF location_code_val IS NULL OR location_code_val = '' THEN
+      location_code_val := 'XX';
+    END IF;
+
+    NEW.order_number := account_code_val || location_code_val || '-'
+                        || LPAD(nextval('public.order_number_seq')::TEXT, 6, '0');
+  END IF;
+  RETURN NEW;
+END;
+$function$;


### PR DESCRIPTION
## Problem

Order numbers render as `ORDXX-000132` even for orders that have a real location.

`generate_order_number()` still queried the legacy `clients.client_code` (by `client_id`) and `client_locations` (by `location_id`). But orders now insert `account_id` (never `client_id`) and a `location_id` that references `account_locations`. Both lookups miss, so every new order falls back to the `ORD` + `XX` placeholders.

## Fix

- **New migration** `20260608120000_*.sql` redefines `generate_order_number()` to read `accounts.account_code` and `account_locations.location_code`. Format unchanged (`account_code || location_code || '-' || seq`); keeps `ORD`/`XX` fallbacks only for genuinely-missing values. Trigger binding, schema, and existing data untouched — **new orders only, no backfill**.
- **/orders row** reprioritized: customer name + location now lead and are prominent; order number is secondary/muted. `LocationCodeDisplay` bumped `text-xs`→`text-sm`.

## Apply / verify

- DB: push the migration (or run the `CREATE OR REPLACE FUNCTION` in the SQL editor — safe anytime, body-only replace).
- After applying, create an order with a location → expect `<CODE><LOC>-NNNNNN` (no `XX`); without a location → `XX`.
- Note: accounts with no `account_code` will still prefix `ORD` (data gap, out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)