### PR TITLE
FUNK CSV order importer (manual Shopify bridge)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,6 +58,7 @@ import MarketPricingAnalysis from "@/pages/shared/MarketPricingAnalysis";
 import UsersAccess from "@/pages/internal/UsersAccess";
 import AdminFeedback from "@/pages/internal/AdminFeedback";
 import ShopifyDebug from "@/pages/internal/ShopifyDebug";
+import FunkImport from "@/pages/internal/FunkImport";
 import Portal from "@/pages/client/Portal";
 import NewOrder from "@/pages/client/NewOrder";
 import OrderHistory from "@/pages/client/OrderHistory";
@@ -290,6 +291,11 @@ const App = () => (
             <Route path="/admin-tools" element={
               <ProtectedRoute allowedRoles={['ADMIN']}>
                 <InternalLayout><AdminTools /></InternalLayout>
+              </ProtectedRoute>
+            } />
+            <Route path="/admin/funk-import" element={
+              <ProtectedRoute allowedRoles={['ADMIN', 'OPS']}>
+                <InternalLayout><FunkImport /></InternalLayout>
               </ProtectedRoute>
             } />
             <Route path="/settings/notifications" element={

--- a/src/components/layout/InternalLayout.tsx
+++ b/src/components/layout/InternalLayout.tsx
@@ -38,6 +38,7 @@ import {
   LineChart,
   Network,
   Bell,
+  FileUp,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
@@ -213,6 +214,7 @@ export function InternalLayout({ children }: InternalLayoutProps) {
               <NavGroup label="Manufacturing" icon={Factory} open={cmOpen} onOpenChange={setCmOpen}>
                 
                 <NavItem to="/orders" icon={ShoppingCart} label="Orders" onClick={closeSidebar} />
+                <NavItem to="/admin/funk-import" icon={FileUp} label="FUNK Import" onClick={closeSidebar} />
                 <NavItem to="/production" icon={Flame} label="Run Sheet" onClick={closeSidebar} end />
                 <NavItem to="/inventory" icon={Warehouse} label="Inventory Levels" onClick={closeSidebar} end />
                 <NavItem to="/products" icon={Package} label="Products" onClick={closeSidebar} />

--- a/src/components/products/ProductsListTab.tsx
+++ b/src/components/products/ProductsListTab.tsx
@@ -44,6 +44,7 @@ interface Product {
   grind_options: GrindOption[];
   is_active: boolean;
   is_perennial: boolean;
+  is_placeholder?: boolean | null;
   client_id: string | null;
   account_id: string | null;
   packaging_variant: PackagingVariant | null;
@@ -202,9 +203,9 @@ export function ProductsListTab() {
   const { data: products, isLoading } = useQuery({
     queryKey: ['all-products'],
     queryFn: async () => {
-      const { data, error } = await supabase
+      const { data, error } = await (supabase as any)
         .from('products')
-        .select('id, product_name, sku, format, bag_size_g, grind_options, is_active, is_perennial, client_id, account_id, packaging_variant, roast_group, packaging_material_override, packaging_labour_override, client:clients(name), account:accounts(account_name)')
+        .select('id, product_name, sku, format, bag_size_g, grind_options, is_active, is_perennial, is_placeholder, client_id, account_id, packaging_variant, roast_group, packaging_material_override, packaging_labour_override, client:clients(name), account:accounts(account_name)')
         .order('product_name');
 
       if (error) throw error;
@@ -879,6 +880,9 @@ export function ProductsListTab() {
                                     <Badge variant={p.is_active ? 'default' : 'secondary'} className="text-xs">
                                       {p.is_active ? 'Active' : 'Inactive'}
                                     </Badge>
+                                    {p.is_placeholder && (
+                                      <Badge variant="outline" className="ml-1 text-[10px]">PLACEHOLDER</Badge>
+                                    )}
                                   </td>
                                   <td className="py-1.5 px-2">
                                     <div className="flex items-center gap-1">

--- a/src/lib/funkCsvImport.test.ts
+++ b/src/lib/funkCsvImport.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseCsv, parseFunkCsv, cleanSubscriptionName, isDropName, parseBagSize,
+  matchLineItem, placeholderName, nextPlaceholderSeq, parseDropCans, sumSlotCans,
+  parseOrderDate, classifyOrders, buildShipNowGroups, aggregateBatchMonths,
+  dropShipDate, dateStamp, slotProductName, dropBatchReference, monthShortYY,
+  funkReferenceBase, nextBusinessDayDeadline,
+  type ProductLite, type MappingLite,
+} from './funkCsvImport';
+
+describe('parseCsv', () => {
+  it('handles quoted commas and embedded newlines', () => {
+    const csv = 'a,b,c\n1,"two, with comma","line1\nline2"\n';
+    const rows = parseCsv(csv);
+    expect(rows).toEqual([
+      ['a', 'b', 'c'],
+      ['1', 'two, with comma', 'line1\nline2'],
+    ]);
+  });
+
+  it('handles escaped double quotes', () => {
+    expect(parseCsv('x\n"he said ""hi"""')).toEqual([['x'], ['he said "hi"']]);
+  });
+});
+
+describe('cleanSubscriptionName', () => {
+  it('strips Subscription from a perennial sub line', () => {
+    expect(cleanSubscriptionName('Technicolour Subscription - 2LB bag / Whole Beans'))
+      .toBe('Technicolour - 2LB bag / Whole Beans');
+  });
+  it('leaves the DROP subscription box untouched', () => {
+    const n = 'Drip Drip DROP Subscription Box';
+    expect(cleanSubscriptionName(n)).toBe(n);
+  });
+  it('leaves non-subscription names untouched', () => {
+    expect(cleanSubscriptionName('Technicolour - 250g / Whole Beans'))
+      .toBe('Technicolour - 250g / Whole Beans');
+  });
+});
+
+describe('isDropName', () => {
+  it('detects DROP boxes case-insensitively', () => {
+    expect(isDropName('Drip Drip DROP - March')).toBe(true);
+    expect(isDropName('drip drip drop subscription box')).toBe(true);
+    expect(isDropName('Technicolour')).toBe(false);
+  });
+});
+
+describe('parseFunkCsv', () => {
+  const csv = [
+    'Name,Id,Lineitem name,Lineitem quantity,Lineitem sku',
+    '#1001,5550000001,"Technicolour - 250g / Whole Beans",2,TECH-250-WB',
+    '#1001,,"Technicolour Subscription - 250g / Whole Beans",1,',
+    '#1002,5550000002,"Drip Drip DROP - March",1,DROP-MAR',
+    '#1002,,"Technicolour - 2LB bag / Whole Beans",3,TECH-2LB-WB',
+  ].join('\n');
+
+  it('groups by Name and captures Id from the first row', () => {
+    const { orders, error } = parseFunkCsv(csv);
+    expect(error).toBeUndefined();
+    expect(orders).toHaveLength(2);
+    const o1 = orders.find((o) => o.name === '#1001')!;
+    expect(o1.shopifyId).toBe('5550000001');
+    expect(o1.lineItems).toHaveLength(2);
+    expect(o1.lineItems[1].cleanedName).toBe('Technicolour - 250g / Whole Beans');
+  });
+
+  it('marks DROP lines', () => {
+    const { orders } = parseFunkCsv(csv);
+    const o2 = orders.find((o) => o.name === '#1002')!;
+    expect(o2.lineItems[0].isDrop).toBe(true);
+    expect(o2.lineItems[1].isDrop).toBe(false);
+  });
+});
+
+describe('parseBagSize', () => {
+  it('parses common sizes', () => {
+    expect(parseBagSize('Technicolour - 2LB bag / Whole Beans').variant).toBe('BULK_2LB');
+    expect(parseBagSize('X - 250g').variant).toBe('RETAIL_250G');
+    expect(parseBagSize('X - 1kg').variant).toBe('BULK_1KG');
+    expect(parseBagSize('X - 12oz').variant).toBe('RETAIL_340G');
+  });
+  it('falls back to generic 250g', () => {
+    expect(parseBagSize('Mystery item')).toEqual({ variant: null, grams: 250 });
+  });
+});
+
+describe('matchLineItem', () => {
+  const products: ProductLite[] = [
+    { id: 'p1', product_name: 'Technicolour - 250g / Whole Beans', sku: 'TECH-250-WB', is_placeholder: false, packaging_variant: 'RETAIL_250G', bag_size_g: 250, internal_packaging_notes: null },
+    { id: 'ph', product_name: 'Placeholder One (1)', sku: null, is_placeholder: true, packaging_variant: null, bag_size_g: 250, internal_packaging_notes: 'Old thing' },
+  ];
+
+  it('uses a saved sku mapping as a final match', () => {
+    const mappings: MappingLite[] = [{ csv_sku: 'TECH-250-WB', csv_product_name: null, product_id: 'p1' }];
+    expect(matchLineItem('TECH-250-WB', 'whatever', products, mappings))
+      .toEqual({ kind: 'matched', productId: 'p1' });
+  });
+
+  it('guesses by exact name (needs confirmation, never final)', () => {
+    expect(matchLineItem('', 'Technicolour - 250g / Whole Beans', products, []))
+      .toEqual({ kind: 'needs_confirmation', productId: 'p1' });
+  });
+
+  it('returns unmatched when nothing matches', () => {
+    expect(matchLineItem('NOPE', 'Unknown Coffee', products, []))
+      .toEqual({ kind: 'unmatched', productId: null });
+  });
+
+  it('ignores a mapping that points at a placeholder', () => {
+    const mappings: MappingLite[] = [{ csv_sku: 'X', csv_product_name: null, product_id: 'ph' }];
+    expect(matchLineItem('X', 'whatever', products, mappings).kind).toBe('unmatched');
+  });
+});
+
+describe('placeholder naming', () => {
+  it('names sequentially with words', () => {
+    expect(placeholderName(1)).toBe('Placeholder One (1)');
+    expect(placeholderName(2)).toBe('Placeholder Two (2)');
+  });
+  it('continues past existing placeholders', () => {
+    const existing: ProductLite[] = [
+      { id: 'a', product_name: 'Placeholder One (1)', sku: null, is_placeholder: true, packaging_variant: null, bag_size_g: 250, internal_packaging_notes: null },
+      { id: 'b', product_name: 'Placeholder Three (3)', sku: null, is_placeholder: true, packaging_variant: null, bag_size_g: 250, internal_packaging_notes: null },
+    ];
+    expect(nextPlaceholderSeq(existing)).toBe(4);
+  });
+});
+
+describe('parseDropCans', () => {
+  it('reads the can count', () => {
+    expect(parseDropCans('Drip Drip DROP - 2 x 250g')).toBe(2);
+    expect(parseDropCans('Drip Drip DROP - 4 x 250g')).toBe(4);
+    expect(parseDropCans('Drip Drip DROP - mystery')).toBeNull();
+  });
+});
+
+describe('sumSlotCans', () => {
+  it('splits cans evenly across both slots, scaled by line qty', () => {
+    const line = (cans: number, qty: number): any => ({ isDrop: true, dropCans: cans, quantity: qty });
+    expect(sumSlotCans([line(2, 1)])).toEqual({ slot1: 1, slot2: 1, ok: true });
+    expect(sumSlotCans([line(4, 3)])).toEqual({ slot1: 6, slot2: 6, ok: true });
+    expect(sumSlotCans([line(null as any, 1)])).toEqual({ slot1: 0, slot2: 0, ok: false });
+  });
+});
+
+describe('parseOrderDate', () => {
+  it('reads the leading calendar date', () => {
+    expect(parseOrderDate('2026-06-10 08:00:00 -0700')).toEqual({ year: 2026, month: 6, day: 10 });
+    expect(parseOrderDate('not a date')).toBeNull();
+  });
+});
+
+describe('dropShipDate', () => {
+  it('uses the 15th, rolling weekends back to Friday', () => {
+    // Jun 2026: 15th is Monday -> 15.
+    expect(dropShipDate(2026, 6)).toEqual({ year: 2026, month: 6, day: 15 });
+    // Aug 2026: 15th is Saturday -> 14 (Fri).
+    expect(dropShipDate(2026, 8)).toEqual({ year: 2026, month: 8, day: 14 });
+    // Nov 2026: 15th is Sunday -> 13 (Fri).
+    expect(dropShipDate(2026, 11)).toEqual({ year: 2026, month: 11, day: 13 });
+  });
+});
+
+describe('naming + references', () => {
+  it('builds slot names, month suffix, and batch refs', () => {
+    expect(slotProductName(1, 2026, 6)).toBe('FUNK SUB ONE (1) - JUN 26');
+    expect(slotProductName(2, 2026, 6)).toBe('FUNK SUB TWO (2) - JUN 26');
+    expect(monthShortYY(2026, 1)).toBe('JAN 26');
+    expect(dropBatchReference(2026, 6)).toBe('FUNK-DROP-2026-06');
+    expect(dateStamp({ year: 2026, month: 6, day: 15 })).toBe('2026-06-15');
+  });
+});
+
+describe('classifyOrders — hard-date routing', () => {
+  const csv = (rows: string[][]) =>
+    parseFunkCsv([
+      'Name,Id,Created at,Lineitem name,Lineitem quantity,Lineitem sku',
+      ...rows.map((r) => r.join(',')),
+    ].join('\n')).orders;
+
+  it('routes a pure DROP order dated <=14 to the batch (expanded)', () => {
+    const orders = csv([['#1', '1', '2026-06-10 09:00:00 -0700', '"Drip Drip DROP - 2 x 250g"', '3', 'DROP2']]);
+    const c = classifyOrders(orders);
+    expect(c.shipNowOrders).toHaveLength(0);
+    expect(c.decisionOrders).toHaveLength(0);
+    expect(c.batchOrders).toHaveLength(1);
+    expect(c.batchOrders[0]).toMatchObject({ year: 2026, month: 6, slot1Cans: 3, slot2Cans: 3 });
+  });
+
+  it('routes a pure DROP order dated >=15 to ship-now', () => {
+    const orders = csv([['#2', '2', '2026-06-20 09:00:00 -0700', '"Drip Drip DROP - 4 x 250g"', '1', 'DROP4']]);
+    const c = classifyOrders(orders);
+    expect(c.shipNowOrders.map((o) => o.name)).toEqual(['#2']);
+    expect(c.batchOrders).toHaveLength(0);
+    expect(c.decisionOrders).toHaveLength(0);
+  });
+
+  it('routes a mixed order to needs-a-decision (canExpand from date+cans)', () => {
+    const orders = csv([
+      ['#3', '3', '2026-06-05 09:00:00 -0700', '"Drip Drip DROP - 2 x 250g"', '1', 'DROP2'],
+      ['#3', '', '', '"Technicolour - 250g / Whole Beans"', '2', 'TECH'],
+    ]);
+    const c = classifyOrders(orders);
+    expect(c.decisionOrders).toHaveLength(1);
+    expect(c.decisionOrders[0]).toMatchObject({ reason: 'mixed', canExpand: true, slot1Cans: 1, slot2Cans: 1 });
+    expect(c.decisionOrders[0].nonDropLines).toHaveLength(1);
+  });
+
+  it('routes an unparseable DROP order to needs-a-decision (cannot expand)', () => {
+    const orders = csv([['#4', '4', '2026-06-05 09:00:00 -0700', '"Drip Drip DROP mystery box"', '1', 'DROPX']]);
+    const c = classifyOrders(orders);
+    expect(c.decisionOrders).toHaveLength(1);
+    expect(c.decisionOrders[0]).toMatchObject({ reason: 'unparseable', canExpand: false });
+  });
+
+  it('routes a plain retail order to ship-now', () => {
+    const orders = csv([['#5', '5', '2026-06-05 09:00:00 -0700', '"Technicolour - 250g / Whole Beans"', '4', 'TECH']]);
+    const c = classifyOrders(orders);
+    expect(c.shipNowOrders.map((o) => o.name)).toEqual(['#5']);
+  });
+});
+
+describe('buildShipNowGroups + aggregateBatchMonths', () => {
+  it('groups ship-now lines and sums batch demand by month', () => {
+    const orders = parseFunkCsv([
+      'Name,Id,Created at,Lineitem name,Lineitem quantity,Lineitem sku',
+      '#1,1,2026-06-20 09:00:00 -0700,"Technicolour - 250g / Whole Beans",2,TECH',
+      '#1,,,"Technicolour Subscription - 250g / Whole Beans",1,TECH',
+    ].join('\n')).orders;
+    const products: ProductLite[] = [
+      { id: 'p1', product_name: 'Technicolour - 250g / Whole Beans', sku: 'TECH', is_placeholder: false, packaging_variant: 'RETAIL_250G', bag_size_g: 250, internal_packaging_notes: null },
+    ];
+    const groups = buildShipNowGroups(orders, products, []);
+    // retail + subscription twin combine into one group by sku, qty 3.
+    expect(groups).toHaveLength(1);
+    expect(groups[0].totalQuantity).toBe(3);
+
+    const months = aggregateBatchMonths([
+      { order: { name: '#a', shopifyId: '', createdAt: '', lineItems: [] }, year: 2026, month: 6, slot1Cans: 1, slot2Cans: 1, heldLines: [] },
+      { order: { name: '#b', shopifyId: '', createdAt: '', lineItems: [] }, year: 2026, month: 6, slot1Cans: 2, slot2Cans: 2, heldLines: [] },
+    ]);
+    expect(months).toHaveLength(1);
+    expect(months[0]).toMatchObject({ year: 2026, month: 6, slot1Cans: 3, slot2Cans: 3 });
+    expect(months[0].orderRefs.map((o) => o.name)).toEqual(['#a', '#b']);
+  });
+});
+
+describe('reference + deadline helpers', () => {
+  it('builds a dated reference', () => {
+    expect(funkReferenceBase(new Date('2026-06-17T10:00:00'))).toBe('FUNK-CSV-2026-06-17');
+  });
+  it('skips weekends for the work deadline', () => {
+    // Friday 2026-06-19 -> next business day is Monday 2026-06-22.
+    expect(nextBusinessDayDeadline(new Date('2026-06-19T09:00:00'))).toBe('2026-06-22T17:00');
+  });
+});

--- a/src/lib/funkCsvImport.ts
+++ b/src/lib/funkCsvImport.ts
@@ -1,0 +1,650 @@
+// Pure logic for the FUNK CSV order importer (Build 1 of 2).
+//
+// Manual bridge until the Shopify connector is live. Everything here is
+// side-effect free and unit-testable: CSV parsing, order grouping, the
+// Perennial-subscription name cleaning, DROP-box detection, bag-size parsing
+// and product matching. All DB writes live in the FunkImport page.
+
+import type { Database } from '@/integrations/supabase/types';
+
+type PackagingVariant = Database['public']['Enums']['packaging_variant'];
+
+// ---------------------------------------------------------------------------
+// CSV parsing (RFC-4180: quoted fields may contain commas and newlines)
+// ---------------------------------------------------------------------------
+
+/** Parse CSV text into rows of cells, handling quoted commas + embedded newlines. */
+export function parseCsv(text: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let cell = '';
+  let inQuotes = false;
+  // Strip a leading BOM if present.
+  const s = text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
+
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (inQuotes) {
+      if (c === '"') {
+        if (s[i + 1] === '"') {
+          cell += '"';
+          i++; // escaped quote
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        cell += c;
+      }
+      continue;
+    }
+    if (c === '"') {
+      inQuotes = true;
+    } else if (c === ',') {
+      row.push(cell);
+      cell = '';
+    } else if (c === '\n' || c === '\r') {
+      // Handle CRLF as a single break.
+      if (c === '\r' && s[i + 1] === '\n') i++;
+      row.push(cell);
+      cell = '';
+      rows.push(row);
+      row = [];
+    } else {
+      cell += c;
+    }
+  }
+  // Flush trailing cell/row (file may not end with a newline).
+  if (cell.length > 0 || row.length > 0) {
+    row.push(cell);
+    rows.push(row);
+  }
+  // Drop fully-empty rows (blank lines).
+  return rows.filter((r) => r.some((v) => v.trim() !== ''));
+}
+
+export interface CsvLineItem {
+  /** Raw "Lineitem name" from the export. */
+  rawName: string;
+  /** Name after Perennial-subscription cleaning (used for matching/display). */
+  cleanedName: string;
+  sku: string;
+  quantity: number;
+  /** True when this line is a Drip Drip DROP box. */
+  isDrop: boolean;
+  /** Can count read from a DROP-box name ("2 x 250g" -> 2); null if unparseable. */
+  dropCans: number | null;
+}
+
+export interface CsvOrder {
+  /** Shopify order number, e.g. "#1234" — present on every line of the order. */
+  name: string;
+  /** Long numeric Shopify "Id" captured from the order's first row. */
+  shopifyId: string;
+  /** Raw "Created at" value captured from the order's first row (may be ''). */
+  createdAt: string;
+  lineItems: CsvLineItem[];
+}
+
+const DROP_MARKER = 'drip drip drop';
+const DROP_SUB_BOX = 'drip drip drop subscription box';
+
+/** A Drip Drip DROP box line (the subscription box included). */
+export function isDropName(name: string): boolean {
+  return name.toLowerCase().includes(DROP_MARKER);
+}
+
+/**
+ * Read the can count from a DROP-box name: "2 x 250g" -> 2, "4 x 250g" -> 4.
+ * Returns null when the pattern can't be parsed (caller must not guess).
+ */
+export function parseDropCans(name: string): number | null {
+  const m = /(\d+)\s*x\s*\d+\s*g/i.exec(name);
+  if (!m) return null;
+  const n = parseInt(m[1], 10);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+/**
+ * Perennial-subscription cleaning. If the name contains "Subscription" and is
+ * NOT the "Drip Drip DROP Subscription Box", strip the word "Subscription" so
+ * the line matches its retail twin (produced identically).
+ *
+ *   "Technicolour Subscription - 2LB bag / Whole Beans"
+ *     -> "Technicolour - 2LB bag / Whole Beans"
+ */
+export function cleanSubscriptionName(name: string): string {
+  const lower = name.toLowerCase();
+  if (!lower.includes('subscription')) return name.trim();
+  if (lower.includes(DROP_SUB_BOX)) return name.trim();
+  return name
+    .replace(/\bsubscription\b/gi, ' ')
+    .replace(/\s+/g, ' ') // collapse whitespace left behind
+    .replace(/\s+-\s+-\s+/g, ' - ') // tidy doubled separators
+    .replace(/^\s*-\s*/, '') // strip a now-leading dash
+    .trim();
+}
+
+/** Column indexes for the columns we care about (others ignored). */
+interface ColumnMap {
+  name: number;
+  id: number;
+  createdAt: number;
+  lineitemName: number;
+  lineitemQty: number;
+  lineitemSku: number;
+}
+
+function resolveColumns(header: string[]): ColumnMap | null {
+  const idx = (label: string) =>
+    header.findIndex((h) => h.trim().toLowerCase() === label.toLowerCase());
+  const map: ColumnMap = {
+    name: idx('Name'),
+    id: idx('Id'),
+    createdAt: idx('Created at'),
+    lineitemName: idx('Lineitem name'),
+    lineitemQty: idx('Lineitem quantity'),
+    lineitemSku: idx('Lineitem sku'),
+  };
+  if (map.name < 0 || map.lineitemName < 0 || map.lineitemQty < 0) return null;
+  return map;
+}
+
+/**
+ * Parse a Shopify orders CSV into orders grouped by "Name". The numeric "Id"
+ * is captured from each order's first row that carries one.
+ */
+export function parseFunkCsv(text: string): { orders: CsvOrder[]; error?: string } {
+  const rows = parseCsv(text);
+  if (rows.length < 2) return { orders: [], error: 'CSV has no data rows.' };
+  const cols = resolveColumns(rows[0]);
+  if (!cols) {
+    return {
+      orders: [],
+      error: 'CSV missing required columns (Name, Lineitem name, Lineitem quantity).',
+    };
+  }
+
+  const byName = new Map<string, CsvOrder>();
+  for (let r = 1; r < rows.length; r++) {
+    const row = rows[r];
+    const name = (row[cols.name] ?? '').trim();
+    if (!name) continue; // every order line carries Name; skip stray rows
+    const rawItemName = (row[cols.lineitemName] ?? '').trim();
+    const sku = cols.lineitemSku >= 0 ? (row[cols.lineitemSku] ?? '').trim() : '';
+    const qty = parseInt((row[cols.lineitemQty] ?? '').trim(), 10);
+    const shopifyId = cols.id >= 0 ? (row[cols.id] ?? '').trim() : '';
+    const createdAt = cols.createdAt >= 0 ? (row[cols.createdAt] ?? '').trim() : '';
+
+    let order = byName.get(name);
+    if (!order) {
+      order = { name, shopifyId, createdAt, lineItems: [] };
+      byName.set(name, order);
+    }
+    // Capture Id / Created at from the first row of the order that carries them.
+    if (!order.shopifyId && shopifyId) order.shopifyId = shopifyId;
+    if (!order.createdAt && createdAt) order.createdAt = createdAt;
+
+    if (!rawItemName) continue; // not a line-item row
+    const isDrop = isDropName(rawItemName);
+    order.lineItems.push({
+      rawName: rawItemName,
+      cleanedName: cleanSubscriptionName(rawItemName),
+      sku,
+      quantity: Number.isFinite(qty) && qty > 0 ? qty : 1,
+      isDrop,
+      dropCans: isDrop ? parseDropCans(rawItemName) : null,
+    });
+  }
+  return { orders: Array.from(byName.values()) };
+}
+
+// ---------------------------------------------------------------------------
+// Bag-size parsing (for placeholder variants)
+// ---------------------------------------------------------------------------
+
+export interface ParsedBagSize {
+  variant: PackagingVariant | null;
+  grams: number;
+}
+
+const GRAMS_BY_VARIANT: Record<PackagingVariant, number> = {
+  RETAIL_250G: 250,
+  RETAIL_300G: 300,
+  RETAIL_340G: 340,
+  RETAIL_454G: 454,
+  CROWLER_200G: 200,
+  CROWLER_250G: 250,
+  CAN_125G: 125,
+  BULK_2LB: 907,
+  BULK_1KG: 1000,
+  BULK_5LB: 2268,
+  BULK_2KG: 2000,
+};
+
+/** Best-effort bag-size parse from a line name; generic 250g fallback. */
+export function parseBagSize(name: string): ParsedBagSize {
+  const n = name.toLowerCase();
+  const v = (variant: PackagingVariant): ParsedBagSize => ({
+    variant,
+    grams: GRAMS_BY_VARIANT[variant],
+  });
+  if (/\b5\s?lb\b/.test(n)) return v('BULK_5LB');
+  if (/\b2\s?lb\b/.test(n)) return v('BULK_2LB');
+  if (/\b1\s?lb\b|\b16\s?oz\b|454\s?g/.test(n)) return v('RETAIL_454G');
+  if (/\b2\s?kg\b/.test(n)) return v('BULK_2KG');
+  if (/\b1\s?kg\b/.test(n)) return v('BULK_1KG');
+  if (/12\s?oz|340\s?g/.test(n)) return v('RETAIL_340G');
+  if (/300\s?g/.test(n)) return v('RETAIL_300G');
+  if (/250\s?g/.test(n)) return v('RETAIL_250G');
+  if (/200\s?g/.test(n)) return v('CROWLER_200G');
+  if (/125\s?g/.test(n)) return v('CAN_125G');
+  return { variant: null, grams: 250 }; // generic
+}
+
+// ---------------------------------------------------------------------------
+// Product matching
+// ---------------------------------------------------------------------------
+
+export interface ProductLite {
+  id: string;
+  product_name: string;
+  sku: string | null;
+  is_placeholder: boolean | null;
+  packaging_variant: PackagingVariant | null;
+  bag_size_g: number | null;
+  internal_packaging_notes: string | null;
+}
+
+export interface MappingLite {
+  csv_sku: string | null;
+  csv_product_name: string | null;
+  product_id: string;
+}
+
+export type MatchKind = 'matched' | 'needs_confirmation' | 'unmatched';
+
+export interface MatchResult {
+  kind: MatchKind;
+  productId: string | null;
+}
+
+const norm = (s: string | null | undefined) => (s ?? '').trim().toLowerCase();
+
+/**
+ * Match one cleaned line against saved mappings then products.
+ *  1. Saved mapping (by sku when present, else by cleaned name) -> matched.
+ *  2. Auto-guess: exact sku or exact name against products -> needs_confirmation.
+ *  3. Else unmatched.
+ * A mapping/guess pointing at a placeholder product is never treated as final.
+ */
+export function matchLineItem(
+  sku: string,
+  cleanedName: string,
+  products: ProductLite[],
+  mappings: MappingLite[],
+): MatchResult {
+  const realById = new Map(products.filter((p) => !p.is_placeholder).map((p) => [p.id, p]));
+  const hasSku = sku.trim() !== '';
+
+  // 1. Saved mapping.
+  const mapping = hasSku
+    ? mappings.find((m) => norm(m.csv_sku) === norm(sku))
+    : mappings.find((m) => norm(m.csv_product_name) === norm(cleanedName));
+  if (mapping && realById.has(mapping.product_id)) {
+    return { kind: 'matched', productId: mapping.product_id };
+  }
+
+  // 2. Auto-guess against real products (never final).
+  if (hasSku) {
+    const bySku = products.find((p) => !p.is_placeholder && norm(p.sku) === norm(sku));
+    if (bySku) return { kind: 'needs_confirmation', productId: bySku.id };
+  }
+  const byName = products.find((p) => !p.is_placeholder && norm(p.product_name) === norm(cleanedName));
+  if (byName) return { kind: 'needs_confirmation', productId: byName.id };
+
+  // 3. Unmatched.
+  return { kind: 'unmatched', productId: null };
+}
+
+// ---------------------------------------------------------------------------
+// Placeholder naming
+// ---------------------------------------------------------------------------
+
+const NUMBER_WORDS = [
+  'Zero', 'One', 'Two', 'Three', 'Four', 'Five', 'Six', 'Seven', 'Eight', 'Nine',
+  'Ten', 'Eleven', 'Twelve', 'Thirteen', 'Fourteen', 'Fifteen', 'Sixteen',
+  'Seventeen', 'Eighteen', 'Nineteen', 'Twenty',
+];
+
+/** "Placeholder One (1)", "Placeholder Two (2)", ... numeric word past 20. */
+export function placeholderName(seq: number): string {
+  const word = NUMBER_WORDS[seq] ?? String(seq);
+  return `Placeholder ${word} (${seq})`;
+}
+
+/** Next sequence number, continuing past any existing placeholder products. */
+export function nextPlaceholderSeq(existing: ProductLite[]): number {
+  let max = 0;
+  for (const p of existing) {
+    if (!p.is_placeholder) continue;
+    const m = /\((\d+)\)\s*$/.exec(p.product_name);
+    if (m) max = Math.max(max, parseInt(m[1], 10));
+  }
+  return max + 1;
+}
+
+// ---------------------------------------------------------------------------
+// Order classification + review grouping
+// ---------------------------------------------------------------------------
+
+export interface ContributingRow {
+  orderName: string;
+  rawName: string;
+  cleanedName: string;
+  quantity: number;
+}
+
+/** A group of identical CSV lines that resolve to one product/placeholder. */
+export interface ReviewGroup {
+  /** Stable key: csv sku when present, else cleaned name. */
+  key: string;
+  csvSku: string;
+  cleanedName: string;
+  /** Representative raw name (for the placeholder note + display). */
+  rawName: string;
+  totalQuantity: number;
+  rows: ContributingRow[];
+  match: MatchResult;
+}
+
+export interface OrderRef {
+  name: string;
+  shopifyId: string;
+}
+
+/** Per-DROP-box-line can expansion into the two 250g slots. */
+export interface SlotTotals {
+  slot1: number;
+  slot2: number;
+  ok: boolean; // false when any DROP line is unparseable / not evenly splittable
+}
+
+/**
+ * Expand the DROP lines of an order into per-slot can totals.
+ * A box of N cans -> N/2 to slot 1 and N/2 to slot 2 (2-can => 1+1, 4-can => 2+2),
+ * multiplied by the line quantity. Odd / unparseable counts mark `ok = false`.
+ */
+export function sumSlotCans(dropLines: CsvLineItem[]): SlotTotals {
+  let slot1 = 0;
+  let slot2 = 0;
+  for (const d of dropLines) {
+    if (d.dropCans == null) return { slot1: 0, slot2: 0, ok: false };
+    const each = d.dropCans / 2;
+    if (!Number.isInteger(each) || each <= 0) return { slot1: 0, slot2: 0, ok: false };
+    slot1 += each * d.quantity;
+    slot2 += each * d.quantity;
+  }
+  return { slot1, slot2, ok: true };
+}
+
+/** Parse the order's Shopify "Created at" into a calendar date. */
+export function parseOrderDate(createdAt: string): { year: number; month: number; day: number } | null {
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(createdAt.trim());
+  if (m) return { year: +m[1], month: +m[2], day: +m[3] };
+  const d = new Date(createdAt);
+  if (!Number.isNaN(d.getTime())) {
+    return { year: d.getFullYear(), month: d.getMonth() + 1, day: d.getDate() };
+  }
+  return null;
+}
+
+/** Auto-routed DROP order folded into a month's batch (no non-DROP lines). */
+export interface BatchClass {
+  order: CsvOrder;
+  year: number;
+  month: number;
+  slot1Cans: number;
+  slot2Cans: number;
+  /** Non-DROP lines riding along (only set for held mixed orders). */
+  heldLines: CsvLineItem[];
+}
+
+export type DecisionReason = 'mixed' | 'unparseable' | 'no_date';
+
+/** A mixed / unparseable order the user must explicitly route. */
+export interface DecisionClass {
+  order: CsvOrder;
+  reason: DecisionReason;
+  year: number | null;
+  month: number | null;
+  day: number | null;
+  /** True when, if held for the batch, the DROP lines can be expanded. */
+  canExpand: boolean;
+  slot1Cans: number;
+  slot2Cans: number;
+  dropLines: CsvLineItem[];
+  nonDropLines: CsvLineItem[];
+}
+
+export interface Classification {
+  /** Orders whose lines all flow to the ship-now bundle (auto). */
+  shipNowOrders: CsvOrder[];
+  /** Pure-DROP orders dated <= 14th, auto-folded into their month's batch. */
+  batchOrders: BatchClass[];
+  /** Mixed / unparseable / dateless orders awaiting a user decision. */
+  decisionOrders: DecisionClass[];
+}
+
+/**
+ * Hard-date routing (Build 2). Per order, by the order's own Shopify date:
+ *  - no DROP line                         -> ship-now.
+ *  - mixed (DROP + non-DROP)              -> NEEDS A DECISION.
+ *  - pure DROP, unparseable cans          -> NEEDS A DECISION.
+ *  - pure DROP, no/invalid date           -> NEEDS A DECISION.
+ *  - pure DROP, day <= 14                 -> this month's DROP batch (expanded).
+ *  - pure DROP, day >= 15                 -> ship-now one-off (folds as retail).
+ * Pure calendar rule — never checks whether a batch has physically shipped.
+ */
+export function classifyOrders(newOrders: CsvOrder[]): Classification {
+  const shipNowOrders: CsvOrder[] = [];
+  const batchOrders: BatchClass[] = [];
+  const decisionOrders: DecisionClass[] = [];
+
+  for (const order of newOrders) {
+    const dropLines = order.lineItems.filter((li) => li.isDrop);
+    if (dropLines.length === 0) {
+      shipNowOrders.push(order);
+      continue;
+    }
+    const nonDropLines = order.lineItems.filter((li) => !li.isDrop);
+    const mixed = nonDropLines.length > 0;
+    const date = parseOrderDate(order.createdAt);
+    const slots = sumSlotCans(dropLines);
+    const canExpand = slots.ok && date != null;
+
+    const toDecision = (reason: DecisionReason) =>
+      decisionOrders.push({
+        order,
+        reason,
+        year: date?.year ?? null,
+        month: date?.month ?? null,
+        day: date?.day ?? null,
+        canExpand,
+        slot1Cans: slots.slot1,
+        slot2Cans: slots.slot2,
+        dropLines,
+        nonDropLines,
+      });
+
+    if (mixed) {
+      toDecision('mixed');
+      continue;
+    }
+    if (!date) {
+      toDecision('no_date');
+      continue;
+    }
+    if (!slots.ok) {
+      toDecision('unparseable');
+      continue;
+    }
+    if (date.day <= 14) {
+      batchOrders.push({
+        order,
+        year: date.year,
+        month: date.month,
+        slot1Cans: slots.slot1,
+        slot2Cans: slots.slot2,
+        heldLines: [],
+      });
+    } else {
+      shipNowOrders.push(order); // folds into the normal bundle as a retail line
+    }
+  }
+
+  return { shipNowOrders, batchOrders, decisionOrders };
+}
+
+/**
+ * Group every line item of the given orders into ship-now ReviewGroups
+ * (Build 1 grouping + product matching). DROP-box lines that reach here are
+ * treated as ordinary retail lines.
+ */
+export function buildShipNowGroups(
+  orders: CsvOrder[],
+  products: ProductLite[],
+  mappings: MappingLite[],
+): ReviewGroup[] {
+  const groupMap = new Map<string, ReviewGroup>();
+  for (const order of orders) {
+    for (const li of order.lineItems) {
+      const key = li.sku.trim() !== '' ? `sku:${norm(li.sku)}` : `name:${norm(li.cleanedName)}`;
+      let g = groupMap.get(key);
+      if (!g) {
+        g = {
+          key,
+          csvSku: li.sku.trim(),
+          cleanedName: li.cleanedName,
+          rawName: li.rawName,
+          totalQuantity: 0,
+          rows: [],
+          match: matchLineItem(li.sku, li.cleanedName, products, mappings),
+        };
+        groupMap.set(key, g);
+      }
+      g.totalQuantity += li.quantity;
+      g.rows.push({
+        orderName: order.name,
+        rawName: li.rawName,
+        cleanedName: li.cleanedName,
+        quantity: li.quantity,
+      });
+    }
+  }
+  return Array.from(groupMap.values());
+}
+
+// ---------------------------------------------------------------------------
+// DROP batch month aggregation + slot/ship-date helpers
+// ---------------------------------------------------------------------------
+
+export const monthKey = (year: number, month: number) => `${year}-${String(month).padStart(2, '0')}`;
+
+export interface BatchMonth {
+  year: number;
+  month: number;
+  slot1Cans: number;
+  slot2Cans: number;
+  /** Order names recorded against this batch (destination 'drop_batch'). */
+  orderRefs: OrderRef[];
+  /** Non-DROP lines from held mixed orders that ship with the batch. */
+  heldLines: { orderName: string; line: CsvLineItem }[];
+}
+
+/** Aggregate auto + held batch demand into per-month slot totals. */
+export function aggregateBatchMonths(batchClasses: BatchClass[]): BatchMonth[] {
+  const byMonth = new Map<string, BatchMonth>();
+  for (const b of batchClasses) {
+    const key = monthKey(b.year, b.month);
+    let m = byMonth.get(key);
+    if (!m) {
+      m = { year: b.year, month: b.month, slot1Cans: 0, slot2Cans: 0, orderRefs: [], heldLines: [] };
+      byMonth.set(key, m);
+    }
+    m.slot1Cans += b.slot1Cans;
+    m.slot2Cans += b.slot2Cans;
+    m.orderRefs.push({ name: b.order.name, shopifyId: b.order.shopifyId });
+    for (const line of b.heldLines) m.heldLines.push({ orderName: b.order.name, line });
+  }
+  return Array.from(byMonth.values()).sort((a, b) => monthKey(a.year, a.month).localeCompare(monthKey(b.year, b.month)));
+}
+
+const MONTHS_SHORT = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'];
+
+/** "JUN 26" style suffix for slot product names. */
+export function monthShortYY(year: number, month: number): string {
+  return `${MONTHS_SHORT[month - 1]} ${String(year % 100).padStart(2, '0')}`;
+}
+
+/** Slot product display name, e.g. "FUNK SUB ONE (1) - JUN 26". */
+export function slotProductName(slot: 1 | 2, year: number, month: number): string {
+  const word = slot === 1 ? 'ONE (1)' : 'TWO (2)';
+  return `FUNK SUB ${word} - ${monthShortYY(year, month)}`;
+}
+
+/**
+ * Ship date for a month's standing DROP order: the 15th, rolled back to the
+ * preceding Friday when the 15th lands on a weekend. Real calendar math.
+ */
+export function dropShipDate(year: number, month: number): { year: number; month: number; day: number } {
+  const dow = new Date(year, month - 1, 15).getDay();
+  let day = 15;
+  if (dow === 6) day = 14; // Saturday -> Friday
+  else if (dow === 0) day = 13; // Sunday -> Friday
+  return { year, month, day };
+}
+
+const pad2 = (n: number) => String(n).padStart(2, '0');
+
+/** YYYY-MM-DD stamp for a {year,month,day}. */
+export function dateStamp(d: { year: number; month: number; day: number }): string {
+  return `${d.year}-${pad2(d.month)}-${pad2(d.day)}`;
+}
+
+/** Noon (local) of a {year,month,day} as an ISO string — used for work_deadline_at. */
+export function noonIso(d: { year: number; month: number; day: number }): string {
+  return new Date(d.year, d.month - 1, d.day, 12, 0, 0).toISOString();
+}
+
+/** Standing DROP order reference, e.g. "FUNK-DROP-2026-06". */
+export function dropBatchReference(year: number, month: number): string {
+  return `FUNK-DROP-${year}-${pad2(month)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Reference + work-deadline helpers
+// ---------------------------------------------------------------------------
+
+/** YYYY-MM-DD in local time. */
+export function todayStamp(d = new Date()): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+/** Base reference "FUNK-CSV-YYYY-MM-DD" (suffix added when one exists today). */
+export function funkReferenceBase(d = new Date()): string {
+  return `FUNK-CSV-${todayStamp(d)}`;
+}
+
+/** End of next business day at 17:00 local, as a `datetime-local` value. */
+export function nextBusinessDayDeadline(now = new Date()): string {
+  const d = new Date(now);
+  d.setDate(d.getDate() + 1);
+  while (d.getDay() === 0 || d.getDay() === 6) d.setDate(d.getDate() + 1);
+  d.setHours(17, 0, 0, 0);
+  // Format as YYYY-MM-DDTHH:mm for an <input type="datetime-local">.
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}

--- a/src/pages/internal/FunkImport.tsx
+++ b/src/pages/internal/FunkImport.tsx
@@ -1,0 +1,801 @@
+import { useMemo, useRef, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+import {
+  Upload, Check, ChevronsUpDown, ChevronDown, ChevronRight, Package, Box, AlertTriangle, Truck,
+} from 'lucide-react';
+import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from '@/contexts/AuthContext';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import {
+  Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList,
+} from '@/components/ui/command';
+import { cn } from '@/lib/utils';
+import {
+  parseFunkCsv, classifyOrders, buildShipNowGroups, aggregateBatchMonths,
+  parseBagSize, placeholderName, nextPlaceholderSeq, matchLineItem,
+  funkReferenceBase, nextBusinessDayDeadline, slotProductName, dropShipDate,
+  dateStamp, noonIso, dropBatchReference, monthShortYY,
+  type ProductLite, type MappingLite, type ReviewGroup, type Classification,
+  type BatchClass, type BatchMonth,
+} from '@/lib/funkCsvImport';
+
+// funk_* tables + products.is_placeholder are not yet in the generated Supabase
+// types (additive migrations, types not regenerated) — mirror the Shopify-pull
+// pattern and cast through `any`.
+const sb = supabase as any;
+
+const errMsg = (e: unknown): string => {
+  if (!e) return 'Unknown error';
+  if (typeof e === 'string') return e;
+  if (typeof e === 'object' && e !== null) {
+    const a = e as any;
+    return a.message ?? a.error_description ?? JSON.stringify(a);
+  }
+  return String(e);
+};
+
+// Ship-now group decision. `pending` = a guess the user has not yet confirmed.
+type Resolution =
+  | { status: 'product'; productId: string }
+  | { status: 'placeholder' }
+  | { status: 'pending'; guessId: string };
+
+type DecisionChoice = 'ship_now' | 'drop_batch';
+
+interface ParsedState {
+  fileName: string;
+  newCount: number;
+  skippedCount: number;
+  classification: Classification;
+  products: ProductLite[];
+  mappings: MappingLite[];
+}
+
+const seedRes = (g: ReviewGroup): Resolution => {
+  if (g.match.kind === 'matched' && g.match.productId) return { status: 'product', productId: g.match.productId };
+  if (g.match.kind === 'needs_confirmation' && g.match.productId) return { status: 'pending', guessId: g.match.productId };
+  return { status: 'placeholder' };
+};
+
+export default function FunkImport() {
+  const { authUser } = useAuth();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const [parsed, setParsed] = useState<ParsedState | null>(null);
+  const [resolutions, setResolutions] = useState<Record<string, Resolution>>({});
+  const [decisions, setDecisions] = useState<Record<string, DecisionChoice>>({});
+  const [workDeadline, setWorkDeadline] = useState<string>(nextBusinessDayDeadline());
+  const [submitting, setSubmitting] = useState(false);
+
+  const productsQ = useQuery({
+    queryKey: ['funk-import', 'products'],
+    queryFn: async (): Promise<ProductLite[]> => {
+      const { data, error } = await sb
+        .from('products')
+        .select('id, product_name, sku, is_placeholder, packaging_variant, bag_size_g, internal_packaging_notes')
+        .order('product_name');
+      if (error) throw error;
+      return (data ?? []) as ProductLite[];
+    },
+  });
+
+  const realProducts = useMemo(
+    () => (productsQ.data ?? []).filter((p) => !p.is_placeholder),
+    [productsQ.data],
+  );
+  const productById = useMemo(() => {
+    const m = new Map<string, ProductLite>();
+    for (const p of productsQ.data ?? []) m.set(p.id, p);
+    return m;
+  }, [productsQ.data]);
+
+  // ---- file upload + parse --------------------------------------------------
+  const onPickFile = async (file: File) => {
+    if (!productsQ.data) {
+      toast.error('Products still loading — try again in a moment.');
+      return;
+    }
+    try {
+      const text = await file.text();
+      const { orders, error } = parseFunkCsv(text);
+      if (error) { toast.error(error); return; }
+      if (orders.length === 0) { toast.error('No orders found in CSV.'); return; }
+
+      // Dedupe against funk_imported_orders by Shopify order Name.
+      const names = orders.map((o) => o.name);
+      const { data: existing, error: dedupeErr } = await sb
+        .from('funk_imported_orders')
+        .select('shopify_order_name')
+        .in('shopify_order_name', names);
+      if (dedupeErr) throw dedupeErr;
+      const seen = new Set(
+        (existing ?? []).map((r: { shopify_order_name: string }) => r.shopify_order_name),
+      );
+      const newOrders = orders.filter((o) => !seen.has(o.name));
+      const skippedCount = orders.length - newOrders.length;
+
+      const { data: mapRows, error: mapErr } = await sb
+        .from('funk_import_product_mappings')
+        .select('csv_sku, csv_product_name, product_id');
+      if (mapErr) throw mapErr;
+      const mappings = (mapRows ?? []) as MappingLite[];
+
+      const classification = classifyOrders(newOrders);
+      setResolutions({});
+      setDecisions({});
+      setParsed({
+        fileName: file.name,
+        newCount: newOrders.length,
+        skippedCount,
+        classification,
+        products: productsQ.data,
+        mappings,
+      });
+      if (newOrders.length === 0) toast.info(`${orders.length} orders, all already imported (skipped).`);
+      else toast.success(`${newOrders.length} new, ${skippedCount} already imported (skipped).`);
+    } catch (e) {
+      toast.error(errMsg(e));
+    }
+  };
+
+  const setRes = (key: string, r: Resolution) => setResolutions((p) => ({ ...p, [key]: r }));
+  const effRes = (g: ReviewGroup): Resolution => resolutions[g.key] ?? seedRes(g);
+
+  // ---- derived buckets ------------------------------------------------------
+  const shipNowOrders = useMemo(() => {
+    if (!parsed) return [];
+    const held = parsed.classification.decisionOrders
+      .filter((d) => decisions[d.order.name] === 'ship_now')
+      .map((d) => d.order);
+    return [...parsed.classification.shipNowOrders, ...held];
+  }, [parsed, decisions]);
+
+  const shipNowGroups = useMemo(() => {
+    if (!parsed) return [];
+    return buildShipNowGroups(shipNowOrders, parsed.products, parsed.mappings);
+  }, [parsed, shipNowOrders]);
+
+  const batchMonths = useMemo<BatchMonth[]>(() => {
+    if (!parsed) return [];
+    const heldBatch: BatchClass[] = parsed.classification.decisionOrders
+      .filter((d) => decisions[d.order.name] === 'drop_batch' && d.year != null && d.month != null)
+      .map((d) => ({
+        order: d.order,
+        year: d.year as number,
+        month: d.month as number,
+        slot1Cans: d.slot1Cans,
+        slot2Cans: d.slot2Cans,
+        heldLines: d.nonDropLines,
+      }));
+    return aggregateBatchMonths([...parsed.classification.batchOrders, ...heldBatch]);
+  }, [parsed, decisions]);
+
+  const buckets = useMemo(() => {
+    const matched: ReviewGroup[] = [];
+    const needs: ReviewGroup[] = [];
+    const unmatched: ReviewGroup[] = [];
+    for (const g of shipNowGroups) {
+      if (g.match.kind === 'matched') matched.push(g);
+      else if (g.match.kind === 'needs_confirmation') needs.push(g);
+      else unmatched.push(g);
+    }
+    return { matched, needs, unmatched };
+  }, [shipNowGroups]);
+
+  const unactioned = useMemo(
+    () => (parsed?.classification.decisionOrders ?? []).filter((d) => !decisions[d.order.name]),
+    [parsed, decisions],
+  );
+
+  const pendingGroups = shipNowGroups.filter((g) => effRes(g).status === 'pending').length;
+
+  const summary = useMemo(() => {
+    const byProduct = new Map<string, number>();
+    let placeholders = 0;
+    let shipUnits = 0;
+    for (const g of shipNowGroups) {
+      shipUnits += g.totalQuantity;
+      const r = effRes(g);
+      if (r.status === 'product') byProduct.set(r.productId, (byProduct.get(r.productId) ?? 0) + g.totalQuantity);
+      else if (r.status === 'placeholder') placeholders++;
+    }
+    const dropUnits = batchMonths.reduce((s, m) => s + m.slot1Cans + m.slot2Cans, 0);
+    return {
+      shipLines: byProduct.size + placeholders,
+      shipUnits,
+      placeholders,
+      dropUnits,
+      decisionsLeft: unactioned.length,
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shipNowGroups, batchMonths, resolutions, unactioned]);
+
+  // ---- confirm + create -----------------------------------------------------
+  const handleConfirm = async () => {
+    if (!parsed) return;
+    if (unactioned.length > 0) {
+      toast.error(`${unactioned.length} order(s) still need a decision (ship now or hold for batch).`);
+      return;
+    }
+    if (pendingGroups > 0) { toast.error(`${pendingGroups} guessed match(es) need confirming.`); return; }
+    if (!workDeadline) { toast.error('Set a work deadline before confirming.'); return; }
+
+    setSubmitting(true);
+    try {
+      // FUNK account (find by name; never auto-create).
+      const { data: accts, error: acctErr } = await sb
+        .from('accounts').select('id, account_name').ilike('account_name', '%funk%').eq('is_active', true);
+      if (acctErr) throw acctErr;
+      const funk = (accts ?? [])[0];
+      if (!funk) {
+        toast.error('No active FUNK account found. Create the FUNK account first, then re-import.');
+        setSubmitting(false);
+        return;
+      }
+
+      // Shared placeholder allocator (reuse by stored CSV name; sequential names).
+      const allProducts = [...parsed.products];
+      const reuseByNote = new Map<string, string>();
+      for (const p of allProducts) if (p.is_placeholder && p.internal_packaging_notes) reuseByNote.set(p.internal_packaging_notes, p.id);
+      let seq = nextPlaceholderSeq(allProducts);
+      const ensurePlaceholder = async (rawName: string): Promise<string> => {
+        const hit = reuseByNote.get(rawName);
+        if (hit) return hit;
+        const bag = parseBagSize(rawName);
+        const { data, error } = await sb.from('products').insert({
+          product_name: placeholderName(seq),
+          is_placeholder: true, is_active: true,
+          bag_size_g: bag.grams, packaging_variant: bag.variant, format: 'WHOLE_BEAN',
+          internal_packaging_notes: rawName,
+        }).select('id').single();
+        if (error) throw error;
+        reuseByNote.set(rawName, data.id);
+        seq++;
+        return data.id;
+      };
+
+      // ---- ship-now bundle ----------------------------------------------------
+      const groupProductId = new Map<string, string>();
+      for (const g of shipNowGroups) {
+        const r = effRes(g);
+        groupProductId.set(g.key, r.status === 'product' ? r.productId : await ensurePlaceholder(g.rawName));
+      }
+      const shipQty = new Map<string, number>();
+      for (const g of shipNowGroups) {
+        const pid = groupProductId.get(g.key)!;
+        shipQty.set(pid, (shipQty.get(pid) ?? 0) + g.totalQuantity);
+      }
+
+      let bundleOrderId: string | null = null;
+      let bundleOrderNumber = '';
+      if (shipQty.size > 0) {
+        const refBase = funkReferenceBase();
+        const { data: sameDay, error: refErr } = await sb
+          .from('orders').select('client_po').eq('account_id', funk.id).like('client_po', `${refBase}%`);
+        if (refErr) throw refErr;
+        const existingRefs = (sameDay ?? []).length;
+        const reference = existingRefs === 0 ? refBase : `${refBase}-${existingRefs + 1}`;
+
+        const { data: order, error: orderErr } = await sb.from('orders').insert({
+          account_id: funk.id,
+          order_number: '',
+          status: 'CONFIRMED',
+          work_deadline_at: new Date(workDeadline).toISOString(),
+          delivery_method: 'COURIER',
+          client_po: reference,
+          source_channel: 'manual',
+          internal_ops_notes: `FUNK CSV import — ${parsed.fileName} (${parsed.newCount} orders)`,
+          created_by_user_id: authUser?.id,
+          created_by_admin: true,
+        }).select('id, order_number').single();
+        if (orderErr) throw orderErr;
+        if (!order) throw new Error('Order insert returned null — possible RLS or trigger issue.');
+        bundleOrderId = order.id;
+        bundleOrderNumber = order.order_number;
+
+        const { data: shipment, error: shipErr } = await sb.from('order_shipments')
+          .insert({ order_id: order.id, shipment_number: 1, delivery_method: 'COURIER' })
+          .select('id').single();
+        if (shipErr) throw shipErr;
+
+        const lines = Array.from(shipQty.entries()).map(([product_id, quantity_units]) => ({
+          order_id: order.id, product_id, quantity_units, grind: null,
+          unit_price_locked: 0, shipment_id: shipment?.id ?? null,
+        }));
+        const { error: liErr } = await sb.from('order_line_items').insert(lines);
+        if (liErr) throw liErr;
+      }
+
+      // ---- DROP batch orders (one standing order per month) ------------------
+      for (const m of batchMonths) {
+        // Resolve slot products via funk_drop_slots (get-or-create).
+        const slotProduct: Record<1 | 2, string | null> = { 1: null, 2: null };
+        for (const slot of [1, 2] as const) {
+          const cans = slot === 1 ? m.slot1Cans : m.slot2Cans;
+          if (cans <= 0) continue;
+          const { data: slotRow, error: slotErr } = await sb.from('funk_drop_slots')
+            .select('product_id')
+            .eq('batch_year', m.year).eq('batch_month', m.month).eq('slot_number', slot)
+            .maybeSingle();
+          if (slotErr) throw slotErr;
+          if (slotRow?.product_id) {
+            slotProduct[slot] = slotRow.product_id;
+          } else {
+            const { data: prod, error: prodErr } = await sb.from('products').insert({
+              product_name: slotProductName(slot, m.year, m.month),
+              is_placeholder: true, is_active: true,
+              bag_size_g: 250, packaging_variant: 'RETAIL_250G', format: 'WHOLE_BEAN',
+              internal_packaging_notes: `FUNK DROP slot ${slot} — ${monthShortYY(m.year, m.month)}`,
+            }).select('id').single();
+            if (prodErr) throw prodErr;
+            slotProduct[slot] = prod.id;
+            const { error: insSlot } = await sb.from('funk_drop_slots').insert({
+              batch_year: m.year, batch_month: m.month, slot_number: slot,
+              product_id: prod.id, sourced_green_ref: null,
+            });
+            if (insSlot) throw insSlot;
+          }
+        }
+
+        // Demand per product for this month: slot cans + any held non-DROP lines.
+        const demand = new Map<string, number>();
+        if (slotProduct[1] && m.slot1Cans > 0) demand.set(slotProduct[1]!, m.slot1Cans);
+        if (slotProduct[2] && m.slot2Cans > 0) demand.set(slotProduct[2]!, (demand.get(slotProduct[2]!) ?? 0) + m.slot2Cans);
+        for (const { line } of m.heldLines) {
+          const match = matchLineItem(line.sku, line.cleanedName, parsed.products, parsed.mappings);
+          const pid = match.kind === 'matched' && match.productId
+            ? match.productId
+            : await ensurePlaceholder(line.rawName);
+          demand.set(pid, (demand.get(pid) ?? 0) + line.quantity);
+        }
+
+        // Get-or-create the standing batch order for this month.
+        const { data: batchRow, error: batchErr } = await sb.from('funk_drop_batches')
+          .select('order_id').eq('batch_year', m.year).eq('batch_month', m.month).maybeSingle();
+        if (batchErr) throw batchErr;
+
+        const ship = dropShipDate(m.year, m.month);
+        let batchOrderId: string;
+        let batchShipmentId: string | null = null;
+        if (batchRow?.order_id) {
+          batchOrderId = batchRow.order_id;
+          const { data: existShip } = await sb.from('order_shipments')
+            .select('id').eq('order_id', batchOrderId).order('shipment_number').limit(1).maybeSingle();
+          batchShipmentId = existShip?.id ?? null;
+        } else {
+          const { data: bo, error: boErr } = await sb.from('orders').insert({
+            account_id: funk.id,
+            order_number: '',
+            status: 'CONFIRMED',
+            work_deadline_at: noonIso(ship),
+            delivery_method: 'COURIER',
+            client_po: dropBatchReference(m.year, m.month),
+            source_channel: 'manual',
+            internal_ops_notes: `FUNK monthly DROP batch — ${monthShortYY(m.year, m.month)} (ships ${dateStamp(ship)})`,
+            created_by_user_id: authUser?.id,
+            created_by_admin: true,
+          }).select('id').single();
+          if (boErr) throw boErr;
+          batchOrderId = bo.id;
+          const { data: bShip, error: bShipErr } = await sb.from('order_shipments')
+            .insert({ order_id: batchOrderId, shipment_number: 1, delivery_method: 'COURIER' })
+            .select('id').single();
+          if (bShipErr) throw bShipErr;
+          batchShipmentId = bShip?.id ?? null;
+          const { error: insBatch } = await sb.from('funk_drop_batches').insert({
+            batch_year: m.year, batch_month: m.month, ship_date: dateStamp(ship), order_id: batchOrderId,
+          });
+          if (insBatch) throw insBatch;
+        }
+
+        // Add/update line quantities for the newly imported demand.
+        for (const [product_id, qty] of demand.entries()) {
+          const { data: existLine, error: elErr } = await sb.from('order_line_items')
+            .select('id, quantity_units').eq('order_id', batchOrderId).eq('product_id', product_id).maybeSingle();
+          if (elErr) throw elErr;
+          if (existLine) {
+            const { error: updErr } = await sb.from('order_line_items')
+              .update({ quantity_units: (existLine.quantity_units ?? 0) + qty }).eq('id', existLine.id);
+            if (updErr) throw updErr;
+          } else {
+            const { error: insErr } = await sb.from('order_line_items').insert({
+              order_id: batchOrderId, product_id, quantity_units: qty, grind: null,
+              unit_price_locked: 0, shipment_id: batchShipmentId,
+            });
+            if (insErr) throw insErr;
+          }
+        }
+      }
+
+      // ---- import session + dedupe ledger ------------------------------------
+      const { data: session, error: sessErr } = await sb.from('funk_import_sessions').insert({
+        file_name: parsed.fileName,
+        orders_new: parsed.newCount,
+        orders_skipped: parsed.skippedCount,
+        bundle_order_id: bundleOrderId,
+      }).select('id').single();
+      if (sessErr) throw sessErr;
+
+      // Every included order, recorded with its resolved destination.
+      const ledger: { name: string; shopifyId: string; destination: DecisionChoice }[] = [];
+      for (const o of parsed.classification.shipNowOrders) ledger.push({ name: o.name, shopifyId: o.shopifyId, destination: 'ship_now' });
+      for (const b of parsed.classification.batchOrders) ledger.push({ name: b.order.name, shopifyId: b.order.shopifyId, destination: 'drop_batch' });
+      for (const d of parsed.classification.decisionOrders) {
+        const choice = decisions[d.order.name]!;
+        ledger.push({ name: d.order.name, shopifyId: d.order.shopifyId, destination: choice });
+      }
+      if (ledger.length > 0) {
+        const { error: ledErr } = await sb.from('funk_imported_orders').insert(
+          ledger.map((l) => ({
+            shopify_order_name: l.name,
+            shopify_order_id: l.shopifyId || null,
+            destination: l.destination,
+            import_session_id: session.id,
+          })),
+        );
+        if (ledErr) throw ledErr;
+      }
+
+      // Remember ship-now mappings (never for placeholders).
+      for (const g of shipNowGroups) {
+        const r = effRes(g);
+        if (r.status !== 'product') continue;
+        const useSku = g.csvSku.trim() !== '';
+        const col = useSku ? 'csv_sku' : 'csv_product_name';
+        const val = useSku ? g.csvSku.trim() : g.cleanedName;
+        const { data: ex } = await sb.from('funk_import_product_mappings').select('id').eq(col, val).maybeSingle();
+        if (ex) await sb.from('funk_import_product_mappings').update({ product_id: r.productId }).eq('id', ex.id);
+        else await sb.from('funk_import_product_mappings').insert({
+          csv_sku: useSku ? g.csvSku.trim() : null,
+          csv_product_name: useSku ? null : g.cleanedName,
+          product_id: r.productId,
+        });
+      }
+
+      queryClient.invalidateQueries({ queryKey: ['orders'] });
+      queryClient.invalidateQueries({ queryKey: ['funk-import'] });
+      if (bundleOrderId) {
+        toast.success(`Bundle order ${bundleOrderNumber} created.`);
+        navigate(`/orders/${bundleOrderId}`);
+      } else {
+        toast.success('Import complete — DROP batch order(s) updated.');
+        navigate('/orders');
+      }
+    } catch (e) {
+      toast.error(errMsg(e));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  // ---- render ---------------------------------------------------------------
+  return (
+    <div className="mx-auto max-w-5xl space-y-6 p-4">
+      <div>
+        <h1 className="text-2xl font-semibold">FUNK CSV Import</h1>
+        <p className="text-sm text-muted-foreground">
+          Manual bridge until the Shopify connector is live. Upload a Shopify orders export, review the
+          three buckets, and create the ship-now bundle plus this month's DROP batch.
+        </p>
+      </div>
+
+      <Card>
+        <CardContent className="flex flex-wrap items-center gap-3 pt-6">
+          <Input
+            ref={fileRef} type="file" accept=".csv,text/csv" className="max-w-sm"
+            onChange={(e) => { const f = e.target.files?.[0]; if (f) onPickFile(f); }}
+          />
+          <Button variant="outline" onClick={() => fileRef.current?.click()}>
+            <Upload className="mr-2 h-4 w-4" /> Choose CSV
+          </Button>
+          {parsed && (
+            <span className="text-sm text-muted-foreground">
+              {parsed.fileName} — {parsed.newCount} new, {parsed.skippedCount} already imported (skipped)
+            </span>
+          )}
+        </CardContent>
+      </Card>
+
+      {parsed && parsed.newCount > 0 && (
+        <>
+          <Card>
+            <CardContent className="flex flex-wrap items-end gap-6 pt-6">
+              <Stat label="Ship-now lines" value={summary.shipLines} />
+              <Stat label="Ship-now units" value={summary.shipUnits} />
+              <Stat label="DROP cans" value={summary.dropUnits} />
+              <Stat label="Placeholders" value={summary.placeholders} />
+              <Stat label="Need a decision" value={summary.decisionsLeft} />
+              <Stat label="New / skipped" value={`${parsed.newCount} / ${parsed.skippedCount}`} />
+              <div className="flex flex-col gap-1">
+                <label className="text-xs font-medium text-muted-foreground">Ship-now work deadline</label>
+                <Input type="datetime-local" value={workDeadline} onChange={(e) => setWorkDeadline(e.target.value)} className="w-56" />
+              </div>
+              <Button
+                className="ml-auto"
+                disabled={submitting || pendingGroups > 0 || summary.decisionsLeft > 0}
+                onClick={handleConfirm}
+              >
+                {submitting ? 'Creating…' : 'Confirm & create orders'}
+              </Button>
+            </CardContent>
+          </Card>
+          {(pendingGroups > 0 || summary.decisionsLeft > 0) && (
+            <p className="text-sm text-amber-600">
+              {summary.decisionsLeft > 0 && `${summary.decisionsLeft} order(s) need a decision. `}
+              {pendingGroups > 0 && `${pendingGroups} guessed match(es) need confirming. `}
+              Resolve these before creating orders.
+            </p>
+          )}
+
+          {/* SHIP NOW */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base"><Package className="h-4 w-4" /> Ship now</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              {shipNowGroups.length === 0 ? (
+                <p className="text-sm text-muted-foreground">No ship-now lines.</p>
+              ) : (
+                <>
+                  <Section title="Matched" count={buckets.matched.length}>
+                    {buckets.matched.map((g) => <MatchedRow key={g.key} group={g} productById={productById} />)}
+                  </Section>
+                  <Section title="Needs confirmation" count={buckets.needs.length}>
+                    {buckets.needs.map((g) => (
+                      <DecisionRow key={g.key} group={g} resolution={effRes(g)} products={realProducts}
+                        productById={productById} onChange={(r) => setRes(g.key, r)} showAcceptGuess />
+                    ))}
+                  </Section>
+                  <Section title="Unmatched" count={buckets.unmatched.length}>
+                    {buckets.unmatched.map((g) => (
+                      <DecisionRow key={g.key} group={g} resolution={effRes(g)} products={realProducts}
+                        productById={productById} onChange={(r) => setRes(g.key, r)} />
+                    ))}
+                  </Section>
+                </>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* DROP BATCH */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base"><Box className="h-4 w-4" /> This month's DROP batch</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {batchMonths.length === 0 ? (
+                <p className="text-sm text-muted-foreground">No DROP boxes routed to a batch.</p>
+              ) : (
+                batchMonths.map((m) => {
+                  const ship = dropShipDate(m.year, m.month);
+                  return (
+                    <div key={`${m.year}-${m.month}`} className="rounded border p-3">
+                      <div className="mb-2 flex items-center gap-2 font-medium">
+                        <Truck className="h-4 w-4" /> {monthShortYY(m.year, m.month)} batch — ships {dateStamp(ship)}
+                      </div>
+                      <SlotLine label={slotProductName(1, m.year, m.month)} cans={m.slot1Cans} />
+                      <SlotLine label={slotProductName(2, m.year, m.month)} cans={m.slot2Cans} />
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        Slot products are placeholders until named/sourced — the slot row is the stable key.
+                      </p>
+                      {m.heldLines.length > 0 && (
+                        <div className="mt-2 text-xs text-muted-foreground">
+                          + {m.heldLines.length} held non-DROP line(s) ride along on the batch order:
+                          <ul className="pl-4">
+                            {m.heldLines.map((h, i) => <li key={i}>{h.orderName} — {h.line.quantity}× {h.line.cleanedName}</li>)}
+                          </ul>
+                        </div>
+                      )}
+                    </div>
+                  );
+                })
+              )}
+            </CardContent>
+          </Card>
+
+          {/* NEEDS A DECISION */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <AlertTriangle className="h-4 w-4" /> Needs a decision ({unactioned.length} open)
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {parsed.classification.decisionOrders.length === 0 ? (
+                <p className="text-sm text-muted-foreground">No mixed or unreadable orders.</p>
+              ) : (
+                parsed.classification.decisionOrders.map((d) => {
+                  const choice = decisions[d.order.name];
+                  const canHold = d.canExpand;
+                  return (
+                    <div key={d.order.name} className="rounded border px-3 py-2">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="font-medium">{d.order.name}</span>
+                        <Badge variant="outline" className="text-amber-600">
+                          {d.reason === 'mixed' ? 'mixed order' : d.reason === 'unparseable' ? 'can count unreadable' : 'no order date'}
+                        </Badge>
+                        {choice && (
+                          <Badge variant="default" className="gap-1">
+                            <Check className="h-3 w-3" /> {choice === 'ship_now' ? 'ship now' : 'hold for DROP batch'}
+                          </Badge>
+                        )}
+                      </div>
+                      <ul className="mt-1 pl-4 text-xs text-muted-foreground">
+                        {d.order.lineItems.map((li, i) => (
+                          <li key={i}>{li.isDrop ? '🟦 ' : ''}{li.quantity}× {li.cleanedName}{li.isDrop && li.dropCans == null ? ' (can count unreadable)' : ''}</li>
+                        ))}
+                      </ul>
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        <Button size="sm" variant={choice === 'ship_now' ? 'secondary' : 'outline'}
+                          onClick={() => setDecisions((p) => ({ ...p, [d.order.name]: 'ship_now' }))}>
+                          Ship the whole order now
+                        </Button>
+                        <Button size="sm" variant={choice === 'drop_batch' ? 'secondary' : 'outline'}
+                          disabled={!canHold}
+                          title={canHold ? '' : 'Can count or order date unreadable — cannot expand into a batch.'}
+                          onClick={() => setDecisions((p) => ({ ...p, [d.order.name]: 'drop_batch' }))}>
+                          Hold whole order for this month's DROP batch
+                        </Button>
+                      </div>
+                    </div>
+                  );
+                })
+              )}
+            </CardContent>
+          </Card>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function Stat({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="flex flex-col">
+      <span className="text-xs font-medium text-muted-foreground">{label}</span>
+      <span className="text-xl font-semibold">{value}</span>
+    </div>
+  );
+}
+
+function SlotLine({ label, cans }: { label: string; cans: number }) {
+  return (
+    <div className="flex items-center justify-between text-sm">
+      <span>{label}</span>
+      <span className="font-semibold">{cans} cans (250g)</span>
+    </div>
+  );
+}
+
+function Section({ title, count, children }: { title: string; count: number; children: React.ReactNode }) {
+  return (
+    <div>
+      <h3 className="mb-2 text-sm font-semibold">{title} <span className="text-muted-foreground">({count})</span></h3>
+      {count === 0 ? <p className="text-sm text-muted-foreground">None.</p> : <div className="space-y-2">{children}</div>}
+    </div>
+  );
+}
+
+function ContributingRows({ group }: { group: ReviewGroup }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="mt-1">
+      <button className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground" onClick={() => setOpen((o) => !o)}>
+        {open ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+        {group.rows.length} contributing line{group.rows.length === 1 ? '' : 's'}
+      </button>
+      {open && (
+        <ul className="mt-1 pl-5 text-xs text-muted-foreground">
+          {group.rows.map((r, i) => <li key={i}>{r.orderName} — {r.quantity}× {r.rawName}</li>)}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function MatchedRow({ group, productById }: { group: ReviewGroup; productById: Map<string, ProductLite> }) {
+  const product = productById.get(group.match.productId!);
+  return (
+    <div className="rounded border px-3 py-2">
+      <div className="flex items-center justify-between gap-2">
+        <span className="font-medium">{product?.product_name ?? '(unknown product)'}</span>
+        <span className="text-sm font-semibold">{group.totalQuantity} units</span>
+      </div>
+      <ContributingRows group={group} />
+    </div>
+  );
+}
+
+function DecisionRow({
+  group, resolution, products, productById, onChange, showAcceptGuess,
+}: {
+  group: ReviewGroup;
+  resolution: Resolution;
+  products: ProductLite[];
+  productById: Map<string, ProductLite>;
+  onChange: (r: Resolution) => void;
+  showAcceptGuess?: boolean;
+}) {
+  const guessId = group.match.productId;
+  const guess = guessId ? productById.get(guessId) : undefined;
+  const chosen = resolution.status === 'product' ? productById.get(resolution.productId) : undefined;
+  return (
+    <div className="rounded border px-3 py-2">
+      <div className="flex items-center justify-between gap-2">
+        <div className="min-w-0">
+          <div className="truncate font-medium">{group.cleanedName}</div>
+          {group.csvSku && <div className="text-xs text-muted-foreground">SKU {group.csvSku}</div>}
+        </div>
+        <span className="shrink-0 text-sm font-semibold">{group.totalQuantity} units</span>
+      </div>
+      <div className="mt-2 flex flex-wrap items-center gap-2">
+        {resolution.status === 'product' && (
+          <Badge variant="default" className="gap-1"><Check className="h-3 w-3" /> {chosen?.product_name ?? 'product'}</Badge>
+        )}
+        {resolution.status === 'placeholder' && (
+          <Badge variant="secondary" className="max-w-xs gap-1"><Check className="h-3 w-3" /> new placeholder for “{group.rawName}”</Badge>
+        )}
+        {resolution.status === 'pending' && (
+          <Badge variant="outline" className="text-amber-600">needs confirmation</Badge>
+        )}
+        {showAcceptGuess && guessId && resolution.status === 'pending' && (
+          <Button size="sm" variant="outline" onClick={() => onChange({ status: 'product', productId: guessId })}>
+            Accept guess: {guess?.product_name ?? 'product'}
+          </Button>
+        )}
+        <ProductCombobox products={products} value={resolution.status === 'product' ? resolution.productId : ''}
+          onChange={(id) => onChange({ status: 'product', productId: id })} />
+        <Button size="sm" variant={resolution.status === 'placeholder' ? 'secondary' : 'ghost'}
+          disabled={resolution.status === 'placeholder'} onClick={() => onChange({ status: 'placeholder' })}>
+          {resolution.status === 'placeholder' ? 'Placeholder ✓' : 'Send to placeholder'}
+        </Button>
+      </div>
+      <ContributingRows group={group} />
+    </div>
+  );
+}
+
+function ProductCombobox({ products, value, onChange }: { products: ProductLite[]; value: string; onChange: (id: string) => void }) {
+  const [open, setOpen] = useState(false);
+  const selected = products.find((p) => p.id === value);
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button size="sm" variant="outline" className="justify-between gap-2">
+          {selected ? selected.product_name : 'Pick a product'}
+          <ChevronsUpDown className="h-3 w-3 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-80 p-0" align="start">
+        <Command>
+          <CommandInput placeholder="Search products…" />
+          <CommandList>
+            <CommandEmpty>No product found.</CommandEmpty>
+            <CommandGroup>
+              {products.map((p) => (
+                <CommandItem key={p.id} value={`${p.product_name} ${p.sku ?? ''}`}
+                  onSelect={() => { onChange(p.id); setOpen(false); }}>
+                  <Check className={cn('mr-2 h-4 w-4', value === p.id ? 'opacity-100' : 'opacity-0')} />
+                  <span className="truncate">{p.product_name}</span>
+                  {p.sku && <span className="ml-2 text-xs text-muted-foreground">{p.sku}</span>}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}


### PR DESCRIPTION
Additive ADMIN/OPS importer at `/admin/funk-import` that turns a Shopify orders CSV into JIM orders — a manual bridge until the Shopify connector is live. No changes to existing order, production, FG ledger, or pricing logic.

## Build 1 — ship-now bundle
- RFC-4180 CSV parse (quoted commas + embedded newlines)
- Dedupe by Shopify order name via `funk_imported_orders`
- Perennial-subscription name cleaning; saved-mapping / auto-guess / unmatched product matching; sequential placeholder products; mapping persistence
- One CONFIRMED bundle order against the FUNK account, ref `FUNK-CSV-YYYY-MM-DD`

## Build 2 — DROP batch engine
- Hard-date routing by each order's Shopify date (≤14 → batch, ≥15 → ship-now)
- Mixed / unparseable orders land in a **Needs-a-decision** bucket with per-order ship-now / hold-for-batch actions
- DROP can expansion into two 250g slot products; get-or-create `funk_drop_slots` + `funk_drop_batches`; monthly standing order with Fri-adjusted 15th ship date; existing batch line qtys incremented on re-import
- Three-bucket review screen + running summary

## Notes
- Logic isolated in `src/lib/funkCsvImport.ts` — **29 Vitest cases**, `tsc` clean
- `funk_*` tables / `products.is_placeholder` reached via the established `supabase as any` pattern (generated types not yet regenerated)
- Verified end-to-end in a live session across all three buckets (no DB writes committed during testing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)