### PR TITLE
WIP/FG: read from inventory_transactions ledger; floor counts write balancing ADJUSTMENT rows

### DIFF
--- a/src/components/admin/GenericLaneConversion.tsx
+++ b/src/components/admin/GenericLaneConversion.tsx
@@ -551,17 +551,27 @@ function ReassignFgDialog({
       const genIds = (genProducts ?? []).map((p) => p.id);
       if (genIds.length === 0) return [];
 
+      // FG on-hand per generic product, from the inventory_transactions ledger.
       const { data, error } = await supabase
-        .from('fg_inventory')
-        .select('product_id, units_on_hand')
+        .from('inventory_transactions')
+        .select('product_id, quantity_units, transaction_type')
         .in('product_id', genIds)
-        .gt('units_on_hand', 0);
+        .in('transaction_type', ['PACK_PRODUCE_FG', 'SHIP_CONSUME_FG', 'ADJUSTMENT']);
       if (error) throw error;
 
-      return (data ?? []).map((row) => ({
-        ...row,
-        product_name: genProducts?.find((p) => p.id === row.product_id)?.product_name ?? 'Unknown',
-      }));
+      const byProduct: Record<string, number> = {};
+      for (const r of data ?? []) {
+        if (!r.product_id) continue;
+        byProduct[r.product_id] = (byProduct[r.product_id] ?? 0) + Number(r.quantity_units ?? 0);
+      }
+
+      return genIds
+        .map((id) => ({
+          product_id: id,
+          units_on_hand: Math.max(0, byProduct[id] ?? 0),
+          product_name: genProducts?.find((p) => p.id === id)?.product_name ?? 'Unknown',
+        }))
+        .filter((row) => row.units_on_hand > 0);
     },
   });
 
@@ -573,54 +583,19 @@ function ReassignFgDialog({
     if (!sourceProductId || !targetProductId || numAmount <= 0) return;
     setSubmitting(true);
     try {
-      // Decrement source
-      const { data: srcRow, error: e1 } = await supabase
-        .from('fg_inventory')
-        .select('units_on_hand')
-        .eq('product_id', sourceProductId)
-        .single();
-      if (e1) throw e1;
-      const newSourceUnits = (srcRow?.units_on_hand ?? 0) - numAmount;
-      const { error: e2 } = await supabase
-        .from('fg_inventory')
-        .update({ units_on_hand: newSourceUnits } as any)
-        .eq('product_id', sourceProductId);
-      if (e2) throw e2;
-
-      // Upsert target
-      const { data: tgtRow } = await supabase
-        .from('fg_inventory')
-        .select('units_on_hand')
-        .eq('product_id', targetProductId)
-        .maybeSingle();
-      const oldTargetUnits = tgtRow?.units_on_hand ?? 0;
-      const newTargetUnits = oldTargetUnits + numAmount;
-      if (tgtRow) {
-        const { error: e3 } = await supabase
-          .from('fg_inventory')
-          .update({ units_on_hand: newTargetUnits } as any)
-          .eq('product_id', targetProductId);
-        if (e3) throw e3;
-      } else {
-        const { error: e3 } = await supabase
-          .from('fg_inventory')
-          .insert({ product_id: targetProductId, units_on_hand: numAmount });
-        if (e3) throw e3;
-      }
-
-      // Get target product name
       const targetName = nonGenericProducts.find((p) => p.id === targetProductId)?.product_name ?? 'target';
       const sourceName = selectedSource?.product_name ?? 'Generic';
 
-      // Log entries
-      const { error: e4 } = await supabase.from('fg_inventory_log').insert([
-        { product_id: sourceProductId, units_delta: -numAmount, units_after: newSourceUnits, notes: `Reassigned to ${targetName}`, created_by: authUserId },
-        { product_id: targetProductId, units_delta: numAmount, units_after: newTargetUnits, notes: `Reassigned from ${sourceName}`, created_by: authUserId },
+      // Balanced FG reassignment written to the inventory_transactions ledger:
+      // −units off the source product, +units onto the target product.
+      const { error } = await supabase.from('inventory_transactions').insert([
+        { product_id: sourceProductId, transaction_type: 'ADJUSTMENT' as const, quantity_units: -numAmount, notes: `Reassigned to ${targetName}`, created_by: authUserId, is_system_generated: false },
+        { product_id: targetProductId, transaction_type: 'ADJUSTMENT' as const, quantity_units: numAmount, notes: `Reassigned from ${sourceName}`, created_by: authUserId, is_system_generated: false },
       ]);
-      if (e4) throw e4;
+      if (error) throw error;
 
       toast.success(`${numAmount} units moved to ${targetName}`);
-      queryClient.invalidateQueries({ queryKey: ['fg-inventory'] });
+      queryClient.invalidateQueries({ queryKey: ['authoritative-fg-ledger'] });
       queryClient.invalidateQueries({ queryKey: ['generic-fg-inventory'] });
       resetAndClose();
     } catch (err: any) {

--- a/src/components/production/ShipTab.tsx
+++ b/src/components/production/ShipTab.tsx
@@ -158,8 +158,8 @@ export function ShipTab({ dateFilterConfig, today }: ShipTabProps) {
     });
   }, [allOrderLineItems, dateFilterConfig.mode]);
 
-  // ========== AUTHORITATIVE FG INVENTORY (from source-of-truth tables) ==========
-  // FG = sum(packing_runs.units_packed) - sum(ship_picks.units_picked for open orders)
+  // ========== AUTHORITATIVE FG INVENTORY (from the inventory_transactions ledger) ==========
+  // FG = sum(quantity_units) over PACK_PRODUCE_FG + SHIP_CONSUME_FG + ADJUSTMENT, per product
   const { data: authFg } = useAuthoritativeFg();
   const { data: authShortList } = useAuthoritativeShortList();
   

--- a/src/components/products/FGInventoryTab.tsx
+++ b/src/components/products/FGInventoryTab.tsx
@@ -1,67 +1,37 @@
 import React, { useState, useMemo, useRef, useCallback } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
 import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
-import { Plus, Minus, Search, PackagePlus } from 'lucide-react';
+import { Plus, Minus, Search } from 'lucide-react';
 import { PackagingBadge, type PackagingVariant } from '@/components/PackagingBadge';
-import { format } from 'date-fns';
+import { useAuthoritativeFg } from '@/hooks/useAuthoritativeInventory';
 
-interface FGInventoryRow {
-  id: string;
+interface FGRow {
   product_id: string;
   units_on_hand: number;
-  updated_at: string;
-  product: {
-    id: string;
-    product_name: string;
-    sku: string | null;
-    packaging_variant: PackagingVariant | null;
-    is_active: boolean;
-    client: { name: string } | null;
-  };
-}
-
-interface ActiveProduct {
-  id: string;
   product_name: string;
   sku: string | null;
   packaging_variant: PackagingVariant | null;
-  client: { name: string } | null;
+  client_name: string | null;
 }
 
 export function FGInventoryTab() {
   const queryClient = useQueryClient();
+  const { authUser } = useAuth();
   const [searchQuery, setSearchQuery] = useState('');
   const [editingRowId, setEditingRowId] = useState<string | null>(null);
-  const lastEditTime = useRef<number>(0);
   const sortFreezeTimeout = useRef<NodeJS.Timeout | null>(null);
   const [isSortFrozen, setIsSortFrozen] = useState(false);
 
-  // Fetch FG inventory with product info
-  const { data: inventory, isLoading } = useQuery({
-    queryKey: ['fg-inventory-all'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('fg_inventory')
-        .select(`
-          id,
-          product_id,
-          units_on_hand,
-          updated_at,
-          product:products(id, product_name, sku, packaging_variant, is_active, client:clients(name))
-        `)
-        .order('updated_at', { ascending: false });
+  // FG on-hand from the inventory_transactions ledger (single source of truth).
+  const { data: authoritativeFg, isLoading: fgLoading } = useAuthoritativeFg();
 
-      if (error) throw error;
-      return (data ?? []) as FGInventoryRow[];
-    },
-  });
-
-  // Fetch all active products (for backfill)
-  const { data: activeProducts } = useQuery({
+  // Active products supply the display metadata (client, packaging, sku).
+  const { data: activeProducts, isLoading: productsLoading } = useQuery({
     queryKey: ['active-products-for-fg'],
     queryFn: async () => {
       const { data, error } = await supabase
@@ -69,73 +39,75 @@ export function FGInventoryTab() {
         .select('id, product_name, sku, packaging_variant, client:clients(name)')
         .eq('is_active', true)
         .order('product_name');
-
       if (error) throw error;
-      return (data ?? []) as ActiveProduct[];
+      return data ?? [];
     },
   });
 
-  // Products without inventory rows
-  const productsWithoutInventory = useMemo(() => {
-    if (!activeProducts || !inventory) return [];
-    const inventoryProductIds = new Set(inventory.map((i) => i.product_id));
-    return activeProducts.filter((p) => !inventoryProductIds.has(p.id));
-  }, [activeProducts, inventory]);
+  const isLoading = fgLoading || productsLoading;
 
-  // Filter and sort inventory
+  const rows = useMemo<FGRow[]>(() => {
+    const fg = authoritativeFg ?? {};
+    return (activeProducts ?? []).map((p) => ({
+      product_id: p.id,
+      units_on_hand: fg[p.id]?.fg_available_units ?? 0,
+      product_name: p.product_name,
+      sku: p.sku,
+      packaging_variant: (p.packaging_variant as PackagingVariant | null) ?? null,
+      client_name: (p.client as { name: string } | null)?.name ?? null,
+    }));
+  }, [activeProducts, authoritativeFg]);
+
   const filteredInventory = useMemo(() => {
-    if (!inventory) return [];
-    
-    let filtered = inventory.filter((row) => row.product.is_active);
-    
+    let filtered = rows;
     if (searchQuery.trim()) {
       const query = searchQuery.toLowerCase();
       filtered = filtered.filter((row) =>
-        row.product.product_name.toLowerCase().includes(query) ||
-        row.product.sku?.toLowerCase().includes(query) ||
-        row.product.client?.name.toLowerCase().includes(query)
+        row.product_name.toLowerCase().includes(query) ||
+        row.sku?.toLowerCase().includes(query) ||
+        row.client_name?.toLowerCase().includes(query)
       );
     }
-
-    // Sort by client, then product name (unless sort is frozen)
     if (!isSortFrozen) {
-      filtered.sort((a, b) => {
-        const clientA = a.product.client?.name ?? '';
-        const clientB = b.product.client?.name ?? '';
+      filtered = [...filtered].sort((a, b) => {
+        const clientA = a.client_name ?? '';
+        const clientB = b.client_name ?? '';
         if (clientA !== clientB) return clientA.localeCompare(clientB);
-        return a.product.product_name.localeCompare(b.product.product_name);
+        return a.product_name.localeCompare(b.product_name);
       });
     }
-
     return filtered;
-  }, [inventory, searchQuery, isSortFrozen]);
+  }, [rows, searchQuery, isSortFrozen]);
 
-  // Freeze sort on edit
   const freezeSort = useCallback(() => {
     setIsSortFrozen(true);
-    lastEditTime.current = Date.now();
-    
-    if (sortFreezeTimeout.current) {
-      clearTimeout(sortFreezeTimeout.current);
-    }
+    if (sortFreezeTimeout.current) clearTimeout(sortFreezeTimeout.current);
     sortFreezeTimeout.current = setTimeout(() => {
       setIsSortFrozen(false);
       setEditingRowId(null);
     }, 1200);
   }, []);
 
-  // Update mutation
-  const updateMutation = useMutation({
-    mutationFn: async ({ id, units }: { id: string; units: number }) => {
+  // A change writes ONE balancing ADJUSTMENT row to inventory_transactions
+  // (quantity_units = counted − current ledger balance). Stamped with the user;
+  // created_at provides the timestamp. No writes to the retired fg_inventory.
+  const adjustMutation = useMutation({
+    mutationFn: async ({ productId, unitsDelta, newUnits }: { productId: string; unitsDelta: number; newUnits: number }) => {
+      if (!unitsDelta) return;
       const { error } = await supabase
-        .from('fg_inventory')
-        .update({ units_on_hand: units, updated_at: new Date().toISOString() })
-        .eq('id', id);
-
+        .from('inventory_transactions')
+        .insert({
+          transaction_type: 'ADJUSTMENT',
+          product_id: productId,
+          quantity_units: unitsDelta,
+          notes: `FG floor count: counted ${newUnits} units (delta ${unitsDelta >= 0 ? '+' : ''}${unitsDelta})`,
+          created_by: authUser?.id,
+          is_system_generated: false,
+        });
       if (error) throw error;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['fg-inventory-all'] });
+      queryClient.invalidateQueries({ queryKey: ['authoritative-fg-ledger'] });
     },
     onError: (err) => {
       console.error(err);
@@ -143,46 +115,19 @@ export function FGInventoryTab() {
     },
   });
 
-  // Backfill mutation
-  const backfillMutation = useMutation({
-    mutationFn: async () => {
-      if (productsWithoutInventory.length === 0) return 0;
-
-      const rows = productsWithoutInventory.map((p) => ({
-        product_id: p.id,
-        units_on_hand: 0,
-      }));
-
-      const { error } = await supabase.from('fg_inventory').insert(rows);
-      if (error) throw error;
-
-      return productsWithoutInventory.length;
-    },
-    onSuccess: (count) => {
-      if (count > 0) {
-        toast.success(`Added ${count} inventory row${count > 1 ? 's' : ''}`);
-        queryClient.invalidateQueries({ queryKey: ['fg-inventory-all'] });
-      }
-    },
-    onError: (err) => {
-      console.error(err);
-      toast.error('Failed to add inventory rows');
-    },
-  });
-
-  const handleQuantityChange = (row: FGInventoryRow, delta: number) => {
+  const handleQuantityChange = (row: FGRow, delta: number) => {
     const newUnits = Math.max(0, row.units_on_hand + delta);
-    setEditingRowId(row.id);
+    setEditingRowId(row.product_id);
     freezeSort();
-    updateMutation.mutate({ id: row.id, units: newUnits });
+    adjustMutation.mutate({ productId: row.product_id, unitsDelta: newUnits - row.units_on_hand, newUnits });
   };
 
-  const handleInputChange = (row: FGInventoryRow, value: string) => {
+  const handleInputChange = (row: FGRow, value: string) => {
     const numValue = value.replace(/[^0-9]/g, '');
-    const units = numValue === '' ? 0 : parseInt(numValue, 10);
-    setEditingRowId(row.id);
+    const newUnits = numValue === '' ? 0 : parseInt(numValue, 10);
+    setEditingRowId(row.product_id);
     freezeSort();
-    updateMutation.mutate({ id: row.id, units: Math.max(0, units) });
+    adjustMutation.mutate({ productId: row.product_id, unitsDelta: Math.max(0, newUnits) - row.units_on_hand, newUnits: Math.max(0, newUnits) });
   };
 
   return (
@@ -197,20 +142,6 @@ export function FGInventoryTab() {
             className="pl-9"
           />
         </div>
-        {productsWithoutInventory.length > 0 && (
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => backfillMutation.mutate()}
-            disabled={backfillMutation.isPending}
-            className="gap-2"
-          >
-            <PackagePlus className="h-4 w-4" />
-            {backfillMutation.isPending
-              ? 'Adding…'
-              : `Add ${productsWithoutInventory.length} missing`}
-          </Button>
-        )}
       </div>
 
       <Card>
@@ -222,7 +153,7 @@ export function FGInventoryTab() {
             <p className="text-muted-foreground">Loading…</p>
           ) : filteredInventory.length === 0 ? (
             <p className="text-muted-foreground">
-              {searchQuery ? 'No matching products.' : 'No inventory records yet.'}
+              {searchQuery ? 'No matching products.' : 'No active products.'}
             </p>
           ) : (
             <table className="w-full text-sm">
@@ -233,21 +164,20 @@ export function FGInventoryTab() {
                   <th className="pb-2">SKU</th>
                   <th className="pb-2">Packaging</th>
                   <th className="pb-2 text-right">On Hand</th>
-                  <th className="pb-2 text-right">Updated</th>
                 </tr>
               </thead>
               <tbody>
                 {filteredInventory.map((row) => (
                   <tr
-                    key={row.id}
-                    className={`border-b last:border-0 ${editingRowId === row.id ? 'bg-muted/50' : ''}`}
+                    key={row.product_id}
+                    className={`border-b last:border-0 ${editingRowId === row.product_id ? 'bg-muted/50' : ''}`}
                   >
-                    <td className="py-2 font-medium">{row.product.product_name}</td>
-                    <td className="py-2">{row.product.client?.name ?? '—'}</td>
-                    <td className="py-2">{row.product.sku || '—'}</td>
+                    <td className="py-2 font-medium">{row.product_name}</td>
+                    <td className="py-2">{row.client_name ?? '—'}</td>
+                    <td className="py-2">{row.sku || '—'}</td>
                     <td className="py-2">
-                      {row.product.packaging_variant ? (
-                        <PackagingBadge variant={row.product.packaging_variant} />
+                      {row.packaging_variant ? (
+                        <PackagingBadge variant={row.packaging_variant} />
                       ) : (
                         <span className="text-muted-foreground">—</span>
                       )}
@@ -270,7 +200,7 @@ export function FGInventoryTab() {
                           value={row.units_on_hand}
                           onChange={(e) => handleInputChange(row, e.target.value)}
                           onFocus={() => {
-                            setEditingRowId(row.id);
+                            setEditingRowId(row.product_id);
                             freezeSort();
                           }}
                         />
@@ -283,9 +213,6 @@ export function FGInventoryTab() {
                           <Plus className="h-3 w-3" />
                         </Button>
                       </div>
-                    </td>
-                    <td className="py-2 text-right text-muted-foreground text-xs">
-                      {format(new Date(row.updated_at), 'MMM d, h:mm a')}
                     </td>
                   </tr>
                 ))}

--- a/src/components/roast-groups/RoastGroupWipSection.tsx
+++ b/src/components/roast-groups/RoastGroupWipSection.tsx
@@ -16,9 +16,11 @@ interface Props {
 /**
  * WIP summary + Adjust button, shown on the roast-group detail page (ADMIN/OPS only).
  *
- * WIP balance is computed the same way as Inventory Levels:
- *   sum(inventory_transactions.quantity_kg for {ROAST_OUTPUT, PACK_CONSUME_WIP, ADJUSTMENT, LOSS})
- *   + sum(wip_adjustments.kg_delta)
+ * WIP balance is computed the same way as Inventory Levels, entirely from the
+ * inventory_transactions ledger:
+ *   sum(quantity_kg for {ROAST_OUTPUT, PACK_CONSUME_WIP, ADJUSTMENT, LOSS})
+ * Manual floor-count / recount adjustments are ADJUSTMENT rows here now (the
+ * separate wip_adjustments table is retired).
  */
 export function RoastGroupWipSection({ roastGroupKey, displayName }: Props) {
   const { authUser } = useAuth();
@@ -28,23 +30,16 @@ export function RoastGroupWipSection({ roastGroupKey, displayName }: Props) {
   const { data, isLoading } = useQuery({
     queryKey: ['roast-group-wip', roastGroupKey],
     queryFn: async () => {
-      const [txRes, adjRes] = await Promise.all([
-        supabase
-          .from('inventory_transactions')
-          .select('quantity_kg, transaction_type')
-          .eq('roast_group', roastGroupKey)
-          .in('transaction_type', ['ROAST_OUTPUT', 'PACK_CONSUME_WIP', 'ADJUSTMENT', 'LOSS']),
-        supabase
-          .from('wip_adjustments')
-          .select('kg_delta, reason, notes, created_at, created_by')
-          .eq('roast_group', roastGroupKey)
-          .order('created_at', { ascending: false }),
-      ]);
-      if (txRes.error) throw txRes.error;
-      if (adjRes.error) throw adjRes.error;
+      const { data, error } = await supabase
+        .from('inventory_transactions')
+        .select('quantity_kg, transaction_type, notes, created_at, created_by')
+        .eq('roast_group', roastGroupKey)
+        .in('transaction_type', ['ROAST_OUTPUT', 'PACK_CONSUME_WIP', 'ADJUSTMENT', 'LOSS'])
+        .order('created_at', { ascending: false });
+      if (error) throw error;
 
       let txSum = 0;
-      for (const r of txRes.data ?? []) {
+      for (const r of data ?? []) {
         const kg = Number(r.quantity_kg) || 0;
         if (r.transaction_type === 'LOSS') {
           // LOSS rows reduce WIP — ledger writes are typically negative,
@@ -54,11 +49,10 @@ export function RoastGroupWipSection({ roastGroupKey, displayName }: Props) {
           txSum += kg;
         }
       }
-      let adjSum = 0;
-      for (const a of adjRes.data ?? []) adjSum += Number(a.kg_delta) || 0;
 
-      const lastAdj = (adjRes.data ?? [])[0] ?? null;
-      return { balance: txSum + adjSum, lastAdj };
+      // Most recent manual adjustment (floor count / recount) for the footnote.
+      const lastAdj = (data ?? []).find((r) => r.transaction_type === 'ADJUSTMENT') ?? null;
+      return { balance: txSum, lastAdj };
     },
   });
 
@@ -108,7 +102,7 @@ export function RoastGroupWipSection({ roastGroupKey, displayName }: Props) {
           <p className="text-xs text-muted-foreground">
             Last adjusted{' '}
             {format(new Date(lastAdj.created_at), 'MMM d, yyyy h:mm a')}
-            {lastAdj.reason ? ` (${lastAdj.reason})` : ''}
+            {lastAdj.notes ? ` (${lastAdj.notes})` : ''}
           </p>
         )}
       </CardContent>

--- a/src/hooks/useAuthoritativeInventory.ts
+++ b/src/hooks/useAuthoritativeInventory.ts
@@ -1,12 +1,15 @@
 /**
  * Authoritative Inventory Hooks
- * 
- * These hooks compute inventory from SOURCE-OF-TRUTH tables:
- * - WIP = sum(roasted_batches.actual_output_kg where status='ROASTED') - sum(packing_runs.kg_consumed)
- * - FG = sum(packing_runs.units_packed) - sum(ship_picks.units_picked)
- * - Demand = CONFIRMED orders only (not DRAFT/SUBMITTED/CANCELLED)
- * 
- * These replace any cached "levels" tables for production UX.
+ *
+ * These hooks compute inventory from the inventory_transactions ledger — the
+ * single source of truth that triggers/RPCs maintain and that manual floor
+ * counts append balancing ADJUSTMENT rows to:
+ * - WIP per roast_group = sum(quantity_kg) over ROAST_OUTPUT + PACK_CONSUME_WIP + ADJUSTMENT + LOSS
+ * - FG per product      = sum(quantity_units) over PACK_PRODUCE_FG + SHIP_CONSUME_FG + ADJUSTMENT
+ * - Demand = CONFIRMED/open orders (order_line_items + ship_picks for picked progress)
+ *
+ * These replace the older packing_runs − ship_picks and wip_adjustments
+ * derivations and any cached "levels" tables for production UX.
  */
 
 import { useQuery } from '@tanstack/react-query';
@@ -95,22 +98,6 @@ function useRoastedBatches() {
 }
 
 /**
- * Fetch all packing runs (for WIP consumption and FG creation)
- */
-function usePackingRuns() {
-  return useQuery({
-    queryKey: ['authoritative-packing-runs'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('packing_runs')
-        .select('id, product_id, units_packed, kg_consumed');
-      if (error) throw error;
-      return data ?? [];
-    },
-  });
-}
-
-/**
  * Fetch WIP-related transactions from inventory_transactions ledger
  * This includes ROAST_OUTPUT (positive), PACK_CONSUME_WIP (negative), ADJUSTMENT, and LOSS
  * The ledger is the single source of truth for all WIP movements
@@ -131,16 +118,22 @@ function useWipLedgerTransactions() {
 }
 
 /**
- * Fetch manual WIP adjustments (opening balances, recounts, losses, etc.)
- * These are separate from inventory_transactions and must be included for correct WIP totals.
+ * Fetch FG-related transactions from the inventory_transactions ledger.
+ * FG on-hand per product = sum(quantity_units) over PACK_PRODUCE_FG (+),
+ * SHIP_CONSUME_FG (−, written on pick/return), and ADJUSTMENT (floor count).
+ * This ledger is the single source of truth for FG, replacing the old
+ * packing_runs − ship_picks derivation so floor-count ADJUSTMENT rows move
+ * the on-hand number.
  */
-function useWipManualAdjustments() {
+function useFgLedgerTransactions() {
   return useQuery({
-    queryKey: ['authoritative-wip-manual-adjustments'],
+    queryKey: ['authoritative-fg-ledger'],
     queryFn: async () => {
       const { data, error } = await supabase
-        .from('wip_adjustments')
-        .select('roast_group, kg_delta');
+        .from('inventory_transactions')
+        .select('product_id, quantity_units, transaction_type')
+        .not('product_id', 'is', null)
+        .in('transaction_type', ['PACK_PRODUCE_FG', 'SHIP_CONSUME_FG', 'ADJUSTMENT']);
       if (error) throw error;
       return data ?? [];
     },
@@ -262,11 +255,6 @@ export interface WipLedgerTx {
   quantity_kg: number | null;
   transaction_type: string | null;
 }
-export interface WipManualAdjustmentRow {
-  roast_group: string | null;
-  kg_delta: number | null;
-}
-
 /** Minimal batch shape for blend-reservation accounting. */
 export interface BlendReservationBatch {
   roast_group: string | null;
@@ -284,7 +272,9 @@ export interface BlendReservationBatch {
  * - ROAST_OUTPUT: positive kg added (roasted batches, INCLUDING blend component batches,
  *   which write a ROAST_OUTPUT to their own component roast group when roasted)
  * - PACK_CONSUME_WIP: negative kg removed (packing consumed)
- * - ADJUSTMENT: +/- kg (blend output +, blend component decrement -, reverts, manual)
+ * - ADJUSTMENT: +/- kg (blend output +, blend component decrement -, reverts, and the
+ *   manual floor-count / recount / opening-balance adjustments — these were formerly in
+ *   the separate wip_adjustments table, now backfilled into inventory_transactions)
  * - LOSS: negative kg (recorded losses)
  *
  * Blend bookkeeping must stay balanced: executing a blend writes a positive ADJUSTMENT
@@ -303,7 +293,6 @@ export interface BlendReservationBatch {
  */
 export function computeAuthoritativeWip(
   wipTransactions: WipLedgerTx[],
-  manualAdjustments: WipManualAdjustmentRow[] = [],
   reservationBatches: BlendReservationBatch[] = [],
 ): Record<string, AuthoritativeWip> {
   // Aggregate transactions by roast group and type
@@ -334,11 +323,6 @@ export function computeAuthoritativeWip(
         adjustmentsByGroup[tx.roast_group] = (adjustmentsByGroup[tx.roast_group] ?? 0) + kg;
         break;
     }
-  }
-
-  for (const adj of manualAdjustments) {
-    if (!adj.roast_group) continue;
-    adjustmentsByGroup[adj.roast_group] = (adjustmentsByGroup[adj.roast_group] ?? 0) + Number(adj.kg_delta ?? 0);
   }
 
   // Reservation: ROASTED component batches earmarked for a blend, not yet consumed.
@@ -388,7 +372,6 @@ export function computeAuthoritativeWip(
  */
 export function useAuthoritativeWip() {
   const { data: wipTransactions, isLoading: wipLoading } = useWipLedgerTransactions();
-  const { data: manualAdjustments, isLoading: manualLoading } = useWipManualAdjustments();
   const { data: roastGroups, isLoading: roastGroupsLoading } = useRoastGroupsInfo();
   const { data: batches, isLoading: batchesLoading } = useRoastedBatches();
 
@@ -396,14 +379,13 @@ export function useAuthoritativeWip() {
     if (!wipTransactions) return {};
     return computeAuthoritativeWip(
       wipTransactions,
-      manualAdjustments ?? [],
       (batches ?? []) as BlendReservationBatch[],
     );
-  }, [wipTransactions, manualAdjustments, batches]);
+  }, [wipTransactions, batches]);
 
   return {
     data: wip,
-    isLoading: wipLoading || manualLoading || roastGroupsLoading || batchesLoading,
+    isLoading: wipLoading || roastGroupsLoading || batchesLoading,
   };
 }
 
@@ -439,22 +421,96 @@ export function useAuthoritativePlannedWip() {
   return { data: planned, isLoading };
 }
 
+export interface FgLedgerTx {
+  product_id: string | null;
+  quantity_units: number | null;
+  transaction_type: string | null;
+}
+
+/** Per-product FG metadata used to decorate the ledger sums. */
+export interface FgProductInfo {
+  name: string;
+  sku: string | null;
+  bag_size_g: number;
+  roast_group: string | null;
+}
+
 /**
- * Authoritative FG by product
- * FG = sum(units_packed) - sum(units_picked for OPEN orders)
+ * Pure FG reducer — single source of truth for authoritative FG, computed
+ * ENTIRELY from the inventory_transactions ledger (quantity_units):
+ * - PACK_PRODUCE_FG: +units packed (negative when a pack is reversed)
+ * - SHIP_CONSUME_FG: −units when picked/shipped (positive when returned)
+ * - ADJUSTMENT: +/- units from a manual FG floor count / recount
+ *
+ * fg_available_units = created + ship(net, signed) + adjustments. This is true
+ * physical on-hand: every pick reduces it immediately and stays reduced once the
+ * order ships; a cancel must write a returning SHIP_CONSUME_FG (+units) for the
+ * coffee to re-enter FG. Extracted so it can be unit-tested without Supabase.
+ */
+export function computeAuthoritativeFg(
+  fgTransactions: FgLedgerTx[],
+  productInfo: Record<string, FgProductInfo> = {},
+): Record<string, AuthoritativeFg> {
+  const createdByProduct: Record<string, number> = {};   // PACK_PRODUCE_FG (signed)
+  const shipByProduct: Record<string, number> = {};       // SHIP_CONSUME_FG (signed, usually ≤ 0)
+  const adjustByProduct: Record<string, number> = {};      // ADJUSTMENT units (signed)
+
+  for (const tx of fgTransactions) {
+    if (!tx.product_id) continue;
+    const units = Number(tx.quantity_units ?? 0);
+    if (!units) continue;
+    switch (tx.transaction_type) {
+      case 'PACK_PRODUCE_FG':
+        createdByProduct[tx.product_id] = (createdByProduct[tx.product_id] ?? 0) + units;
+        break;
+      case 'SHIP_CONSUME_FG':
+        shipByProduct[tx.product_id] = (shipByProduct[tx.product_id] ?? 0) + units;
+        break;
+      case 'ADJUSTMENT':
+        adjustByProduct[tx.product_id] = (adjustByProduct[tx.product_id] ?? 0) + units;
+        break;
+    }
+  }
+
+  const allProducts = new Set([
+    ...Object.keys(createdByProduct),
+    ...Object.keys(shipByProduct),
+    ...Object.keys(adjustByProduct),
+  ]);
+  const result: Record<string, AuthoritativeFg> = {};
+
+  for (const pid of allProducts) {
+    const info = productInfo[pid];
+    const created = createdByProduct[pid] ?? 0;
+    const shipNet = shipByProduct[pid] ?? 0;   // signed (consumption is negative)
+    const adjust = adjustByProduct[pid] ?? 0;
+    result[pid] = {
+      product_id: pid,
+      product_name: info?.name ?? '',
+      sku: info?.sku ?? null,
+      bag_size_g: info?.bag_size_g ?? 0,
+      roast_group: info?.roast_group ?? null,
+      fg_created_units: created,
+      fg_allocated_units: -shipNet,            // total units consumed (picked/shipped), positive
+      fg_available_units: Math.max(0, created + shipNet + adjust),
+    };
+  }
+
+  return result;
+}
+
+/**
+ * Authoritative FG by product — thin React-Query wrapper around
+ * computeAuthoritativeFg (the pure ledger reducer above).
  */
 export function useAuthoritativeFg() {
-  const { data: packingRuns, isLoading: packingLoading } = usePackingRuns();
-  const { data: shipPicks, isLoading: picksLoading } = useShipPicks();
+  const { data: fgTransactions, isLoading: ledgerLoading } = useFgLedgerTransactions();
   const { data: products, isLoading: productsLoading } = useProductsWithRoastGroup();
-  const { data: orderLines, isLoading: linesLoading } = useOpenOrderLines();
-  
+
   const fg = useMemo((): Record<string, AuthoritativeFg> => {
-    if (!packingRuns || !shipPicks || !products) return {};
-    
-    // Map product info
-    const productInfo: Record<string, { name: string; sku: string | null; bag_size_g: number; roast_group: string | null }> = {};
-    for (const p of products) {
+    if (!fgTransactions) return {};
+    const productInfo: Record<string, FgProductInfo> = {};
+    for (const p of products ?? []) {
       productInfo[p.id] = {
         name: p.product_name,
         sku: p.sku,
@@ -462,56 +518,12 @@ export function useAuthoritativeFg() {
         roast_group: p.roast_group,
       };
     }
-    
-    // Map order_line_item_id to product_id
-    const lineToProduct: Record<string, string> = {};
-    for (const li of orderLines ?? []) {
-      lineToProduct[li.id] = li.product_id;
-    }
-    
-    // Calculate FG created by product
-    const createdByProduct: Record<string, number> = {};
-    for (const pr of packingRuns) {
-      createdByProduct[pr.product_id] = (createdByProduct[pr.product_id] ?? 0) + pr.units_packed;
-    }
-    
-    // Calculate FG allocated (picked) by product
-    const allocatedByProduct: Record<string, number> = {};
-    for (const pick of shipPicks) {
-      const productId = lineToProduct[pick.order_line_item_id];
-      if (productId) {
-        allocatedByProduct[productId] = (allocatedByProduct[productId] ?? 0) + pick.units_picked;
-      }
-    }
-    
-    // Combine into authoritative FG
-    const allProducts = new Set([...Object.keys(createdByProduct), ...Object.keys(allocatedByProduct)]);
-    const result: Record<string, AuthoritativeFg> = {};
-    
-    for (const pid of allProducts) {
-      const info = productInfo[pid];
-      if (!info) continue;
-      
-      const created = createdByProduct[pid] ?? 0;
-      const allocated = allocatedByProduct[pid] ?? 0;
-      result[pid] = {
-        product_id: pid,
-        product_name: info.name,
-        sku: info.sku,
-        bag_size_g: info.bag_size_g,
-        roast_group: info.roast_group,
-        fg_created_units: created,
-        fg_allocated_units: allocated,
-        fg_available_units: Math.max(0, created - allocated),
-      };
-    }
-    
-    return result;
-  }, [packingRuns, shipPicks, products, orderLines]);
-  
+    return computeAuthoritativeFg(fgTransactions as FgLedgerTx[], productInfo);
+  }, [fgTransactions, products]);
+
   return {
     data: fg,
-    isLoading: packingLoading || picksLoading || productsLoading || linesLoading,
+    isLoading: ledgerLoading || productsLoading,
   };
 }
 
@@ -670,17 +682,22 @@ export function useAuthoritativeRoastDemand() {
  * Picks are progress tracking, not shortage reduction
  */
 export function useAuthoritativeShortList() {
-  const { data: packingRuns, isLoading: packingLoading } = usePackingRuns();
+  const { data: fgTransactions, isLoading: ledgerLoading } = useFgLedgerTransactions();
   const { data: demand, isLoading: demandLoading } = useAuthoritativeDemand();
   const { data: products, isLoading: productsLoading } = useProductsWithRoastGroup();
-  
+
   const shortList = useMemo(() => {
-    if (!packingRuns || !demand || !products) return [];
-    
-    // Calculate FG created (total packed) by product - no allocation subtraction
+    if (!fgTransactions || !demand || !products) return [];
+
+    // FG produced (total packed) by product, from the ledger — PACK_PRODUCE_FG is
+    // signed (reverses are negative), so summing yields net produced. Picks/ships
+    // (SHIP_CONSUME_FG) do not reduce shortage; this measures whether we have
+    // produced enough total to cover demand.
     const fgCreatedByProduct: Record<string, number> = {};
-    for (const pr of packingRuns) {
-      fgCreatedByProduct[pr.product_id] = (fgCreatedByProduct[pr.product_id] ?? 0) + pr.units_packed;
+    for (const tx of fgTransactions) {
+      if (!tx.product_id || tx.transaction_type !== 'PACK_PRODUCE_FG') continue;
+      fgCreatedByProduct[tx.product_id] =
+        (fgCreatedByProduct[tx.product_id] ?? 0) + Number(tx.quantity_units ?? 0);
     }
     
     const items: Array<{
@@ -717,11 +734,11 @@ export function useAuthoritativeShortList() {
     }
     
     return items.sort((a, b) => b.shortage - a.shortage);
-  }, [packingRuns, demand, products]);
-  
+  }, [fgTransactions, demand, products]);
+
   return {
     data: shortList,
-    isLoading: packingLoading || demandLoading || productsLoading,
+    isLoading: ledgerLoading || demandLoading || productsLoading,
   };
 }
 

--- a/src/lib/wipAdjustments.ts
+++ b/src/lib/wipAdjustments.ts
@@ -18,9 +18,11 @@ export interface SaveWipAdjustmentArgs {
 
 /**
  * Single source of truth for writing WIP adjustments.
- * Both the per-row WipAdjustmentModal and the bulk WipFloorCountModal
- * use this helper. Writes ONLY to wip_adjustments — that is what the
- * Inventory Levels WIP math reads as the manual-adjustment source.
+ * Both the per-row WipAdjustmentModal and the bulk WipFloorCountModal use this
+ * helper. Writes ONE balancing ADJUSTMENT row to inventory_transactions — the
+ * single ledger every WIP balance now reads. The human reason is folded into
+ * notes (inventory_transactions has no reason column); the row is stamped with
+ * the logged-in user and relies on created_at (now()) for the timestamp.
  */
 export async function saveWipAdjustment(args: SaveWipAdjustmentArgs): Promise<void> {
   const { roastGroup, kgDelta, reason, notes, createdBy } = args;
@@ -30,25 +32,26 @@ export async function saveWipAdjustment(args: SaveWipAdjustmentArgs): Promise<vo
     throw new Error('kg delta must be a non-zero number.');
   }
 
-  const { error } = await supabase.from('wip_adjustments').insert({
+  const trimmed = notes?.trim();
+  const note = trimmed ? `[${reason}] ${trimmed}` : `[${reason}]`;
+
+  const { error } = await supabase.from('inventory_transactions').insert({
+    transaction_type: 'ADJUSTMENT',
     roast_group: roastGroup,
-    kg_delta: +kgDelta.toFixed(4),
-    reason,
-    notes: notes?.trim() ? notes.trim() : null,
+    quantity_kg: +kgDelta.toFixed(4),
+    notes: note,
     created_by: createdBy ?? null,
+    is_system_generated: false,
   });
 
   if (error) throw error;
 }
 
 export const WIP_ADJUSTMENT_QUERY_KEYS: string[][] = [
-  ['wip-adjustments'],
   ['inventory-transactions-wip'],
-  ['inventory-ledger-wip'],
   ['roast-group-wip'],
   ['roast-group-detail'],
   ['roast-group-inventory-levels'],
-  // Authoritative hooks used by the production page
-  ['authoritative-wip-manual-adjustments'],
+  // Authoritative hook used by the production page
   ['authoritative-wip-ledger'],
 ];

--- a/src/pages/internal/Inventory.tsx
+++ b/src/pages/internal/Inventory.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useMemo } from 'react';
 import { Trash2 } from 'lucide-react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { usePaginatedQuery } from '@/hooks/usePaginatedQuery';
 import { useSearchParams, Link } from 'react-router-dom';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -22,6 +21,7 @@ import { format } from 'date-fns';
 import { GreenCoffeeAlerts } from '@/components/sourcing/GreenCoffeeAlerts';
 import { WipAdjustmentModal } from '@/components/inventory/WipAdjustmentModal';
 import { WipFloorCountModal, type WipFloorRow } from '@/components/inventory/WipFloorCountModal';
+import { useAuthoritativeFg } from '@/hooks/useAuthoritativeInventory';
 
 type WipAdjustmentReason = 'LOSS' | 'COUNT_ADJUSTMENT' | 'CONTAMINATION' | 'OTHER';
 
@@ -326,42 +326,11 @@ export default function Inventory() {
 
   // ===== Finished Goods Tab =====
   
-  // Fetch FG inventory with product details (paginated).
-  const {
-    rows: fgInventory,
-    hasMore: fgHasMore,
-    loadMore: loadMoreFg,
-    isFetching: fgIsFetching,
-    total: fgTotal,
-  } = usePaginatedQuery<FgInventoryRow>({
-    queryKey: ['fg-inventory'],
-    pageSize: 50,
-    fetchPage: async ({ offset, limit }) => {
-      const { data, error, count } = await supabase
-        .from('fg_inventory')
-        .select(
-          `
-          id,
-          product_id,
-          units_on_hand,
-          notes,
-          updated_at,
-          product:products(
-            id,
-            product_name,
-            bag_size_g,
-            packaging_variant,
-            client:clients(name)
-          )
-        `,
-          { count: 'exact' }
-        )
-        .order('updated_at', { ascending: false })
-        .range(offset, offset + limit - 1);
-      if (error) throw error;
-      return { rows: (data ?? []) as unknown as FgInventoryRow[], count };
-    },
-  });
+  // FG on-hand is derived from the SAME authoritative source as the production
+  // tabs / Authoritative Totals box (sum of packing_runs.units_packed minus
+  // ship_picks.units_picked per product) so every surface agrees. This replaces
+  // the old, unused fg_inventory.units_on_hand snapshot which read as empty.
+  const { data: authoritativeFg } = useAuthoritativeFg();
 
   // Fetch all active products (for adding new FG entries)
   const { data: allProducts } = useQuery({
@@ -458,12 +427,31 @@ export default function Inventory() {
     [wipAvailableRows],
   );
 
+  // One row per active product, units sourced from the authoritative FG map.
+  const fgRows = useMemo<FgInventoryRow[]>(() => {
+    const fg = authoritativeFg ?? {};
+    return (allProducts ?? []).map((p) => ({
+      id: p.id,
+      product_id: p.id,
+      units_on_hand: fg[p.id]?.fg_available_units ?? 0,
+      notes: null,
+      updated_at: '',
+      product: {
+        id: p.id,
+        product_name: p.product_name,
+        bag_size_g: p.bag_size_g,
+        packaging_variant: p.packaging_variant,
+        client: p.client,
+      },
+    })) as unknown as FgInventoryRow[];
+  }, [allProducts, authoritativeFg]);
+
   // Finished-not-picked view: products with packed units on hand not yet shipped.
   const fgAvailableRows = useMemo(
-    () => (fgInventory ?? []).filter((r) => r.units_on_hand > 0),
-    [fgInventory],
+    () => fgRows.filter((r) => r.units_on_hand > 0),
+    [fgRows],
   );
-  const fgDisplayRows = fgAvailableOnly ? fgAvailableRows : (fgInventory ?? []);
+  const fgDisplayRows = fgAvailableOnly ? fgAvailableRows : fgRows;
   const fgAvailableUnits = useMemo(
     () => fgAvailableRows.reduce((sum, r) => sum + r.units_on_hand, 0),
     [fgAvailableRows],
@@ -661,7 +649,7 @@ export default function Inventory() {
                 <p className="text-muted-foreground py-4">
                   No finished goods are currently awaiting pick. Toggle “Show all” to see every product.
                 </p>
-              ) : !fgAvailableOnly && fgInventory?.length === 0 && allProducts?.length === 0 ? (
+              ) : !fgAvailableOnly && fgRows.length === 0 ? (
                 <p className="text-muted-foreground py-4">No products configured.</p>
               ) : (
                 <table className="w-full text-sm">
@@ -675,7 +663,6 @@ export default function Inventory() {
                     </tr>
                   </thead>
                   <tbody>
-                    {/* Show products that have FG inventory */}
                     {fgDisplayRows.map((row) => (
                       <FgInventoryRow
                         key={row.id}
@@ -684,60 +671,8 @@ export default function Inventory() {
                         onSet={(value) => handleFgSet(row.product_id, row.units_on_hand, value)}
                       />
                     ))}
-                    {/* Show products without FG inventory (units = 0) — only in the "show all" view */}
-                    {!fgAvailableOnly && allProducts
-                      ?.filter(p => !fgInventory?.some(fg => fg.product_id === p.id))
-                      .map((product) => (
-                        <tr key={product.id} className="border-b text-muted-foreground">
-                          <td className="py-3">{product.product_name}</td>
-                          <td className="py-3">{(product.client as any)?.name ?? '—'}</td>
-                          <td className="py-3">
-                            <div className="flex items-center gap-2">
-                              <span className="text-xs">{product.bag_size_g}g</span>
-                              {product.packaging_variant && (
-                                <PackagingBadge variant={product.packaging_variant as any} />
-                              )}
-                            </div>
-                          </td>
-                          <td className="py-3 text-right">0</td>
-                          <td className="py-3 text-right">
-                            <div className="flex items-center justify-end gap-1">
-                              <Button
-                                size="sm"
-                                variant="outline"
-                                className="h-7 w-7 p-0"
-                                onClick={() => handleFgAdjust(product.id, 0, 1)}
-                              >
-                                <Plus className="h-3 w-3" />
-                              </Button>
-                              <Input
-                                type="number"
-                                className="w-16 h-7 text-center text-sm"
-                                value={0}
-                                onChange={(e) => handleFgSet(product.id, 0, e.target.value)}
-                                min={0}
-                              />
-                            </div>
-                          </td>
-                        </tr>
-                      ))}
                   </tbody>
                 </table>
-              )}
-              {fgHasMore && (
-                <div className="pt-4 flex justify-center">
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="text-xs text-muted-foreground hover:text-foreground"
-                    onClick={loadMoreFg}
-                    disabled={fgIsFetching}
-                  >
-                    {fgIsFetching
-                      ? 'Loading…'
-                      : `Load more${fgTotal ? ` (${fgInventory.length} of ${fgTotal})` : ''}`}
-                  </Button>
-                </div>
               )}
             </CardContent>
           </Card>

--- a/src/pages/internal/Inventory.tsx
+++ b/src/pages/internal/Inventory.tsx
@@ -118,19 +118,6 @@ export default function Inventory() {
     },
   });
 
-  // Fetch WIP adjustments from wip_adjustments table (manual adjustments ONLY)
-  const { data: wipAdjustments } = useQuery({
-    queryKey: ['wip-adjustments'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('wip_adjustments')
-        .select('*')
-        .order('created_at', { ascending: false });
-      if (error) throw error;
-      return data ?? [];
-    },
-  });
-
   // Fetch all roast groups
   const { data: roastGroups } = useQuery({
     queryKey: ['all-roast-groups'],
@@ -152,17 +139,15 @@ export default function Inventory() {
   // and the production-tab dropdowns all agree.
   //
   // Formula (per group):
-  //   wip_net_kg = sum(ROAST_OUTPUT) - sum(|PACK_CONSUME_WIP|) + sum(ADJUSTMENT + LOSS) + sum(wip_adjustments.kg_delta)
+  //   wip_net_kg = sum(ROAST_OUTPUT) - sum(|PACK_CONSUME_WIP|) + sum(ADJUSTMENT + LOSS)
+  // Manual adjustments (floor counts, recounts, opening balances) are ADJUSTMENT rows
+  // in inventory_transactions now — the separate wip_adjustments table is retired.
   const wipByRoastGroup = useMemo((): WipByRoastGroup[] => {
     const computed = computeAuthoritativeWip(
       (inventoryTransactions ?? []).map((tx) => ({
         roast_group: tx.roast_group,
         quantity_kg: tx.quantity_kg,
         transaction_type: tx.transaction_type,
-      })),
-      (wipAdjustments ?? []).map((a) => ({
-        roast_group: a.roast_group,
-        kg_delta: a.kg_delta,
       })),
       [], // no reservation accounting in the inventory-page table
     );
@@ -177,28 +162,35 @@ export default function Inventory() {
       }))
       .filter((row) => row.roasted_kg !== 0 || row.consumed_kg !== 0 || row.adjusted_kg !== 0)
       .sort((a, b) => a.roast_group.localeCompare(b.roast_group));
-  }, [inventoryTransactions, wipAdjustments]);
+  }, [inventoryTransactions]);
 
-  // WIP adjustment mutation
+  // WIP adjustment mutation — writes a balancing ADJUSTMENT row to the
+  // inventory_transactions ledger (the single source of truth). The reason is
+  // folded into notes; the row is stamped with the logged-in user and now().
   const createWipAdjustment = useMutation({
     mutationFn: async () => {
       const delta = parseFloat(adjustKgDelta);
       if (isNaN(delta) || delta === 0) throw new Error('Invalid kg delta');
-      
+
+      const note = adjustNotes?.trim()
+        ? `WIP adjustment (${adjustReason}): ${adjustNotes.trim()}`
+        : `WIP adjustment (${adjustReason})`;
       const { error } = await supabase
-        .from('wip_adjustments')
+        .from('inventory_transactions')
         .insert({
+          transaction_type: 'ADJUSTMENT',
           roast_group: adjustRoastGroup,
-          kg_delta: delta,
-          reason: adjustReason,
-          notes: adjustNotes,
+          quantity_kg: delta,
+          notes: note,
           created_by: authUser?.id,
+          is_system_generated: false,
         });
       if (error) throw error;
     },
     onSuccess: () => {
       toast.success('WIP adjustment recorded');
-      queryClient.invalidateQueries({ queryKey: ['wip-adjustments'] });
+      queryClient.invalidateQueries({ queryKey: ['inventory-transactions-wip'] });
+      queryClient.invalidateQueries({ queryKey: ['authoritative-wip-ledger'] });
       setShowWipAdjust(false);
       setAdjustKgDelta('');
       setAdjustNotes('');
@@ -209,7 +201,8 @@ export default function Inventory() {
     },
   });
 
-  // WIP history delete mutation (orphaned roast groups only)
+  // WIP history delete mutation (orphaned roast groups only).
+  // inventory_transactions is the only live WIP ledger now.
   const deleteWipHistory = useMutation({
     mutationFn: async (roastGroupKey: string) => {
       const { error: e1 } = await supabase
@@ -217,25 +210,12 @@ export default function Inventory() {
         .delete()
         .eq('roast_group', roastGroupKey);
       if (e1) throw e1;
-
-      const { error: e2 } = await supabase
-        .from('wip_adjustments')
-        .delete()
-        .eq('roast_group', roastGroupKey);
-      if (e2) throw e2;
-
-      const { error: e3 } = await supabase
-        .from('wip_ledger')
-        .delete()
-        .eq('roast_group', roastGroupKey);
-      if (e3) throw e3;
     },
     onSuccess: () => {
       toast.success('WIP history cleared');
       setConfirmClearWip(null);
       queryClient.invalidateQueries({ queryKey: ['inventory-transactions-wip'] });
-      queryClient.invalidateQueries({ queryKey: ['wip-adjustments'] });
-      queryClient.invalidateQueries({ queryKey: ['inventory-ledger-wip'] });
+      queryClient.invalidateQueries({ queryKey: ['authoritative-wip-ledger'] });
     },
     onError: (err: any) => {
       console.error(err);
@@ -246,9 +226,9 @@ export default function Inventory() {
   // ===== Finished Goods Tab =====
   
   // FG on-hand is derived from the SAME authoritative source as the production
-  // tabs / Authoritative Totals box (sum of packing_runs.units_packed minus
-  // ship_picks.units_picked per product) so every surface agrees. This replaces
-  // the old, unused fg_inventory.units_on_hand snapshot which read as empty.
+  // tabs / Authoritative Totals box: the inventory_transactions ledger
+  // (PACK_PRODUCE_FG + SHIP_CONSUME_FG + ADJUSTMENT units per product) so every
+  // surface agrees and a floor-count ADJUSTMENT row moves the on-hand number.
   const { data: authoritativeFg } = useAuthoritativeFg();
 
   // Fetch all active products (for adding new FG entries)
@@ -265,39 +245,31 @@ export default function Inventory() {
     },
   });
 
-  // Upsert FG inventory mutation
+  // FG floor count — writes ONE balancing ADJUSTMENT row to the
+  // inventory_transactions ledger (product-scoped, quantity_units = counted −
+  // current ledger balance). No writes to the retired fg_inventory /
+  // fg_inventory_log tables. Stamped with the logged-in user and now().
   const upsertFgInventory = useMutation({
-    mutationFn: async ({ productId, unitsDelta, newUnits }: { 
-      productId: string; 
+    mutationFn: async ({ productId, unitsDelta, newUnits }: {
+      productId: string;
       unitsDelta: number;
       newUnits: number;
     }) => {
-      // Upsert fg_inventory
-      const { error: upsertError } = await supabase
-        .from('fg_inventory')
-        .upsert({
-          product_id: productId,
-          units_on_hand: newUnits,
-          updated_at: new Date().toISOString(),
-          updated_by: authUser?.id,
-        }, {
-          onConflict: 'product_id',
-        });
-      if (upsertError) throw upsertError;
-
-      // Log the change
-      const { error: logError } = await supabase
-        .from('fg_inventory_log')
+      if (!unitsDelta) return;
+      const { error } = await supabase
+        .from('inventory_transactions')
         .insert({
+          transaction_type: 'ADJUSTMENT',
           product_id: productId,
-          units_delta: unitsDelta,
-          units_after: newUnits,
+          quantity_units: unitsDelta,
+          notes: `FG floor count: counted ${newUnits} units (delta ${unitsDelta >= 0 ? '+' : ''}${unitsDelta})`,
           created_by: authUser?.id,
+          is_system_generated: false,
         });
-      if (logError) throw logError;
+      if (error) throw error;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['fg-inventory'] });
+      queryClient.invalidateQueries({ queryKey: ['authoritative-fg-ledger'] });
     },
     onError: (err) => {
       console.error(err);
@@ -307,7 +279,8 @@ export default function Inventory() {
 
   const handleFgAdjust = (productId: string, currentUnits: number, delta: number) => {
     const newUnits = Math.max(0, currentUnits + delta);
-    upsertFgInventory.mutate({ productId, unitsDelta: delta, newUnits });
+    // Balancing delta against the current ledger balance (clamped at 0).
+    upsertFgInventory.mutate({ productId, unitsDelta: newUnits - currentUnits, newUnits });
   };
 
   const handleFgSet = (productId: string, currentUnits: number, newValue: string) => {

--- a/src/pages/internal/OrderDetail.tsx
+++ b/src/pages/internal/OrderDetail.tsx
@@ -8,6 +8,7 @@ import { Label } from '@/components/ui/label';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Badge } from '@/components/ui/badge';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog';
 import { supabase } from '@/integrations/supabase/client';
 import { format } from 'date-fns';
 import { parseDateOnly } from '@/lib/dateOnly';
@@ -498,6 +499,115 @@ export default function OrderDetail() {
     },
   });
 
+  // Cancelling an order that still has picked (FG-consumed) units must decide
+  // the fate of that coffee in the ledger — never silently. We prompt:
+  //   (a) return to stock  → reverse each SHIP_CONSUME_FG (+units) so FG rises
+  //   (b) write off as lost → reverse the pick (+units) AND record an ADJUSTMENT
+  //                           (−units) so the coffee leaves FG, marked as a loss
+  // Then zero the picks and cancel the order. Every row is stamped with the
+  // logged-in user; created_at supplies the timestamp.
+  const [cancelPicks, setCancelPicks] = useState<
+    { pickId: string; productId: string; productName: string; units: number }[] | null
+  >(null);
+
+  const cancelWithPicksMutation = useMutation({
+    mutationFn: async (mode: 'return' | 'writeoff') => {
+      const picks = cancelPicks ?? [];
+      const rows: Database['public']['Tables']['inventory_transactions']['Insert'][] = [];
+      for (const p of picks) {
+        // Reverse the pick consumption — the coffee re-enters FG.
+        rows.push({
+          transaction_type: 'SHIP_CONSUME_FG',
+          product_id: p.productId,
+          order_id: id!,
+          quantity_units: p.units,
+          notes: mode === 'return'
+            ? `Returned ${p.units} units to stock (order ${order?.order_number} cancelled)`
+            : `Reversed ${p.units} picked units (order ${order?.order_number} cancelled)`,
+          is_system_generated: false,
+          created_by: authUser?.id,
+        });
+        // Write-off: immediately remove it again as a recorded loss.
+        if (mode === 'writeoff') {
+          rows.push({
+            transaction_type: 'ADJUSTMENT',
+            product_id: p.productId,
+            order_id: id!,
+            quantity_units: -p.units,
+            notes: `Written off as lost: ${p.units} units (order ${order?.order_number} cancelled)`,
+            is_system_generated: false,
+            created_by: authUser?.id,
+          });
+        }
+      }
+      if (rows.length > 0) {
+        const { error: ledgerErr } = await supabase.from('inventory_transactions').insert(rows);
+        if (ledgerErr) throw ledgerErr;
+      }
+
+      // Zero the picks so the allocation record matches the reversed ledger.
+      const pickIds = picks.map((p) => p.pickId);
+      if (pickIds.length > 0) {
+        const { error: pickErr } = await supabase
+          .from('ship_picks')
+          .update({ units_picked: 0, updated_by: authUser?.id })
+          .in('id', pickIds);
+        if (pickErr) throw pickErr;
+      }
+
+      const { error } = await supabase.rpc('update_order_status' as any, {
+        p_order_id: id!,
+        p_target_status: 'CANCELLED',
+      });
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      toast.success('Order cancelled');
+      setCancelPicks(null);
+      queryClient.invalidateQueries({ queryKey: ['order', id] });
+      queryClient.invalidateQueries({ queryKey: ['orders'] });
+      queryClient.invalidateQueries({ queryKey: ['authoritative-fg-ledger'] });
+      queryClient.invalidateQueries({ queryKey: ['ship-picks', id] });
+      supabase.functions.invoke('notify-order-event', {
+        body: { order_id: id, event_type: 'ORDER_CANCELLED', details: 'Status changed by ops' },
+      }).catch((e) => console.warn('[notify-order-event] CANCELLED failed:', e));
+    },
+    onError: (err: any) => {
+      console.error(err);
+      toast.error(err?.message || 'Failed to cancel order');
+    },
+  });
+
+  // Decide whether cancelling needs the FG-fate prompt. If the order has no
+  // outstanding picked units, cancel straight through the normal path.
+  const initiateCancel = useCallback(async () => {
+    const { data: picks, error } = await supabase
+      .from('ship_picks')
+      .select('id, order_line_item_id, units_picked')
+      .eq('order_id', id!)
+      .gt('units_picked', 0);
+    if (error) {
+      toast.error('Failed to check picked units');
+      return;
+    }
+    const outstanding = (picks ?? [])
+      .map((p) => {
+        const li = (lineItems ?? []).find((l) => l.id === p.order_line_item_id);
+        return {
+          pickId: p.id,
+          productId: li?.product_id ?? '',
+          productName: li?.product?.product_name ?? 'Unknown',
+          units: p.units_picked,
+        };
+      })
+      .filter((p) => p.productId && p.units > 0);
+    if (outstanding.length === 0) {
+      handleStatusChange('CANCELLED');
+      return;
+    }
+    setCancelPicks(outstanding);
+  }, [id, lineItems, handleStatusChange]);
+
   if (isLoading) {
     return (
       <div className="page-container">
@@ -534,6 +644,10 @@ export default function OrderDetail() {
   const handleAdvanceTo = (target: OrderStatus) => {
     if (target === 'SHIPPED') {
       handleMarkAsShipped();
+      return;
+    }
+    if (target === 'CANCELLED') {
+      initiateCancel();
       return;
     }
     if (target === 'CONFIRMED' && order.status === 'SUBMITTED') {
@@ -1043,6 +1157,41 @@ export default function OrderDetail() {
           orderNumber={order.order_number}
         />
       )}
+
+      {/* Cancel-with-picks: decide the fate of already-picked FG */}
+      <Dialog open={cancelPicks !== null} onOpenChange={(o) => { if (!o) setCancelPicks(null); }}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Cancel order — picked coffee</DialogTitle>
+            <DialogDescription>
+              This order has finished goods already picked off the shelf. Choose what happens to them — either way it's recorded in the inventory ledger with your name and the time.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="rounded-md border bg-muted/30 p-3 text-sm space-y-1">
+            {(cancelPicks ?? []).map((p) => (
+              <div key={p.pickId} className="flex justify-between">
+                <span>{p.productName}</span>
+                <span className="font-mono">{p.units} units</span>
+              </div>
+            ))}
+          </div>
+          <DialogFooter className="flex-col sm:flex-row gap-2">
+            <Button
+              variant="outline"
+              disabled={cancelWithPicksMutation.isPending}
+              onClick={() => cancelWithPicksMutation.mutate('writeoff')}
+            >
+              Write off as lost
+            </Button>
+            <Button
+              disabled={cancelWithPicksMutation.isPending}
+              onClick={() => cancelWithPicksMutation.mutate('return')}
+            >
+              {cancelWithPicksMutation.isPending ? 'Working…' : 'Return bags to stock'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/test/wip-blend-stealing.test.ts
+++ b/src/test/wip-blend-stealing.test.ts
@@ -52,7 +52,7 @@ describe('blend WIP stealing', () => {
         consumed_by_blend_at: null,
       },
     ];
-    const wip = computeAuthoritativeWip(ledger, [], batches);
+    const wip = computeAuthoritativeWip(ledger, batches);
     expect(wip[COMPONENT].reserved_for_blend_kg).toBe(10);
     expect(wip[COMPONENT].wip_available_kg).toBe(0);
   });
@@ -72,7 +72,7 @@ describe('blend WIP stealing', () => {
         consumed_by_blend_at: '2026-06-17T12:00:00Z',
       },
     ];
-    const wip = computeAuthoritativeWip(ledger, [], batches);
+    const wip = computeAuthoritativeWip(ledger, batches);
     expect(wip[COMPONENT].reserved_for_blend_kg).toBe(0);
     // 4 kg leftover from the partial blend is now available to the component
     expect(wip[COMPONENT].wip_available_kg).toBe(4);

--- a/supabase/migrations/20260625120000_backfill_wip_adjustments_into_ledger.sql
+++ b/supabase/migrations/20260625120000_backfill_wip_adjustments_into_ledger.sql
@@ -1,0 +1,32 @@
+-- Backfill manual WIP adjustments into the single source-of-truth ledger.
+--
+-- WIP balances are now computed entirely from inventory_transactions
+-- (ROAST_OUTPUT + PACK_CONSUME_WIP + ADJUSTMENT + LOSS, summed by quantity_kg).
+-- The legacy wip_adjustments table (opening balances, recounts, floor counts)
+-- is retired; this copies each of its rows in as an ADJUSTMENT row so existing
+-- WIP balances are preserved when the read drops the wip_adjustments term.
+--
+-- IDEMPOTENT: each source row is tagged in notes with its wip_adjustments.id
+-- ('[backfill wip_adjustments:<uuid>]'). Re-running skips any row already
+-- copied, so it is safe to apply more than once without double-counting.
+--
+-- created_at and created_by are carried over from the source row so the audit
+-- trail (who / when) is preserved, not reset to the migration time.
+
+INSERT INTO public.inventory_transactions
+  (transaction_type, roast_group, quantity_kg, notes, created_by, created_at, is_system_generated)
+SELECT
+  'ADJUSTMENT',
+  wa.roast_group,
+  wa.kg_delta,
+  '[backfill wip_adjustments:' || wa.id::text || '] [' || wa.reason || ']'
+    || CASE WHEN COALESCE(btrim(wa.notes), '') <> '' THEN ' ' || wa.notes ELSE '' END,
+  wa.created_by,
+  wa.created_at,
+  false
+FROM public.wip_adjustments wa
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM public.inventory_transactions it
+  WHERE it.notes LIKE '[backfill wip_adjustments:' || wa.id::text || ']%'
+);


### PR DESCRIPTION
## What & why

WIP and FG balances now read entirely from the **`inventory_transactions`** ledger, and the manual floor-count path writes a single balancing **`ADJUSTMENT`** row to that same ledger so the on-screen number actually moves.

The tables previously assumed to be the source of truth are dead/incomplete — verified against the migrations:
- `wip_ledger` — nothing in the production flow writes it (0 migration inserts; only niche app-writes). Summing it ≈ garbage.
- `fg_inventory_log` — only ever held manual adjustments, never pack/ship. `related_packing_run_id`/`related_order_line_item_id` referenced by the 0617 purge funcs don't even exist on the table.
- `fg_inventory` — old per-product snapshot, retired.
- `wip_adjustments` — retired; rows backfilled into the ledger.

The live trigger/RPC-maintained ledger is `inventory_transactions` (`ROAST_OUTPUT`, `PACK_CONSUME_WIP`, `PACK_PRODUCE_FG`, `SHIP_CONSUME_FG`, `ADJUSTMENT`, `LOSS`).

## Changes

**Reads → ledger (all surfaces, one pass)**
- `useAuthoritativeInventory.ts`: `computeAuthoritativeWip` drops the `wip_adjustments` term (keeps LOSS); new `computeAuthoritativeFg` sums `PACK_PRODUCE_FG + SHIP_CONSUME_FG + ADJUSTMENT` units; short-list repointed. Field interfaces preserved → Ship/Pack/Plan/Roast tabs + AuthoritativeTotals repoint automatically.
- `Inventory.tsx`, `RoastGroupWipSection.tsx` off `wip_adjustments`.
- `FGInventoryTab.tsx`, `GenericLaneConversion.tsx` off dead `fg_inventory`.

**Floor-count writes → one balancing ADJUSTMENT row**
- WIP (`wipAdjustments.ts` + inline) → `roast_group` + `quantity_kg`.
- FG (`Inventory.tsx`, `FGInventoryTab.tsx`) → `product_id` + `quantity_units`.
- No more `fg_inventory` / `fg_inventory_log` / `wip_adjustments` writes. `created_by` + `created_at` on every row. WIP(kg)/FG(units) column split keeps the two sums isolated.

**Cancel gap fixed** (`OrderDetail.tsx`): cancelling an order with outstanding picks now prompts — **return to stock** (`SHIP_CONSUME_FG +units`) or **write off as lost** (reverse + `ADJUSTMENT −units`). Never silent.

**Backfill migration** `20260625120000_backfill_wip_adjustments_into_ledger.sql`: copies `wip_adjustments` → `inventory_transactions` ADJUSTMENT. Idempotent (tagged `[backfill wip_adjustments:<id>]` in notes), preserves original `created_at`/`created_by`.

## Equivalence notes for reviewers
- **WIP**: ledger sum == old derived once the backfill runs (LOSS retained). No missing event type.
- **FG**: matches old `packed − open-order picks` when no shipped/cancelled picks exist. Diverges only there — shipped coffee correctly leaves FG (intended); cancelled coffee handled by the new prompt.
- **Apply the backfill migration before/with deploy** so existing WIP balances carry over.
- The cancel mutation writes the ledger reversal *then* the cancel RPC (client-side, not atomic). Ordered so a cancel-RPC failure leaves coffee returned-but-not-cancelled (visible, retryable) rather than silently lost. A SECURITY DEFINER RPC could make it atomic if desired.

## Verification
tsc clean · 87/87 unit tests pass · lint at baseline parity (0 new errors; remaining are pre-existing `as any` on RPC calls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)