### PR TITLE
fix(production): detect batch ledger entries via source_batch_id

### DIFF
--- a/src/components/production/PlanTab.tsx
+++ b/src/components/production/PlanTab.tsx
@@ -586,13 +586,17 @@ export function PlanTab({ dateFilterConfig: _dateFilterConfig, today }: PlanTabP
 
       if (allBatches.length > 0) {
         const ids = allBatches.map((b) => b.id);
-        const wipRes = await supabase
-          .from('wip_ledger')
-          .select('related_batch_id')
-          .in('related_batch_id', ids);
-        if (wipRes.error) throw wipRes.error;
+        // A batch "has a ledger entry" when an inventory_transactions row carries
+        // its id in source_batch_id (written by mark_batch_roasted for every
+        // ROAST_OUTPUT). The retired wip_ledger table never carried batch refs,
+        // so checking it flagged every batch as an orphan.
+        const ledgerRes = await supabase
+          .from('inventory_transactions')
+          .select('source_batch_id')
+          .in('source_batch_id', ids);
+        if (ledgerRes.error) throw ledgerRes.error;
         const referenced = new Set(
-          (wipRes.data ?? []).map((r) => r.related_batch_id).filter((v): v is string => !!v)
+          (ledgerRes.data ?? []).map((r) => r.source_batch_id).filter((v): v is string => !!v)
         );
         for (const b of allBatches) {
           if (referenced.has(b.id)) continue;

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -3203,6 +3203,7 @@ export type Database = {
           quantity_kg: number | null
           quantity_units: number | null
           roast_group: string | null
+          source_batch_id: string | null
           transaction_type: Database["public"]["Enums"]["inventory_transaction_type"]
         }
         Insert: {
@@ -3217,6 +3218,7 @@ export type Database = {
           quantity_kg?: number | null
           quantity_units?: number | null
           roast_group?: string | null
+          source_batch_id?: string | null
           transaction_type: Database["public"]["Enums"]["inventory_transaction_type"]
         }
         Update: {
@@ -3231,6 +3233,7 @@ export type Database = {
           quantity_kg?: number | null
           quantity_units?: number | null
           roast_group?: string | null
+          source_batch_id?: string | null
           transaction_type?: Database["public"]["Enums"]["inventory_transaction_type"]
         }
         Relationships: [
@@ -3260,6 +3263,13 @@ export type Database = {
             columns: ["product_id"]
             isOneToOne: false
             referencedRelation: "products"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "inventory_transactions_source_batch_id_fkey"
+            columns: ["source_batch_id"]
+            isOneToOne: false
+            referencedRelation: "roasted_batches"
             referencedColumns: ["id"]
           },
         ]


### PR DESCRIPTION
## Problem
The "Data orphans" panel on the production dashboard flagged every roasted batch as a ghost. The ledger check queried the retired `wip_ledger` table by `related_batch_id`, which never carried batch references — so no batch ever matched and all failed the check.

## Fix
- `PlanTab.tsx` — ghost-batch check now queries `inventory_transactions` by `source_batch_id` (the column `mark_batch_roasted` fills in for every `ROAST_OUTPUT` row). A batch is an orphan only when no such row exists.
- `types.ts` — added `source_batch_id` to the `inventory_transactions` Row/Insert/Update + FK relationship → `roasted_batches`.

## Notes
- Only one place runs the batch↔ledger orphan check (this query); other "orphan" references in the app are unrelated (account_users cleanup, PLANNED-batch cleanup).
- Types hand-edited: `supabase gen types --linked` returns 401 (no DB auth in the working env). Re-run when authed to pull the canonical schema.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)