### PR TITLE
fix(orders): work deadline picker registers date on first click

### DIFF
--- a/src/components/orders/WorkDeadlinePicker.interaction.test.tsx
+++ b/src/components/orders/WorkDeadlinePicker.interaction.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup, within } from '@testing-library/react';
+import { WorkDeadlinePicker } from './WorkDeadlinePicker';
+
+/**
+ * Regression test for the "date picker needs two clicks" bug.
+ *
+ * Root cause: the prop->state sync effect used to depend on `hasInteracted`.
+ * On the FIRST interaction, flipping hasInteracted false->true re-ran the sync
+ * effect while the `value` prop still held the OLD value, so it overwrote the
+ * date the user had just clicked. The first click was effectively "eaten".
+ *
+ * This test renders with a STATIC `value` prop (parent ignores onChange). That
+ * is the purest reproduction: post-fix the sync effect no longer re-runs on
+ * interaction, so a single click sticks. Pre-fix it would revert to the value
+ * derived from the unchanged prop.
+ */
+describe('WorkDeadlinePicker single-click selection', () => {
+  beforeEach(() => {
+    // Freeze "today" to a Monday so past-date/weekend disabling is deterministic
+    // and day 15 (a Wednesday) and day 20 (a Monday) are enabled future weekdays.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 6, 13, 9, 0, 0)); // 2026-07-13 Mon, local
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  function openCalendar() {
+    // The date trigger button label is `format(selectedDate, 'MMM d')`
+    // or the placeholder 'Date' when nothing is selected.
+    const trigger = screen.getByRole('button', { name: /Jul|Date/ });
+    fireEvent.click(trigger);
+  }
+
+  it('registers a new date on the first click (edit mode, static value)', () => {
+    // Initial value: Mon 2026-07-13 noon Pacific — an enabled weekday.
+    const initialIso = '2026-07-13T19:00:00.000Z';
+    const onChange = vi.fn();
+
+    render(
+      <WorkDeadlinePicker
+        value={initialIso}
+        onChange={onChange}
+        showSaveButton={false}
+      />,
+    );
+
+    openCalendar();
+
+    // Click day 15 (Wed 2026-07-15) — a single click.
+    const grid = screen.getByRole('grid');
+    const day15 = within(grid).getByRole('gridcell', { name: '15' });
+    fireEvent.click(day15);
+
+    // onChange fired with a NEW value on the first click...
+    expect(onChange).toHaveBeenCalled();
+    const emitted = onChange.mock.calls.at(-1)?.[0] as string;
+    expect(emitted).not.toBe(initialIso);
+
+    // ...and the displayed readout reflects the clicked day (Jul 15), not the
+    // old Jul 13. Pre-fix this reverted to Jul 13 (the "eaten first click").
+    expect(screen.getByText(/Deadline: .*Jul 15/)).toBeTruthy();
+    expect(screen.queryByText(/Deadline: .*Jul 13/)).toBeNull();
+  });
+});

--- a/src/components/orders/WorkDeadlinePicker.tsx
+++ b/src/components/orders/WorkDeadlinePicker.tsx
@@ -91,9 +91,15 @@ export function WorkDeadlinePicker({
   const [selectedDate, setSelectedDate] = useState<Date | undefined>(undefined);
   const [selectedTime, setSelectedTime] = useState<string>(DEFAULT_TIME);
   const [hasInteracted, setHasInteracted] = useState(false);
-  
+
   // Track the last value we emitted to avoid re-syncing our own updates
   const lastEmittedValueRef = useRef<string | null>(null);
+  // Mirror of hasInteracted read inside the sync effect WITHOUT making it a
+  // dependency. If hasInteracted were a dep, the first interaction (false→true)
+  // would re-run this effect while `value` still holds the OLD prop value,
+  // clobbering the date the user just picked — which is what caused the
+  // "first click doesn't register" bug.
+  const hasInteractedRef = useRef(false);
 
   // Parse incoming value to local date and time
   // Only sync from prop if it's a genuinely new external value
@@ -102,7 +108,7 @@ export function WorkDeadlinePicker({
     if (value === lastEmittedValueRef.current) {
       return;
     }
-    
+
     if (value) {
       try {
         const parsed = parseISO(value);
@@ -124,12 +130,12 @@ export function WorkDeadlinePicker({
       }
     } else {
       // No value - set defaults only if user hasn't interacted
-      if (!hasInteracted) {
+      if (!hasInteractedRef.current) {
         setSelectedDate(undefined);
         setSelectedTime(DEFAULT_TIME);
       }
     }
-  }, [value, hasInteracted]);
+  }, [value]);
 
   // Combine date and time into ISO string
   const combinedValue = useMemo(() => {
@@ -174,6 +180,7 @@ export function WorkDeadlinePicker({
   }, [combinedValue, hasInteracted, onChange, value]);
 
   const handleDateSelect = (date: Date | undefined) => {
+    hasInteractedRef.current = true;
     setHasInteracted(true);
     if (date) {
       // Auto-bump weekend dates to next Monday
@@ -188,6 +195,7 @@ export function WorkDeadlinePicker({
   };
 
   const handleTimeSelect = (time: string) => {
+    hasInteractedRef.current = true;
     setHasInteracted(true);
     setSelectedTime(time);
   };


### PR DESCRIPTION
## Problem

The "Set work deadline" date picker required two clicks — the first click looked dead, only the second registered.

## Root cause

In `WorkDeadlinePicker.tsx`, the prop→state sync effect depended on `hasInteracted`. The first interaction flipped that flag `false→true`, which re-ran the sync effect while the `value` prop still held the OLD date (parent hadn't propagated the new one yet). The effect overwrote the just-picked date with the stale value. First click eaten; second click stuck (flag already true, no re-run).

## Fix

- Sync effect now reacts only to genuine external `value` changes: `[value, hasInteracted]` → `[value]`.
- Moved the `hasInteracted` guard inside the effect to a `useRef` mirror so reading it no longer forces a re-run.

Fixes all three consumers at the shared-component level: order entry (`CreateOrderForClient`), order edit (`OrderDetail`), and the set-deadline modal (`SetDeadlineModal`). The other date fields use a different, already-correct component (`ui/date-picker.tsx`) — untouched.

## Testing

- Added `WorkDeadlinePicker.interaction.test.tsx` — renders the real component, opens the calendar, clicks a day once, asserts it registers.
- Verified non-vacuous: test **fails** against the old deps, **passes** with the fix.
- Existing 7 round-trip tests still pass. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)