### PR TITLE
fix(production): count planned batches in PRE_ROAST blend coverage

### DIFF
--- a/src/components/production/RoastGroupDrawer.tsx
+++ b/src/components/production/RoastGroupDrawer.tsx
@@ -285,18 +285,26 @@ export function RoastGroupDrawer({
     wipKg
   );
   
-  // Blend coverage. A blend is never roasted directly (`roastedTotal` is always
-  // 0 for it), so the standard `coverageDelta` reads perpetually short. Instead
-  // measure coverage from on-hand blended WIP + finished goods — the same
-  // wip/fg figures the inventory screens show — against gross demand:
+  // Only POST_ROAST blends use the WIP+FG coverage model. A PRE_ROAST blend is
+  // blended green then roasted directly, producing roasted batches on this group
+  // itself — its coverage works exactly like a single-origin group (planned +
+  // roasted vs net demand), so it must NOT go through the blend path below.
+  const isPostRoastBlend = isBlend && !isPreRoastBlend;
+
+  // Post-roast blend coverage. Such a blend is never roasted directly
+  // (`roastedTotal` is always 0 for it), so the standard `coverageDelta` reads
+  // perpetually short. Instead measure coverage from on-hand blended WIP +
+  // finished goods — the same wip/fg figures the inventory screens show —
+  // against gross demand:
   //   coverage = net WIP + FG (kg) - demand
   // >= 0 means the blend is fully covered (net demand is 0); < 0 is the shortfall.
   const blendCoverageDelta = wipKg + fgKg - demandKg;
-  const isBlendComplete = isBlend && blendCoverageDelta >= 0;
+  const isBlendComplete = isPostRoastBlend && blendCoverageDelta >= 0;
 
-  // For blends: "expected" column should show staged-for-blend kg instead of planned batches
-  // This reflects component inventory ready for blending, not direct roast batches
-  const displayExpectedOutput = isBlend && blendReadiness
+  // For post-roast blends: "expected" column shows staged-for-blend kg instead of
+  // planned batches — reflects component inventory ready for blending. Pre-roast
+  // blends fall through to their own planned-batch expected output.
+  const displayExpectedOutput = isPostRoastBlend && blendReadiness
     ? blendReadiness.stagedForBlendKg
     : plannedExpectedOutput;
 
@@ -768,7 +776,7 @@ export function RoastGroupDrawer({
           <div className="flex flex-col items-end">
             <span className="font-medium">{displayExpectedOutput.toFixed(1)}</span>
             <span className="text-muted-foreground text-xs">
-              {isBlend && blendReadiness ? 'staged' : 'expected'}
+              {isPostRoastBlend && blendReadiness ? 'staged' : 'expected'}
             </span>
           </div>
         </td>
@@ -777,8 +785,10 @@ export function RoastGroupDrawer({
           <span className="text-muted-foreground text-xs ml-1">kg</span>
         </td>
         <td className="py-3 text-right">
-          {/* Blends: coverage is WIP + FG vs demand, not roasted weight (always 0) */}
-          {isBlend ? (
+          {/* Post-roast blends: coverage is WIP + FG vs demand, not roasted weight
+              (always 0). Pre-roast blends roast directly, so they use the normal
+              planned+roasted coverageDelta path below (same as single-origin). */}
+          {isPostRoastBlend ? (
             blendCoverageDelta >= 0 ? (
               <Badge variant="secondary" className="bg-primary/10 text-primary border-primary/20">
                 Covered +{blendCoverageDelta.toFixed(1)} kg


### PR DESCRIPTION
## Problem

On the Roast tab, PRE_ROAST blends (e.g. **Med/Dark Espresso Blend**) showed **"Short = full demand"** no matter how many batches were planned. Single-origin groups worked correctly.

## Root cause

A PRE_ROAST blend is blended green then roasted directly, producing roasted batches on the blend group itself — its coverage works exactly like a single-origin group (planned + roasted vs net demand). But `RoastGroupDrawer` branched coverage/status on `isBlend` alone, routing PRE_ROAST blends through the POST_ROAST `WIP + FG − demand` model, which never looks at their planned/roasted batches.

- Header `expected` (uses `plannedExpectedOutput`) summed correctly → 42.3 kg
- Status badge (uses `blendCoverageDelta = WIP+FG−demand = −14`) → "Short 14.0 kg" ❌

Data was correct (`blend_type=PRE_ROAST`) — pure frontend logic bug.

## Fix

Introduce `isPostRoastBlend = isBlend && !isPreRoastBlend` and gate `blendCoverageDelta`, `isBlendComplete`, `displayExpectedOutput`, the header label, and the status badge on it. PRE_ROAST blends now fall through to the normal `coverageDelta` path.

## Scope

- **7 PRE_ROAST blends** — fixed (Med/Dark now "Covered +28.3 kg")
- **2 POST_ROAST blends** — unchanged (WIP+FG model still correct)
- **29 single-origin groups** — unchanged

No DB migration. `tsc --noEmit` clean; lint clean (pre-existing `any` warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)