### PR TITLE
fix(production): replace laggy roast-group drag reorder with up/down arrows

### DIFF
--- a/src/components/production/RoastGroupDrawer.tsx
+++ b/src/components/production/RoastGroupDrawer.tsx
@@ -10,12 +10,13 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
-import { 
-  ChevronDown, 
-  ChevronRight, 
-  Flame, 
-  Check, 
-  Trash2, 
+import {
+  ChevronDown,
+  ChevronRight,
+  ChevronUp,
+  Flame,
+  Check,
+  Trash2,
   Plus,
   Minus,
   Undo2,
@@ -23,7 +24,6 @@ import {
   Clock,
   Loader2,
   AlertTriangle,
-  GripVertical,
   Package,
   Layers,
   Leaf,
@@ -41,8 +41,6 @@ import {
 import { OhShitModal } from './OhShitModal';
 import { DepletionWarningModal, executeDepletionSwaps, type DepletionSwap } from './DepletionWarningModal';
 import { evaluateMultiRoastGroupImpacts, type MultiRgImpact } from '@/hooks/useGreenLotDepletion';
-import { useSortable } from '@dnd-kit/sortable';
-import { CSS } from '@dnd-kit/utilities';
 import { type RoastGroupComponent, getComponentBreakdown, type ComponentDisplay } from '@/hooks/useRoastGroupComponents';
 import { useBlendReadiness } from '@/hooks/useBlendReadiness';
 
@@ -89,7 +87,10 @@ interface RoastGroupDrawerProps {
   onOpenConfig: (roastGroup: string) => void;
   onEditingChange: (isEditing: boolean) => void;
   onAdjustWipFg: (roastGroup: string) => void;
-  isDragging?: boolean;
+  onMoveUp?: () => void;
+  onMoveDown?: () => void;
+  canMoveUp?: boolean;
+  canMoveDown?: boolean;
   isBlend?: boolean;
   isPreRoastBlend?: boolean;
   isCompleted?: boolean; // true if no remaining demand but has activity (batches/WIP)
@@ -115,7 +116,10 @@ export function RoastGroupDrawer({
   onOpenConfig,
   onEditingChange,
   onAdjustWipFg,
-  isDragging = false,
+  onMoveUp,
+  onMoveDown,
+  canMoveUp = false,
+  canMoveDown = false,
   isBlend = false,
   isPreRoastBlend = false,
   isCompleted = false,
@@ -127,16 +131,7 @@ export function RoastGroupDrawer({
 }: RoastGroupDrawerProps) {
   const { user } = useAuth();
   const queryClient = useQueryClient();
-  
-  // Sortable hook for drag and drop
-  const {
-    attributes,
-    listeners,
-    setNodeRef,
-    transform,
-    transition,
-  } = useSortable({ id: roastGroup });
-  
+
   const [isExpanded, setIsExpanded] = useState(false);
   const [undoConfirmBatchId, setUndoConfirmBatchId] = useState<string | null>(null);
   const [deleteConfirmBatchId, setDeleteConfirmBatchId] = useState<string | null>(null);
@@ -696,23 +691,15 @@ export function RoastGroupDrawer({
     }
   };
 
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-  };
-
   return (
     <>
       {/* Collapsed Row */}
-      <tr 
-        ref={setNodeRef}
-        style={style}
-        className={`border-b cursor-pointer transition-colors 
+      <tr
+        className={`border-b cursor-pointer transition-colors
           ${isFullyRoasted || isCompleted || isBlendComplete ? 'opacity-60' : ''}
           ${hasTimeSensitive && !isFullyRoasted && !isCompleted && !isBlendComplete ? 'bg-destructive/5' : ''}
           ${(isCompleted || isBlendComplete) && !isExpanded ? 'bg-muted/30' : ''}
-          ${isExpanded ? 'bg-muted/50 border-l-2 border-l-primary' : 'hover:bg-muted/50'}
-          ${isDragging ? 'opacity-50' : ''}`}
+          ${isExpanded ? 'bg-muted/50 border-l-2 border-l-primary' : 'hover:bg-muted/50'}`}
         onClick={() => setIsExpanded(!isExpanded)}
       >
         <td className="py-3 w-8 px-2">
@@ -722,13 +709,27 @@ export function RoastGroupDrawer({
             <ChevronRight className="h-4 w-4 text-muted-foreground" />
           )}
         </td>
-        <td 
-          className="py-1 w-10 cursor-grab active:cursor-grabbing" 
-          onClick={(e) => e.stopPropagation()}
-          {...attributes}
-          {...listeners}
-        >
-          <GripVertical className="h-4 w-4 text-muted-foreground" />
+        <td className="py-1 w-10" onClick={(e) => e.stopPropagation()}>
+          <div className="flex flex-col items-center -my-1">
+            <button
+              type="button"
+              aria-label="Move up"
+              disabled={!canMoveUp}
+              onClick={(e) => { e.stopPropagation(); onMoveUp?.(); }}
+              className="text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed"
+            >
+              <ChevronUp className="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              aria-label="Move down"
+              disabled={!canMoveDown}
+              onClick={(e) => { e.stopPropagation(); onMoveDown?.(); }}
+              className="text-muted-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed"
+            >
+              <ChevronDown className="h-4 w-4" />
+            </button>
+          </div>
         </td>
         <td className="py-3">
           <div className="flex flex-col gap-0.5">

--- a/src/components/production/RoastTab.tsx
+++ b/src/components/production/RoastTab.tsx
@@ -33,20 +33,6 @@ import { PlanBlendBatchesModal } from './PlanBlendBatchesModal';
 import { BlendExecuteModal } from './BlendExecuteModal';
 import { DepletionWarningModal, executeDepletionSwaps, type DepletionSwap } from './DepletionWarningModal';
 import { evaluateMultiRoastGroupImpacts, type MultiRgImpact } from '@/hooks/useGreenLotDepletion';
-import {
-  DndContext,
-  closestCenter,
-  KeyboardSensor,
-  PointerSensor,
-  useSensor,
-  useSensors,
-  DragEndEvent,
-} from '@dnd-kit/core';
-import {
-  SortableContext,
-  sortableKeyboardCoordinates,
-  verticalListSortingStrategy,
-} from '@dnd-kit/sortable';
 import type { DateFilterConfig } from './types';
 // Use AUTHORITATIVE inventory hooks - computed from source-of-truth tables
 import { useAuthoritativeWip, useAuthoritativeRoastDemand } from '@/hooks/useAuthoritativeInventory';
@@ -655,57 +641,53 @@ export function RoastTab({ dateFilterConfig, today }: RoastTabProps) {
     return computedSortedGroups;
   }, [editingGroupId, frozenOrder, computedSortedGroups, demandByRoastGroup, groupMatchesRoasterFilter]);
 
-  // Manual ordering mutations
-  const updateDisplayOrderMutation = useMutation({
-    mutationFn: async ({ roastGroup, newOrder }: { roastGroup: string; newOrder: number }) => {
-      const { error } = await supabase
-        .from('roast_groups')
-        .update({ display_order: newOrder })
-        .eq('roast_group', roastGroup);
-      if (error) throw error;
+  // Manual ordering. Persists a full reindex of the visible groups in one
+  // optimistic mutation: the query cache is reordered synchronously (so the row
+  // moves instantly), all rows are written in parallel as a single mutation, and
+  // the cache is invalidated once on settle. No drag transform, no snap-back.
+  const reorderMutation = useMutation({
+    mutationFn: async (orderedGroups: string[]) => {
+      await Promise.all(
+        orderedGroups.map((roastGroup, i) =>
+          supabase
+            .from('roast_groups')
+            .update({ display_order: (i + 1) * 10 })
+            .eq('roast_group', roastGroup)
+            .then(({ error }) => {
+              if (error) throw error;
+            }),
+        ),
+      );
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['roast-groups-config'] });
+    onMutate: async (orderedGroups: string[]) => {
+      await queryClient.cancelQueries({ queryKey: ['roast-groups-config'] });
+      const prev = queryClient.getQueryData<RoastGroupConfig[]>(['roast-groups-config']);
+      const orderMap = new Map(orderedGroups.map((rg, i) => [rg, (i + 1) * 10]));
+      queryClient.setQueryData<RoastGroupConfig[]>(['roast-groups-config'], (old) =>
+        old?.map((c) =>
+          orderMap.has(c.roast_group) ? { ...c, display_order: orderMap.get(c.roast_group)! } : c,
+        ),
+      );
+      return { prev };
     },
-    onError: (err) => {
+    onError: (err, _vars, ctx) => {
       console.error(err);
-      toast.error('Failed to update order');
+      if (ctx?.prev) queryClient.setQueryData(['roast-groups-config'], ctx.prev);
+      toast.error('Failed to reorder');
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['roast-groups-config'] });
     },
   });
 
-  // Handle drag end for reordering
-  const handleDragEnd = useCallback((event: DragEndEvent) => {
-    const { active, over } = event;
-    
-    if (!over || active.id === over.id) return;
-    
-    const oldIndex = sortedGroups.findIndex(g => g.roast_group === active.id);
-    const newIndex = sortedGroups.findIndex(g => g.roast_group === over.id);
-    
-    if (oldIndex === -1 || newIndex === -1) return;
-    
-    // Calculate new display_order values - reindex all groups
-    const reorderedGroups = [...sortedGroups];
-    const [movedGroup] = reorderedGroups.splice(oldIndex, 1);
-    reorderedGroups.splice(newIndex, 0, movedGroup);
-    
-    // Update all groups with new display_order
-    reorderedGroups.forEach((group, index) => {
-      updateDisplayOrderMutation.mutate({ roastGroup: group.roast_group, newOrder: (index + 1) * 10 });
-    });
-  }, [sortedGroups, updateDisplayOrderMutation]);
-
-  // DnD sensors
-  const sensors = useSensors(
-    useSensor(PointerSensor, {
-      activationConstraint: {
-        distance: 8,
-      },
-    }),
-    useSensor(KeyboardSensor, {
-      coordinateGetter: sortableKeyboardCoordinates,
-    })
-  );
+  // Shift a group one slot up (dir=-1) or down (dir=+1) within the visible list.
+  const moveGroup = useCallback((index: number, dir: -1 | 1) => {
+    const target = index + dir;
+    if (target < 0 || target >= sortedGroups.length) return;
+    const order = sortedGroups.map(g => g.roast_group);
+    [order[index], order[target]] = [order[target], order[index]];
+    reorderMutation.mutate(order);
+  }, [sortedGroups, reorderMutation]);
 
   // Auto-prioritize: reorder based on urgency
   const autoPrioritizeMutation = useMutation({
@@ -921,7 +903,7 @@ export function RoastTab({ dateFilterConfig, today }: RoastTabProps) {
                 Roast Plan
               </CardTitle>
               <p className="text-sm text-muted-foreground mt-1">
-                Drag the grip handle to reorder groups manually. Order persists across sessions.
+                Use the up/down arrows to reorder groups manually. Order persists across sessions.
               </p>
             </div>
             <div className="flex items-center gap-4 flex-wrap">
@@ -1015,15 +997,7 @@ export function RoastTab({ dateFilterConfig, today }: RoastTabProps) {
               </p>
             </div>
           ) : (
-            <DndContext
-              sensors={sensors}
-              collisionDetection={closestCenter}
-              onDragEnd={handleDragEnd}
-            >
-              <SortableContext
-                items={sortedGroups.map(g => g.roast_group)}
-                strategy={verticalListSortingStrategy}
-              >
+            <div>
                 <table className="w-full text-sm">
                   <thead>
                     <tr className="border-b text-left">
@@ -1074,6 +1048,10 @@ export function RoastTab({ dateFilterConfig, today }: RoastTabProps) {
                             onOpenConfig={openConfigDialog}
                             onEditingChange={(isEditing) => handleEditingChange(group.roast_group, isEditing)}
                             onAdjustWipFg={(rg) => setWipFgModalGroup(rg)}
+                            onMoveUp={() => moveGroup(index, -1)}
+                            onMoveDown={() => moveGroup(index, 1)}
+                            canMoveUp={index > 0}
+                            canMoveDown={index < sortedGroups.length - 1}
                             isBlend={config?.is_blend ?? false}
                             isPreRoastBlend={config?.is_blend === true && config?.blend_type === 'PRE_ROAST'}
                             isCompleted={group.isCompleted}
@@ -1191,8 +1169,7 @@ export function RoastTab({ dateFilterConfig, today }: RoastTabProps) {
                     )}
                   </tbody>
                 </table>
-              </SortableContext>
-            </DndContext>
+            </div>
           )}
         </CardContent>
       </Card>


### PR DESCRIPTION
## Problem

Dragging to reorder roast-group drawers on the Roast tab was laggy, snapped back to the original slot on drop, then snapped to the new spot after a long pause.

## Root cause

Displayed order was **100% server-derived** (`computedSortedGroups` off the `roast-groups-config` query) with **no optimistic state**. On drop, `handleDragEnd` fired **N separate `display_order` UPDATEs** (reindexing every group), each one's `onSuccess` invalidating the query → a write + refetch storm. dnd-kit released its drag transform on drop *before* any of that landed, so the row returned to its old position, then jumped once the storm settled.

## Fix

Swapped drag-and-drop for per-row **▲/▼ arrow buttons**:
- `moveGroup(index, dir)` swaps two adjacent slots and persists via a single optimistic `reorderMutation`: cache reordered synchronously (row moves instantly), all rows written in parallel as **one mutation**, **one** invalidate on settle, rollback on error.
- Removed `DndContext`/`SortableContext`/sensors from RoastTab and `useSortable`/grip handle from RoastGroupDrawer.
- ▲ disabled on first row, ▼ on last.

No drag transform to fight server state → no snap-back, no pause.

## Scope

Roast tab reorder only. Auto-prioritize-by-urgency and all other behavior unchanged. `tsc --noEmit` clean; no new lint problems (pre-existing `any`/deps warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)