### PR TITLE
fix(production): pack tab completeness ignores shipped-away FG

### DIFF
--- a/src/components/production/PackTab.tsx
+++ b/src/components/production/PackTab.tsx
@@ -271,6 +271,20 @@ export function PackTab({ dateFilterConfig, today }: PackTabProps) {
     return map;
   }, [authFg]);
 
+  // Net FG on-hand per product (created + shipNet + adjust). Unlike
+  // fg_created_units this drops when bags ship, so completeness/shortage is
+  // measured against stock that still physically exists — a SKU whose FG was
+  // packed then shipped to a past order no longer counts toward today's demand.
+  // The editable "units packed" input still binds to gross created above so the
+  // reversal RPC baseline is unchanged.
+  const availableByProductUnits = useMemo(() => {
+    const map: Record<string, number> = {};
+    for (const [pid, f] of Object.entries(authFg ?? {})) {
+      map[pid] = f.fg_available_units;
+    }
+    return map;
+  }, [authFg]);
+
   // Fetch ship_picks for OPEN orders, aggregated by product.
   // A pick is physical evidence that a bag was packed — the downstream station
   // can't pick a bag that wasn't produced. We treat each picked unit as an
@@ -383,9 +397,14 @@ export function PackTab({ dateFilterConfig, today }: PackTabProps) {
         continue;
       }
 
-      const packed = packingByProductUnits[product.product_id] ?? 0;
+      // Completeness/shortage use net available + open-order picks, NOT gross
+      // created. available already subtracts every SHIP_CONSUME_FG (incl. bags
+      // shipped to past orders); adding back the open-order picks reconstructs
+      // "FG physically in play for current demand" = on-shelf + already-picked.
+      // Gross created would falsely mark a SKU complete on stock that shipped.
+      const available = availableByProductUnits[product.product_id] ?? 0;
       const picked = pickedByProductUnits?.[product.product_id] ?? 0;
-      const effectivePacked = Math.max(packed, picked);
+      const effectivePacked = available + picked;
       product.shortage = Math.max(0, product.demanded_units - effectivePacked);
 
       // Get earliest ship date
@@ -952,6 +971,7 @@ export function PackTab({ dateFilterConfig, today }: PackTabProps) {
                       // Authoritative net produced (ledger) — matches the RPC baseline
                       // so the units field reverses correctly; packing_runs is legacy.
                       const packed = packingByProductUnits[product.product_id] ?? 0;
+                      const available = availableByProductUnits[product.product_id] ?? 0;
                       const picked = pickedByProductUnits?.[product.product_id] ?? 0;
                       const isExpanded = expandedProductId === product.product_id;
                       const groupKey = groupKeyOf(product);
@@ -1008,6 +1028,7 @@ export function PackTab({ dateFilterConfig, today }: PackTabProps) {
                           roastGroup={product.roast_group}
                           demandedUnits={product.demanded_units}
                           packedUnits={packed}
+                          availableUnits={available}
                           pickedUnits={picked}
                           wholeBeanUnits={product.wholeBeanUnits}
                           grindUnits={product.grindUnits}

--- a/src/components/production/SortablePackRow.tsx
+++ b/src/components/production/SortablePackRow.tsx
@@ -26,7 +26,13 @@ interface SortablePackRowProps {
   packagingVariant: PackagingVariant | null;
   roastGroup: string | null;
   demandedUnits: number;
+  /** Gross FG produced (sum of PACK_PRODUCE_FG). Binds to the editable numeric
+   *  input only — it's the baseline the reversal RPC reverses against. Do NOT
+   *  use for completeness; it never drops when bags ship. */
   packedUnits: number;
+  /** Net FG on-hand (created + shipNet + adjust). Drives completeness/shortage
+   *  so a SKU whose stock already shipped stops reading as packed. */
+  availableUnits: number;
   /** Downstream picks for open orders. Counted as implicit packs so the row
    *  is flagged complete and won't pressure the packer to over-pack a SKU the
    *  shipper has already grabbed. The numeric input still edits raw packs. */
@@ -67,6 +73,7 @@ export function SortablePackRow({
   roastGroup,
   demandedUnits,
   packedUnits,
+  availableUnits,
   pickedUnits = 0,
   wholeBeanUnits = 0,
   grindUnits = 0,
@@ -99,11 +106,13 @@ export function SortablePackRow({
     transition,
   };
 
-  // Effective packed counts picks as implicit packs so the row can be marked
-  // complete when downstream has already grabbed bags faster than the packer
-  // has clicked through. The numeric input still shows the raw pack count so
-  // packers can keep recording physical work without it appearing double.
-  const effectivePacked = Math.max(packedUnits, pickedUnits);
+  // Effective packed = net on-hand + open-order picks. availableUnits already
+  // subtracts every ship (incl. bags shipped to past orders), so adding back
+  // the open-order picks yields "FG physically in play for current demand" =
+  // on-shelf + already-picked. Using gross packedUnits here would keep a SKU
+  // marked complete on stock that already shipped away. The numeric input still
+  // shows raw pack count so packers keep recording physical work.
+  const effectivePacked = availableUnits + pickedUnits;
   const isComplete = effectivePacked >= demandedUnits;
   const coveredByPicks = pickedUnits > packedUnits && isComplete;
 


### PR DESCRIPTION
## Problem
Pack tab and Ship tab disagreed on FG. Pack showed SKUs "All packed / Complete" while Ship showed zero available and orders showed none picked.

Both tabs read the same ledger (`inventory_transactions` via `useAuthoritativeFg`) but derived different fields:
- **Pack** used `fg_created_units` — gross, all-time sum of `PACK_PRODUCE_FG`, never decremented.
- **Ship** + Authoritative Totals used `fg_available_units` — net on-hand (`created + shipNet + adjust`).

So FG packed then **shipped to a past order** stayed "Complete" in Pack against current open-order demand, even though the bags were gone.

## Fix
Completeness/shortage now use net available + open-order picks:
```
effectivePacked = fg_available_units + openOrderPicks
```
`available` already subtracts every `SHIP_CONSUME_FG` (incl. shipped orders); adding back open picks reconstructs FG physically in play for current demand (on-shelf + already-picked). Shipped-away stock excluded.

The editable "units packed" input still binds to gross `fg_created_units`, so the `update_packing_units` reversal baseline is unchanged.

## Behavior
| Scenario | Before | After |
|---|---|---|
| Packed, on shelf | Complete | Complete |
| Packed + picked (open order) | Complete | Complete |
| Packed then shipped (past order) | **Complete (false)** | Pending / % |
| Under-recorded packs, shipper picked more | Complete | Complete |

Pack now agrees with Ship + Authoritative Totals. No DB migration — frontend only. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)