### PR TITLE
fix(production): pack units input + RPC baseline use net on-hand

### DIFF
--- a/src/components/production/PackTab.tsx
+++ b/src/components/production/PackTab.tsx
@@ -258,11 +258,9 @@ export function PackTab({ dateFilterConfig, today }: PackTabProps) {
       )) as PackingRun[],
   });
 
-  // "Units packed" per product comes from the authoritative FG ledger (net
-  // sum of PACK_PRODUCE_FG), NOT the legacy per-day packing_runs rows. This is
-  // the same date-agnostic baseline update_packing_units reverses against, so
-  // completeness, the editable units field, and the reversal RPC all agree —
-  // editing units down reverses the run instead of diverging from the ledger.
+  // Gross FG produced per product (all-time sum of PACK_PRODUCE_FG). Only used
+  // for the "covered by picks" comparison — it never drops when bags ship, so
+  // it must NOT drive the input value or completeness (see availableByProductUnits).
   const packingByProductUnits = useMemo(() => {
     const map: Record<string, number> = {};
     for (const [pid, f] of Object.entries(authFg ?? {})) {
@@ -271,12 +269,11 @@ export function PackTab({ dateFilterConfig, today }: PackTabProps) {
     return map;
   }, [authFg]);
 
-  // Net FG on-hand per product (created + shipNet + adjust). Unlike
-  // fg_created_units this drops when bags ship, so completeness/shortage is
-  // measured against stock that still physically exists — a SKU whose FG was
-  // packed then shipped to a past order no longer counts toward today's demand.
-  // The editable "units packed" input still binds to gross created above so the
-  // reversal RPC baseline is unchanged.
+  // Net FG on-hand per product (created + shipNet + adjust, floored at 0). Drives
+  // BOTH the editable "units packed" input and completeness/shortage. update_packing_units
+  // now baselines on this same net figure, so the on-screen value and the RPC
+  // baseline agree — a SKU whose FG was packed then shipped shows 0 packed and
+  // reads pending instead of falsely complete on stock that no longer exists.
   const availableByProductUnits = useMemo(() => {
     const map: Record<string, number> = {};
     for (const [pid, f] of Object.entries(authFg ?? {})) {
@@ -1046,11 +1043,11 @@ export function PackTab({ dateFilterConfig, today }: PackTabProps) {
                           deemphasized={deemphasizedIds?.has(product.product_id) ?? false}
                           onToggleExpand={() => setExpandedProductId(isExpanded ? null : product.product_id)}
                           onUpdatePackedUnits={(newValue) => updatePackingUnits(
-                            product.product_id, 
-                            newValue, 
+                            product.product_id,
+                            newValue,
                             product.bag_size_g,
                             product.roast_group,
-                            packed
+                            available
                           )}
                           onEditingChange={(isEditing) => handleEditingChange(product.product_id, isEditing)}
                         />

--- a/src/components/production/SortablePackRow.tsx
+++ b/src/components/production/SortablePackRow.tsx
@@ -26,12 +26,13 @@ interface SortablePackRowProps {
   packagingVariant: PackagingVariant | null;
   roastGroup: string | null;
   demandedUnits: number;
-  /** Gross FG produced (sum of PACK_PRODUCE_FG). Binds to the editable numeric
-   *  input only — it's the baseline the reversal RPC reverses against. Do NOT
-   *  use for completeness; it never drops when bags ship. */
+  /** Gross FG produced (sum of PACK_PRODUCE_FG), all-time. Used only for the
+   *  "covered by picks" comparison; it never drops when bags ship, so do NOT
+   *  use it for the input value or completeness. */
   packedUnits: number;
-  /** Net FG on-hand (created + shipNet + adjust). Drives completeness/shortage
-   *  so a SKU whose stock already shipped stops reading as packed. */
+  /** Net FG on-hand (created + shipNet + adjust). Drives the editable input
+   *  value AND completeness/shortage — the RPC baseline is this same net figure,
+   *  so a SKU whose stock already shipped shows 0 packed and reads pending. */
   availableUnits: number;
   /** Downstream picks for open orders. Counted as implicit packs so the row
    *  is flagged complete and won't pressure the packer to over-pack a SKU the
@@ -110,8 +111,9 @@ export function SortablePackRow({
   // subtracts every ship (incl. bags shipped to past orders), so adding back
   // the open-order picks yields "FG physically in play for current demand" =
   // on-shelf + already-picked. Using gross packedUnits here would keep a SKU
-  // marked complete on stock that already shipped away. The numeric input still
-  // shows raw pack count so packers keep recording physical work.
+  // marked complete on stock that already shipped away. The numeric input binds
+  // to availableUnits (net on-hand) — matching the RPC baseline — so editing it
+  // drives real stock and never shows shipped-away bags as still packed.
   const effectivePacked = availableUnits + pickedUnits;
   const isComplete = effectivePacked >= demandedUnits;
   const coveredByPicks = pickedUnits > packedUnits && isComplete;
@@ -276,7 +278,7 @@ export function SortablePackRow({
         <td className="py-3" onClick={(e) => e.stopPropagation()}>
           {requiresProduction ? (
             <InlinePackingControl
-              value={packedUnits}
+              value={availableUnits}
               onCommit={onUpdatePackedUnits}
               onEditingChange={onEditingChange}
               isComplete={isComplete}

--- a/supabase/migrations/20260709120000_pack_units_baseline_net_onhand.sql
+++ b/supabase/migrations/20260709120000_pack_units_baseline_net_onhand.sql
@@ -1,0 +1,114 @@
+-- Make update_packing_units baseline the NET FG on-hand, not gross produced.
+--
+-- Bug: the pack-units field's baseline was sum(PACK_PRODUCE_FG) — gross,
+-- all-time produced. That count never drops when bags ship, so once any FG for
+-- a SKU shipped out, the "units packed" input kept showing the historical gross
+-- (e.g. 4) even though 0 were physically on hand, and completeness read stale.
+-- The absolute-target UI sends p_new_units; delta = new - gross_baseline then
+-- under-recorded fresh production: packing 9 against a gross baseline of 4 wrote
+-- only +5 FG, leaving net on-hand at 5 instead of 9.
+--
+-- Fix: baseline the net physical on-hand — sum(quantity_units) over
+-- PACK_PRODUCE_FG (+), SHIP_CONSUME_FG (−, written on pick/ship/return), and
+-- ADJUSTMENT (floor count), floored at 0. This is exactly fg_available_units in
+-- src/hooks/useAuthoritativeInventory.ts, which the Pack tab input now binds to,
+-- so the on-screen value and the RPC baseline always agree and delta drives net
+-- on-hand to the entered target:
+--   SKU packed 4 then all shipped -> net 0, input shows 0; pack 9 -> delta 9,
+--   writes +9 FG (and consumes 9 bags of WIP), net on-hand = 9.
+-- Never-shipped SKUs are unaffected: net == gross, so baseline is unchanged.
+--
+-- Only the baseline SELECT changes; the delta / WIP-return / FG-write / advisory
+-- lock logic is identical to 20260626130000_pack_units_ledger_baseline.sql.
+
+CREATE OR REPLACE FUNCTION public.update_packing_units(
+  p_product_id uuid,
+  p_target_date date,
+  p_new_units integer,
+  p_bag_size_g numeric,
+  p_roast_group text
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_previous_units integer := 0;
+  v_delta integer;
+  v_kg_delta numeric;
+BEGIN
+  PERFORM public._assert_internal_staff();
+
+  IF p_new_units IS NULL OR p_new_units < 0 THEN
+    RAISE EXCEPTION 'Units must be >= 0';
+  END IF;
+
+  -- Serialize pack updates per roast group so concurrent absolute-target writes
+  -- resolve in order against the same baseline (last-arrived wins, not lost).
+  IF p_roast_group IS NOT NULL THEN
+    PERFORM pg_advisory_xact_lock(hashtext('pack_wip:' || p_roast_group));
+  END IF;
+
+  -- Authoritative baseline: net FG on-hand per the ledger, floored at 0 — the
+  -- same value as fg_available_units and the number the Pack tab input shows.
+  -- (Was: sum of PACK_PRODUCE_FG only, i.e. gross produced, which stayed high
+  -- after bags shipped and desynced the input from physical stock.)
+  SELECT GREATEST(0, COALESCE(SUM(quantity_units), 0))::integer
+    INTO v_previous_units
+  FROM public.inventory_transactions
+  WHERE product_id = p_product_id
+    AND transaction_type IN ('PACK_PRODUCE_FG', 'SHIP_CONSUME_FG', 'ADJUSTMENT');
+
+  v_delta := p_new_units - v_previous_units;
+  IF v_delta = 0 THEN
+    RETURN p_new_units;
+  END IF;
+
+  v_kg_delta := CASE WHEN p_bag_size_g > 0 THEN (v_delta * p_bag_size_g) / 1000.0 ELSE 0 END;
+
+  -- Legacy back-compat only; FG/WIP are read from the ledger, not this table.
+  INSERT INTO public.packing_runs (product_id, target_date, units_packed, kg_consumed, updated_by)
+  VALUES (
+    p_product_id,
+    p_target_date,
+    p_new_units,
+    CASE WHEN p_bag_size_g > 0 THEN (p_new_units * p_bag_size_g) / 1000.0 ELSE 0 END,
+    auth.uid()
+  )
+  ON CONFLICT (product_id, target_date) DO UPDATE
+  SET units_packed = EXCLUDED.units_packed,
+      kg_consumed = EXCLUDED.kg_consumed,
+      updated_by = EXCLUDED.updated_by,
+      updated_at = now();
+
+  -- Return / consume WIP for the difference. quantity_kg = -v_kg_delta:
+  -- a decrease (v_delta < 0) yields a positive kg row, returning WIP.
+  IF p_roast_group IS NOT NULL AND v_kg_delta <> 0 THEN
+    INSERT INTO public.inventory_transactions
+      (transaction_type, roast_group, product_id, quantity_kg, quantity_units, is_system_generated, created_by, notes)
+    VALUES
+      ('PACK_CONSUME_WIP', p_roast_group, p_product_id, -v_kg_delta, NULL, true, auth.uid(),
+       CASE WHEN v_delta > 0
+         THEN 'Packed ' || v_delta || ' units of ' || p_bag_size_g || 'g'
+         ELSE 'Reversed ' || abs(v_delta) || ' units of ' || p_bag_size_g || 'g'
+       END);
+  END IF;
+
+  -- Add / remove FG for the difference. quantity_units = v_delta:
+  -- a decrease (v_delta < 0) removes the now-unpacked units from FG.
+  INSERT INTO public.inventory_transactions
+    (transaction_type, roast_group, product_id, quantity_kg, quantity_units, is_system_generated, created_by, notes)
+  VALUES
+    ('PACK_PRODUCE_FG', p_roast_group, p_product_id, NULL, v_delta, true, auth.uid(),
+     CASE WHEN v_delta > 0
+       THEN 'Packed ' || v_delta || ' units'
+       ELSE 'Reversed ' || abs(v_delta) || ' units'
+     END);
+
+  RETURN p_new_units;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.update_packing_units(uuid, date, integer, numeric, text)  FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.update_packing_units(uuid, date, integer, numeric, text)  TO authenticated;


### PR DESCRIPTION
Follow-up to #92.

## Problem
After #92 the Pack tab **status** was correct, but the editable "units packed" **input** still showed gross `fg_created_units` (all-time `PACK_PRODUCE_FG`). A SKU packed then fully shipped displayed e.g. `4` with 0 physically on hand.

The input is an absolute-target control — `update_packing_units` computes `delta = new − baseline` — and that RPC baseline was *also* gross produced. So binding the input to net without moving the RPC baseline would miscompute the delta and under-record fresh packing. Both must move together.

## Fix
- **Migration** `20260709120000_pack_units_baseline_net_onhand.sql`: baseline → `GREATEST(0, SUM over PACK_PRODUCE_FG + SHIP_CONSUME_FG + ADJUSTMENT)` = net on-hand, identical to `fg_available_units`. Signature unchanged → no type regen.
- **Frontend**: Pack input value + client no-op baseline now bind to `fg_available_units`.

## Safety
Never-shipped SKUs: net == gross → baseline unchanged, no behavior change. Only shipped/adjusted SKUs differ.

Verified against live data — shipped-out SKUs new baseline `0` vs old gross `28 / 4 / 2` (the exact phantom values users saw in the input).

`tsc --noEmit` clean.

⚠️ **Migration must be applied to the DB** (Lovable/Supabase) for editing to compute correct deltas. The input display fix takes effect on frontend deploy alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)