### PR TITLE
fix(production): stop double-counting roasted output in Roast tab coverage

### DIFF
--- a/src/components/production/RoastGroupDrawer.tsx
+++ b/src/components/production/RoastGroupDrawer.tsx
@@ -43,6 +43,7 @@ import { DepletionWarningModal, executeDepletionSwaps, type DepletionSwap } from
 import { evaluateMultiRoastGroupImpacts, type MultiRgImpact } from '@/hooks/useGreenLotDepletion';
 import { type RoastGroupComponent, getComponentBreakdown, type ComponentDisplay } from '@/hooks/useRoastGroupComponents';
 import { useBlendReadiness } from '@/hooks/useBlendReadiness';
+import { computeRoastCoverage } from '@/lib/roastCoverage';
 
 type RoasterMachine = 'SAMIAC' | 'LORING';
 type DefaultRoaster = 'SAMIAC' | 'LORING' | 'EITHER';
@@ -241,10 +242,12 @@ export function RoastGroupDrawer({
   // ROASTED batches use actual output
   const roastedTodayKg = roastedBatches.reduce((sum, b) => sum + b.actual_output_kg, 0);
   
-  // Total coverage = expected from planned + actual from roasted
-  // Compare against NET demand (demand - WIP - FG)
-  const totalCoverage = plannedExpectedOutput + roastedTotal;
-  const coverageDelta = totalCoverage - netDemandKg;
+  // Coverage = FUTURE planned output vs NET demand (see computeRoastCoverage for
+  // why lifetime roasted must NOT be added here).
+  const { coverageDeltaKg: coverageDelta } = computeRoastCoverage({
+    netDemandKg,
+    plannedExpectedKg: plannedExpectedOutput,
+  });
 
   // Calculate component breakdown for display
   const componentBreakdown = useMemo(() => {

--- a/src/components/production/RoastTab.tsx
+++ b/src/components/production/RoastTab.tsx
@@ -29,6 +29,7 @@ import { RoastGroupDrawer } from './RoastGroupDrawer';
 import { WipFgAdjustModal } from './WipFgAdjustModal';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { createOrReuseRoastGroup } from '@/lib/roastGroupCreation';
+import { computeRoastCoverage } from '@/lib/roastCoverage';
 import { PlanBlendBatchesModal } from './PlanBlendBatchesModal';
 import { BlendExecuteModal } from './BlendExecuteModal';
 import { DepletionWarningModal, executeDepletionSwaps, type DepletionSwap } from './DepletionWarningModal';
@@ -823,7 +824,7 @@ export function RoastTab({ dateFilterConfig, today }: RoastTabProps) {
     setShowConfigDialog(true);
   };
 
-  const handleCreateSuggestedBatches = (roastGroup: string, demandKg: number) => {
+  const handleCreateSuggestedBatches = (roastGroup: string, netDemandKg: number) => {
     const config = configByGroup[roastGroup];
     const standardBatch = config?.standard_batch_kg ?? 20;
     const defaultRoaster = config?.default_roaster ?? 'EITHER';
@@ -836,9 +837,11 @@ export function RoastTab({ dateFilterConfig, today }: RoastTabProps) {
         const inboundKg = b.planned_output_kg ?? 0;
         return sum + inboundKg * (1 - yieldLossPct / 100);
       }, 0);
-    const roastedKg = roastedInventory[roastGroup] ?? 0;
-    const remainingNeed = demandKg - roastedKg - plannedExpectedOutput;
-    
+    const { remainingNeedKg: remainingNeed } = computeRoastCoverage({
+      netDemandKg,
+      plannedExpectedKg: plannedExpectedOutput,
+    });
+
     if (remainingNeed <= 0) {
       toast.info('No additional batches needed');
       return;
@@ -1027,7 +1030,10 @@ export function RoastTab({ dateFilterConfig, today }: RoastTabProps) {
                           const inboundKg = b.planned_output_kg ?? 0;
                           return sum + inboundKg * (1 - yieldLossPct / 100);
                         }, 0);
-                      const remainingNeed = Math.max(0, group.total_kg - roastedTotal - plannedExpectedOutput);
+                      const remainingNeed = computeRoastCoverage({
+                        netDemandKg: group.net_demand_kg,
+                        plannedExpectedKg: plannedExpectedOutput,
+                      }).remainingNeedKg;
                       const expectedOutputPerBatch = standardBatch * (1 - yieldLossPct / 100);
                       const suggestedBatches = remainingNeed > 0 ? Math.ceil(remainingNeed / expectedOutputPerBatch) : 0;
                       
@@ -1110,8 +1116,10 @@ export function RoastTab({ dateFilterConfig, today }: RoastTabProps) {
                       const plannedExpectedOutput = groupBatches
                         .filter(b => b.status === 'PLANNED')
                         .reduce((sum, b) => sum + (b.planned_output_kg ?? 0) * (1 - yieldLossPct / 100), 0);
-                      const roastedTotal = roastedInventory[g.roast_group] ?? 0;
-                      const remainingNeed = Math.max(0, g.total_kg - roastedTotal - plannedExpectedOutput);
+                      const remainingNeed = computeRoastCoverage({
+                        netDemandKg: g.net_demand_kg,
+                        plannedExpectedKg: plannedExpectedOutput,
+                      }).remainingNeedKg;
                       return remainingNeed > 0;
                     }) && (
                       <tr className="bg-primary/5 border-t-2 border-primary/20">
@@ -1126,8 +1134,10 @@ export function RoastTab({ dateFilterConfig, today }: RoastTabProps) {
                               const plannedExpectedOutput = groupBatches
                                 .filter(b => b.status === 'PLANNED')
                                 .reduce((sum, b) => sum + (b.planned_output_kg ?? 0) * (1 - yieldLossPct / 100), 0);
-                              const roastedTotal = roastedInventory[g.roast_group] ?? 0;
-                              const remainingNeed = Math.max(0, g.total_kg - roastedTotal - plannedExpectedOutput);
+                              const remainingNeed = computeRoastCoverage({
+                                netDemandKg: g.net_demand_kg,
+                                plannedExpectedKg: plannedExpectedOutput,
+                              }).remainingNeedKg;
                               const expectedOutputPerBatch = config.standard_batch_kg * (1 - yieldLossPct / 100);
                               const suggestedBatches = remainingNeed > 0 ? Math.ceil(remainingNeed / expectedOutputPerBatch) : 0;
                               
@@ -1145,7 +1155,7 @@ export function RoastTab({ dateFilterConfig, today }: RoastTabProps) {
                                         variant="outline"
                                         className="h-7 text-xs"
                                         aria-label={ariaLabel}
-                                        onClick={() => handleCreateSuggestedBatches(g.roast_group, g.total_kg)}
+                                        onClick={() => handleCreateSuggestedBatches(g.roast_group, g.net_demand_kg)}
                                       >
                                         <Plus className="h-3 w-3 mr-1" />
                                         {g.roast_group} (+{suggestedBatches})

--- a/src/lib/roastCoverage.test.ts
+++ b/src/lib/roastCoverage.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { computeRoastCoverage } from './roastCoverage';
+
+describe('computeRoastCoverage', () => {
+  it('reports the Colombia case as short (the bug this replaced)', () => {
+    // netDemand 3.0 already subtracts on-hand WIP (3.8) + FG (0) from demand (6.8);
+    // no PLANNED batches queued. Must read SHORT 3.0 — not "Covered" off lifetime roasted.
+    const c = computeRoastCoverage({ netDemandKg: 3.0, plannedExpectedKg: 0 });
+    expect(c.isCovered).toBe(false);
+    expect(c.coverageDeltaKg).toBeCloseTo(-3.0);
+    expect(c.remainingNeedKg).toBeCloseTo(3.0);
+  });
+
+  it('covers when planned output meets net demand', () => {
+    const c = computeRoastCoverage({ netDemandKg: 3.0, plannedExpectedKg: 3.0 });
+    expect(c.isCovered).toBe(true);
+    expect(c.coverageDeltaKg).toBeCloseTo(0);
+    expect(c.remainingNeedKg).toBe(0);
+  });
+
+  it('shows surplus when planned output exceeds net demand', () => {
+    const c = computeRoastCoverage({ netDemandKg: 3.0, plannedExpectedKg: 5.0 });
+    expect(c.isCovered).toBe(true);
+    expect(c.coverageDeltaKg).toBeCloseTo(2.0);
+    expect(c.remainingNeedKg).toBe(0);
+  });
+
+  it('zero net demand is covered with no remaining need', () => {
+    const c = computeRoastCoverage({ netDemandKg: 0, plannedExpectedKg: 0 });
+    expect(c.isCovered).toBe(true);
+    expect(c.remainingNeedKg).toBe(0);
+  });
+
+  // Invariant A: a PLANNED batch flipping to ROASTED is coverage-neutral.
+  // Roasting output X moves X out of plannedExpected and (via new WIP) X out of
+  // netDemand simultaneously, so coverageDelta must not change.
+  it('is invariant when a batch goes PLANNED -> ROASTED', () => {
+    const X = 12; // batch output kg
+    const before = computeRoastCoverage({ netDemandKg: 20, plannedExpectedKg: 15 });
+    const after = computeRoastCoverage({ netDemandKg: 20 - X, plannedExpectedKg: 15 - X });
+    expect(after.coverageDeltaKg).toBeCloseTo(before.coverageDeltaKg);
+    expect(after.remainingNeedKg).toBeCloseTo(before.remainingNeedKg);
+  });
+
+  it('holds the invariant even when net demand floors at 0 after roasting', () => {
+    // Over-supplied group: after roasting, net demand would go negative but is
+    // clamped to 0 upstream. Feeding the clamped value keeps delta monotonic
+    // (surplus grows, never flips back to short).
+    const before = computeRoastCoverage({ netDemandKg: 5, plannedExpectedKg: 8 });
+    const afterClamped = computeRoastCoverage({ netDemandKg: 0, plannedExpectedKg: 3 });
+    expect(before.isCovered).toBe(true);
+    expect(afterClamped.isCovered).toBe(true);
+    expect(afterClamped.coverageDeltaKg).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/src/lib/roastCoverage.ts
+++ b/src/lib/roastCoverage.ts
@@ -1,0 +1,43 @@
+/**
+ * Roast coverage — single source of truth for "does this roast group have enough
+ * roasted output to cover its demand, and if not, how much more must be roasted?"
+ *
+ * The one rule this encodes: on-hand roasted coffee is ALREADY reflected in
+ * `netDemandKg` (which is gross demand minus on-hand WIP minus FG). Coverage is
+ * therefore about FUTURE output only — the yield-adjusted expected output of
+ * PLANNED batches. Lifetime/cumulative roasted weight must NOT be added here; it
+ * would double-count coffee already turned into WIP/FG and consumed.
+ *
+ * Because a batch's actual output enters WIP the instant it flips
+ * PLANNED→ROASTED (atomic in the `mark_batch_roasted` RPC), that transition is
+ * coverage-neutral: `plannedExpectedKg` drops by X and `netDemandKg` drops by X,
+ * so `coverageDeltaKg` is unchanged. This invariant is what the accompanying
+ * test guards.
+ */
+export interface RoastCoverageInput {
+  /** Gross demand already net of on-hand WIP + FG (kg). Never negative. */
+  netDemandKg: number;
+  /** Future yield-adjusted output from PLANNED batches (kg). */
+  plannedExpectedKg: number;
+}
+
+export interface RoastCoverage {
+  /** plannedExpected − netDemand. ≥0 = covered (surplus); <0 = short. */
+  coverageDeltaKg: number;
+  /** kg still to plan/roast to reach coverage = max(0, −coverageDelta). */
+  remainingNeedKg: number;
+  /** True when planned output meets or exceeds net demand. */
+  isCovered: boolean;
+}
+
+export function computeRoastCoverage({
+  netDemandKg,
+  plannedExpectedKg,
+}: RoastCoverageInput): RoastCoverage {
+  const coverageDeltaKg = plannedExpectedKg - netDemandKg;
+  return {
+    coverageDeltaKg,
+    remainingNeedKg: Math.max(0, -coverageDeltaKg),
+    isCovered: coverageDeltaKg >= 0,
+  };
+}


### PR DESCRIPTION
## Problem
Roast-tab coverage compared **net demand** (already net of on-hand WIP+FG) against **lifetime roasted weight**, re-crediting coffee already consumed into WIP/FG. A group short on the Pack tab (3.8 kg WIP vs 6.8 kg demand → **Short 3.0 kg**) showed **"Covered +10.4 kg"** on the Roast tab, so the roaster was never prompted to make up the shortfall.

## Fix
Coverage is now **future-only**: planned (yield-adjusted) output vs net demand.

- Extracted to `computeRoastCoverage()` ([src/lib/roastCoverage.ts](src/lib/roastCoverage.ts)) — one tested source of truth.
- **Invariant A** (machine-checked): a `PLANNED→ROASTED` transition is coverage-neutral — output leaves `plannedExpected` and enters WIP simultaneously, so `coverageDelta` is unchanged.
- Verified `mark_batch_roasted` writes the `ROAST_OUTPUT` ledger row **atomically** with the status flip → no false-Short flashes on roast.
- Fixed the coverage badge + all 4 remaining-need call sites (suggestion handler + row/predicate/chip quick-add).

## Verification
- `tsc --noEmit` clean
- New test 6/6 (incl. Colombia short case + invariant)
- Full suite **105/105** (was 99 + 6 new)
- Not browser-driven: Roast tab is auth-gated; verified by types + tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)