### PR TITLE
fix(coroast): read booking owner via account_id, not null member_id

### DIFF
--- a/src/components/bookings/BookingDetailModal.tsx
+++ b/src/components/bookings/BookingDetailModal.tsx
@@ -45,11 +45,11 @@ export function BookingDetailModal({ open, onOpenChange, booking, members, allBo
   const [editEndTime, setEditEndTime] = useState('');
   const [editError, setEditError] = useState<string | null>(null);
 
-  const member = booking ? members.find(m => m.id === booking.member_id) : undefined;
+  const member = booking ? members.find(m => m.id === booking.account_id) : undefined;
   const durationHrs = booking ? (timeToMinutes(booking.end_time) - timeToMinutes(booking.start_time)) / 60 : 0;
   const tier = member?.tier ?? 'MEMBER';
   const tierDefaults = TIER_RATES[tier] ?? TIER_RATES.MEMBER;
-  const { data: pricing } = useAccountPricing(booking?.member_id);
+  const { data: pricing } = useAccountPricing(booking?.account_id);
   const rates = {
     overageRate: pricing?.overageRate.value ?? tierDefaults.overageRate,
     includedHours: pricing?.includedHours.value ?? tierDefaults.includedHours,
@@ -97,7 +97,7 @@ export function BookingDetailModal({ open, onOpenChange, booking, members, allBo
     if (!booking) return 'Included';
     const month = booking.booking_date.slice(0, 7);
     const monthBookings = allBookings
-      .filter(b => b.member_id === booking.member_id && b.booking_date.startsWith(month) && !['CANCELLED_FREE', 'CANCELLED_CHARGED', 'CANCELLED_WAIVED'].includes(b.status))
+      .filter(b => b.account_id === booking.account_id && b.booking_date.startsWith(month) && !['CANCELLED_FREE', 'CANCELLED_CHARGED', 'CANCELLED_WAIVED'].includes(b.status))
       .sort((a, b) => a.booking_date.localeCompare(b.booking_date) || a.start_time.localeCompare(b.start_time));
     let running = 0;
     for (const bk of monthBookings) {
@@ -130,7 +130,7 @@ export function BookingDetailModal({ open, onOpenChange, booking, members, allBo
       }).eq('id', booking.id);
       if (error) throw error;
       await supabase.from('coroast_hour_ledger').insert({
-        member_id: booking.member_id, billing_period_id: booking.billing_period_id,
+        account_id: booking.account_id, billing_period_id: booking.billing_period_id,
         booking_id: booking.id, entry_type: 'BOOKING_RETURNED' as any,
         hours_delta: -durationHrs, notes: `Free cancellation for ${booking.booking_date}`,
       });
@@ -150,7 +150,7 @@ export function BookingDetailModal({ open, onOpenChange, booking, members, allBo
       }).eq('id', booking.id);
       if (error) throw error;
       await supabase.from('coroast_hour_ledger').insert({
-        member_id: booking.member_id, billing_period_id: booking.billing_period_id,
+        account_id: booking.account_id, billing_period_id: booking.billing_period_id,
         booking_id: booking.id, entry_type: 'BOOKING_RETURNED' as any,
         hours_delta: refundedHoursFiftyPercent(durationHrs),
         notes: `50% cancellation for ${booking.booking_date}`,
@@ -195,11 +195,11 @@ export function BookingDetailModal({ open, onOpenChange, booking, members, allBo
       }).eq('id', booking.id);
       if (error) throw error;
       await supabase.from('coroast_waiver_log').insert({
-        member_id: booking.member_id, booking_id: booking.id,
+        account_id: booking.account_id, booking_id: booking.id,
         fee_amount_waived: fullFee, waive_reason: waiveReason.trim(),
       });
       await supabase.from('coroast_hour_ledger').insert({
-        member_id: booking.member_id, billing_period_id: booking.billing_period_id,
+        account_id: booking.account_id, billing_period_id: booking.billing_period_id,
         booking_id: booking.id, entry_type: 'BOOKING_RETURNED' as any,
         hours_delta: -durationHrs, notes: `Waived cancellation for ${booking.booking_date}`,
       });

--- a/src/components/bookings/BookingWeekView.tsx
+++ b/src/components/bookings/BookingWeekView.tsx
@@ -84,7 +84,7 @@ export function BookingWeekView({ blocks, bookings, members, windows = [], onSlo
       .filter(b => !CANCELLED_STATUSES.includes(b.status))
       .sort((a, b) => a.booking_date.localeCompare(b.booking_date) || a.start_time.localeCompare(b.start_time));
     for (const bk of sorted) {
-      const key = `${bk.member_id}:${bk.booking_date.slice(0, 7)}`;
+      const key = `${bk.account_id}:${bk.booking_date.slice(0, 7)}`;
       if (!grouped.has(key)) grouped.set(key, []);
       grouped.get(key)!.push(bk);
     }
@@ -128,7 +128,7 @@ export function BookingWeekView({ blocks, bookings, members, windows = [], onSlo
       if (CANCELLED_STATUSES.includes(bk.status)) continue;
       const isNoShow = bk.status === 'NO_SHOW';
       const isCompleted = bk.status === 'COMPLETED';
-      const baseColor = getMemberColor(bk.member_id, allMemberIds);
+      const baseColor = getMemberColor(bk.account_id ?? '', allMemberIds);
       const color = isNoShow
         ? { bg: NO_SHOW_BG, text: '#fff' }
         : isCompleted

--- a/src/components/bookings/PendingReminders.tsx
+++ b/src/components/bookings/PendingReminders.tsx
@@ -15,7 +15,7 @@ interface ReminderBooking {
   start_time: string;
   end_time: string;
   reminder_sent_at: string | null;
-  coroast_members: { business_name: string } | null;
+  accounts: { account_name: string } | null;
 }
 
 function formatTime(t: string): string {
@@ -37,7 +37,7 @@ export function PendingReminders() {
     queryFn: async () => {
       const { data, error } = await supabase
         .from('coroast_bookings')
-        .select('id, booking_date, start_time, end_time, reminder_sent_at, coroast_members:member_id(business_name)')
+        .select('id, booking_date, start_time, end_time, reminder_sent_at, accounts:account_id(account_name)')
         .eq('status', 'CONFIRMED')
         .is('reminder_sent_at', null)
         .gte('booking_date', today)
@@ -78,7 +78,7 @@ export function PendingReminders() {
           {reminders.map(r => (
             <li key={r.id} className="flex items-center justify-between text-sm border-b pb-2 last:border-0">
               <div>
-                <span className="font-medium">{r.coroast_members?.business_name ?? 'Unknown'}</span>
+                <span className="font-medium">{r.accounts?.account_name ?? 'Unknown'}</span>
                 <span className="ml-2 text-muted-foreground">
                   {format(parseDateOnly(r.booking_date)!, 'EEE, MMM d')}
                 </span>


### PR DESCRIPTION
## What

`coroast_bookings.member_id` is legacy — **null on every row**. `account_id` (FK → `accounts(id)`) is canonical. All write paths already populate `account_id` only. But several **read** sites still referenced `member_id` with no `account_id` fallback and silently degraded.

## Fixes (all → `account_id`)

- **`BookingDetailModal.tsx`**
  - member lookup (line 48) + `useAccountPricing` (52) resolved on null → showed **"Member: Unknown"** and fell back to MEMBER-tier rate, so the **displayed cancellation/no-show fee was computed on the wrong overage rate**
  - `hoursType` month filter (100) compared `member_id === member_id` → `null === null` matched **all accounts' bookings**, wrong Included/Overage badge
  - free / 50% / waive **ledger + waiver_log inserts** wrote `member_id: null` with **no `account_id`** → orphaned rows, invisible to the account-scoped ledger read on the account page
- **`BookingWeekView.tsx`** — overage grouping key (87) and `getMemberColor` (131) keyed on `member_id` → every booking collapsed into one bucket/color
- **`PendingReminders.tsx`** — join `coroast_members:member_id(business_name)` → always "Unknown"; now `accounts:account_id(account_name)`

## Not in scope

No schema change. `member_id` column stays intact (still null). Dropping it is a **follow-up Supabase migration** to run once this ships.

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)